### PR TITLE
Add missing F34 and F35 image test cases

### DIFF
--- a/test/data/manifests/fedora_34-aarch64-oci-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-oci-boot.json
@@ -1,0 +1,10162 @@
+{
+  "compose-request": {
+    "distro": "fedora-34",
+    "arch": "aarch64",
+    "image-type": "oci",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-modular-20210512/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-modular-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      }
+    ],
+    "filename": "disk.qcow2",
+    "blueprint": {}
+  },
+  "manifest": {
+    "sources": {
+      "org.osbuild.files": {
+        "urls": {
+          "sha256:00c29524aad123ec44056e60b9625e75ac428a6c751878a05fadbca7e956c249": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dbus-1.2.18-1.fc34.aarch64.rpm"
+          },
+          "sha256:0176b42c6b51fb3c829f168571527a3559b6a9c8cc5f847b70e3c40fb69f89e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-100.fc34.aarch64.rpm"
+          },
+          "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-legacy-libs-1.8.7-8.fc34.aarch64.rpm"
+          },
+          "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-9.fc34.aarch64.rpm"
+          },
+          "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc34.aarch64.rpm"
+          },
+          "sha256:059f825547fe257247656c29049ebc7bfa1d54a17479f3dcfeff37fbab7084bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.33-20.fc34.aarch64.rpm"
+          },
+          "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libibverbs-37.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc34.aarch64.rpm"
+          },
+          "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.aarch64.rpm"
+          },
+          "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm"
+          },
+          "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pip-21.0.1-4.fc34.noarch.rpm"
+          },
+          "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cyrus-sasl-lib-2.1.27-8.fc34.aarch64.rpm"
+          },
+          "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxml2-2.9.12-4.fc34.aarch64.rpm"
+          },
+          "sha256:0ac62147585be2dae960ed37a3a0c3eb2f8a95d0fd0993991c8bf7238b1d5e27": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dhcp-client-4.4.2-11.b1.fc34.aarch64.rpm"
+          },
+          "sha256:0db1be9a78e5f329a519066a7b37379f6c73fe579154e0a6a26b2dcb4154ccd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-common-2.33-20.fc34.aarch64.rpm"
+          },
+          "sha256:0f9ebdf7f08a506a8d1d6c4b4788dd7ca3dbb832509072b66def4da5b86d7862": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/efibootmgr-16-10.fc34.aarch64.rpm"
+          },
+          "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm"
+          },
+          "sha256:1014763656c1578ae96b38fd3e87c4d07b548cb8423688cc928d0f9762d43a44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfido2-1.6.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libblkid-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:11a0c09b716f8071f0484278bec326fb82e93d987376c8b38188d1febcd5381d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libndp-1.7-7.fc34.aarch64.rpm"
+          },
+          "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:11cd6fae157eb9e4800163633b57bcce21d59a1df4b86a99ba03707b6cee0cfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dhcp-common-4.4.2-11.b1.fc34.noarch.rpm"
+          },
+          "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libuuid-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm"
+          },
+          "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-ng-0.8.2-4.fc34.aarch64.rpm"
+          },
+          "sha256:12b7666d61e7bd8b3b5b1a7c57539964531802287e592e33449e039799ea2071": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbasicobjects-0.1.1-47.fc34.aarch64.rpm"
+          },
+          "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/which-2.21-26.fc34.aarch64.rpm"
+          },
+          "sha256:131adc47f044c9f600f5295ded0f5431cda57fa7276100c3ec81c9d1ce3fa6f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jwt-1.7.1-11.fc34.noarch.rpm"
+          },
+          "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:139b9453b2038e52767d0102def782d58d558ca0603757eb0c97ddda28af1466": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-audit-3.0.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:148aea26e381b33badde0ac2ae716a78f7b565f54f0b6970189a89713f335eaf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-3.0.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:164e1c0e3e8c89aeda4f272b3158932649a69b16aea058105117a64d3cdef517": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rootfiles-8.1-29.fc34.noarch.rpm"
+          },
+          "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm"
+          },
+          "sha256:1877af369228dd661ae1adfc43bbb8d53d3464d59ead0f5bcf6c2be88f8e8685": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-0.21.2-1.fc34.noarch.rpm"
+          },
+          "sha256:1af86c0a8c11e44958b022bf7dad5f48ad974fa8537cf41a12d5b0643444b1dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.3755-1.fc34.aarch64.rpm"
+          },
+          "sha256:1b1af6b54050ec223c3289b107a9695a686c9d46d17a80ec9cd5d0201ec5d544": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonpointer-2.0-2.fc34.noarch.rpm"
+          },
+          "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.aarch64.rpm"
+          },
+          "sha256:1feb6a045cb3e95e3c8e0112ecb4b8ffeb9986a503b52c5497fefce217846b90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc34.noarch.rpm"
+          },
+          "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.aarch64.rpm"
+          },
+          "sha256:2027da420b35a0b70ae5045d2fd79cdccb820f03e5ff4018a2205d3d413ff1af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtdb-1.4.3-6.fc34.aarch64.rpm"
+          },
+          "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm"
+          },
+          "sha256:23a539a271c92906ac0a12c7d877c7f4d0ad8e6b9bbd8642b5232f861b79ed22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shim-aa64-15.4-4.aarch64.rpm"
+          },
+          "sha256:23e3ed871799a9209915359f71660babf451b0b44902e3ed488b7b22aff37718": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-ply-3.11-11.fc34.noarch.rpm"
+          },
+          "sha256:2414cb7345bc193f7ff7983c020c8b0e706aab013ee30af5d457d35c4de4a698": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jinja2-2.11.3-1.fc34.noarch.rpm"
+          },
+          "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/whois-nls-5.5.10-1.fc34.noarch.rpm"
+          },
+          "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpsl-0.21.1-3.fc34.aarch64.rpm"
+          },
+          "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm"
+          },
+          "sha256:27920113489e3260e58d4a033d31401c6ae22ded72895c6b8c0e43ebf89a62df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/parted-3.4-2.fc34.aarch64.rpm"
+          },
+          "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/nettle-3.7.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-all-langpacks-5.1.0-3.fc34.aarch64.rpm"
+          },
+          "sha256:2968703dd232a37620a0ae12146c9d1ec5220f62c40bfb0ecfc60b621d8e1eac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-dicts-2.9.6-27.fc34.aarch64.rpm"
+          },
+          "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-34.23-1.fc34.noarch.rpm"
+          },
+          "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-8.32-30.fc34.aarch64.rpm"
+          },
+          "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxkbcommon-1.3.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:30bc3583e503e0f459e323b27551f7b9a8ab784de15437b5b29f447b31f8d9cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/y/yum-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.aarch64.rpm"
+          },
+          "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:32220dc513a6ebcd4994e7140ecb5859108baf44d12fe6b1f0c0459dbefc54e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pycparser-2.20-3.fc34.noarch.rpm"
+          },
+          "sha256:3228a36807658c7e4d881013aa26f877353388bf3bac6c948984f751c264a359": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xfsprogs-5.10.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:330a36b1dabaf76daafeff3f7fd7a276880bf65d790ee84cb823a1958a4d99d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libnfsidmap-2.5.4-2.rc3.fc34.aarch64.rpm"
+          },
+          "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-6.2-4.20200222.fc34.aarch64.rpm"
+          },
+          "sha256:33b878000610ca3ba875b72f2a454e4fac9471f80579824304ca81e6f3e3f79d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/checkpolicy-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-20210213-1.git5c710c0.fc34.noarch.rpm"
+          },
+          "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm"
+          },
+          "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-setuptools-wheel-53.0.0-2.fc34.noarch.rpm"
+          },
+          "sha256:37cda2c179e4311a1aeeb0ea8d07d3eacc8ea8bf97d122ec22cd596c61b8e770": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/groff-base-1.22.4-7.fc34.aarch64.rpm"
+          },
+          "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.aarch64.rpm"
+          },
+          "sha256:39160ef65b3519a70f14f992edc5967380ef86a6940896751db681781961903d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-server-8.6p1-5.fc34.aarch64.rpm"
+          },
+          "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sed-4.8-7.fc34.aarch64.rpm"
+          },
+          "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.aarch64.rpm"
+          },
+          "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grep-3.6-2.fc34.aarch64.rpm"
+          },
+          "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.0.1-4.fc34.noarch.rpm"
+          },
+          "sha256:3b3bba1d61529a1dde47f234f34d0fdee07a38aa5958d87e30357ea04bbff142": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.aarch64.rpm"
+          },
+          "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/keyutils-libs-1.6.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-0.21-4.fc34.aarch64.rpm"
+          },
+          "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/setup-2.13.7-3.fc34.noarch.rpm"
+          },
+          "sha256:3e69e8412d5914ec01c5e82264833698e92a1b88a7c7b5ed9b1f0351fc91f5d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-34-39.noarch.rpm"
+          },
+          "sha256:3f7bde703045c2651fbd4142131ea1e303a565269388a08e2312af0eb83307a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-issuegen-0.21.2-1.fc34.noarch.rpm"
+          },
+          "sha256:3fb05067cbd7fcf3283f2ab306c2dae668d818d3a69422e729c2ef62974810a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fonts-filesystem-2.0.5-5.fc34.noarch.rpm"
+          },
+          "sha256:3fdab509a59e0a765364d6f119c38c796a4420cc49b46595a37d98eb649d6c80": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm"
+          },
+          "sha256:40e231991444a589b17e0b5b338be8874d071e3d17e210aba6f6639620775f79": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-1.9.5p2-1.fc34.aarch64.rpm"
+          },
+          "sha256:4123331b5d06f91ff31d147e4769806052f59b620e7677f69b0073eaf7beccb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:424f73b97c7d7541d35685108bdcddb03100cd0f3d6e0fd9def576462ca65b59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-profile-0.21.2-1.fc34.noarch.rpm"
+          },
+          "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.aarch64.rpm"
+          },
+          "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.9.9-2.fc34.noarch.rpm"
+          },
+          "sha256:43b0b5d425a2041daeb6b41db2858abda1f92ecc38c6125f7de3b7502580a9f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:45d38ed1d2247e17e3e8faf7d6755216c5ef4422736129f55b712f160532d8f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libini_config-1.3.1-47.fc34.aarch64.rpm"
+          },
+          "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm"
+          },
+          "sha256:47c92a952b162b7bafbe49a7e409a7a81825adc77b3e139651913d52d8aa84fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/h/hostname-3.23-4.fc34.aarch64.rpm"
+          },
+          "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsemanage-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnl3-3.5.0-6.fc34.aarch64.rpm"
+          },
+          "sha256:4a74ae08a713e9b4e74ff27bfaf57374312370402f90e2796e66c504557ae189": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pysocks-1.7.1-8.fc34.noarch.rpm"
+          },
+          "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:4b65dc9856b0d0ce555dd9bce88dcfb680ba689a2c6b88ae9f84b016553d96af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iputils-20210202-2.fc34.aarch64.rpm"
+          },
+          "sha256:4baf8ba6a5ed4609695f79a8bbc8324d7efa322a3573c8c5fa3942361eac0f1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.30.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-1.12.20-3.fc34.aarch64.rpm"
+          },
+          "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-2.9.6-27.fc34.aarch64.rpm"
+          },
+          "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/curl-7.76.1-12.fc34.aarch64.rpm"
+          },
+          "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-common-1.12.20-3.fc34.noarch.rpm"
+          },
+          "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gdbm-libs-1.19-2.fc34.aarch64.rpm"
+          },
+          "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/gnutls-3.7.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:55833f669ed1dbd32e79f494824c309b71bc373d2bf28eb5cdb663459dc6f7cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-100.fc34.aarch64.rpm"
+          },
+          "sha256:56634e58fc7499d719a3f431dd188e8f2655ebfa402e94ce105794a47debf45b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtalloc-2.3.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.aarch64.rpm"
+          },
+          "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc34.aarch64.rpm"
+          },
+          "sha256:59cc4d563ecb4c8b517f5dd7505f1cda297f950f32fc700344aa7789b69ca99c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-babel-2.9.1-1.fc34.noarch.rpm"
+          },
+          "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:5d2c28837f0573ae2647b8fbba85f7c502f9c3da0a3eab1c9ba121de4a1a6cee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-dateutil-2.8.1-3.fc34.noarch.rpm"
+          },
+          "sha256:5dcac7772d73ad1523f87cbeb1dc76dd62af4d2bb73dd06896a47d2bcf503e5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-8.6p1-5.fc34.aarch64.rpm"
+          },
+          "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm"
+          },
+          "sha256:6046f881a5c0822c30bd037aec040c65594b6328b1c0d72b6681fe1575eac765": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcbor-0.7.0-3.fc34.aarch64.rpm"
+          },
+          "sha256:60ddc7b15e9742ff9995d1b336489b92721e21a45034d20f20d2fc800e419d1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/popt-1.18-4.fc34.aarch64.rpm"
+          },
+          "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:61a9dbd9020e29012947978acf33a0c1150e6c3e078de372f1e38fb9c4ef529a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/chrony-4.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:61ba1ecff8f8578cbd3445df596d001067bb0281745191ac168fcc6079d8e1cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/man-db-2.9.3-3.fc34.aarch64.rpm"
+          },
+          "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-3.9.9-2.fc34.aarch64.rpm"
+          },
+          "sha256:6297d7eee103c679a0f1ea411568d3940af3fe8f38e19388a1544df70bda8b3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-requests-2.25.1-1.fc34.noarch.rpm"
+          },
+          "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpcap-1.10.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-0.23.22-3.fc34.aarch64.rpm"
+          },
+          "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbrotli-1.0.9-4.fc34.aarch64.rpm"
+          },
+          "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-libs-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm"
+          },
+          "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtirpc-1.3.2-0.fc34.aarch64.rpm"
+          },
+          "sha256:668a30c6f526e51705af9cb9d98fd11f279f5e86f7d905876ae9a86f486a8c36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-common-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm"
+          },
+          "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm"
+          },
+          "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-34.23-1.fc34.noarch.rpm"
+          },
+          "sha256:686e015d81c1be2e6b88c7e8a50d45109d7273143a034caa9c935ecd014e1c62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libref_array-0.1.5-47.fc34.aarch64.rpm"
+          },
+          "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-trust-0.23.22-3.fc34.aarch64.rpm"
+          },
+          "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/procps-ng-3.3.17-1.fc34.1.aarch64.rpm"
+          },
+          "sha256:69de3dd68dc2b76e2a85c710a51e9c8acefe595d6ac5d9f19113c4062a5f0d92": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/ipcalc-1.0.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:6a864bec34b7d39de3e6ae1e39ec07fa3a2d21837a9a2d7151228d7f0ac38e73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/passwd-0.80-10.fc34.aarch64.rpm"
+          },
+          "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-34-2.noarch.rpm"
+          },
+          "sha256:6d1b95e06ec98f6d65c64e18fec693d379b98128a3e94b4dec8929321354c549": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cloud-utils-growpart-0.31-8.fc34.noarch.rpm"
+          },
+          "sha256:6d1c024b295c423746b44f120cf36ceb0fd898f8ce5a276813d7c78a3c8ece52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-34-39.noarch.rpm"
+          },
+          "sha256:6d3301f6e99d9728698822e81fc2d170694cc367b7e7fea5c7a019f7b1a6073b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/inih-49-3.fc34.aarch64.rpm"
+          },
+          "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm"
+          },
+          "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fuse-libs-2.9.9-11.fc34.aarch64.rpm"
+          },
+          "sha256:70a90c6c682016e91fb4745eedbd23f28e150a38b01d18f85ce4e50fb4e0ca6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pyserial-3.4-10.fc34.noarch.rpm"
+          },
+          "sha256:71427f6f8f3f6370dccde81a76d566ff17144e7e375381ef13e04a661e63cba1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-9.fc34.aarch64.rpm"
+          },
+          "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtextstyle-0.21-4.fc34.aarch64.rpm"
+          },
+          "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-config-0.9.6-1.fc34.noarch.rpm"
+          },
+          "sha256:7285fcc290a8af2cf845beb845e661cd4c06c2275417b15eb507824dedec7c69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnghttp2-1.43.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtasn1-4.16.0-4.fc34.aarch64.rpm"
+          },
+          "sha256:7721bc647c521d96e07e665f7da306326d3bd1499d610c58552317815aaf3c45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lmdb-libs-0.9.29-1.fc34.aarch64.rpm"
+          },
+          "sha256:79834af7f95c0d1e5dcf85b794819bd854197a52d2966594abdb3c3de0fcceb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dejavu-sans-fonts-2.37-16.fc34.noarch.rpm"
+          },
+          "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:79864051052858a1c95538888ca61a43b509b6eae4ae269ae6ea7bf8b076a2b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmnl-1.0.4-13.fc34.aarch64.rpm"
+          },
+          "sha256:7c24e53e12891046bb6721e624cf9effd1946c0d076464427c2a86b29671318e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/c-ares-1.17.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:7cc0891a9e7c19757c03cba6c8155738d9db9f5774380c412106adf0eca44077": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/less-590-2.fc34.aarch64.rpm"
+          },
+          "sha256:7d00ccbb224617a00f58053afd88e7a49062446f1306ba39c72b78d20aeee1ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-cffi-1.14.5-1.fc34.aarch64.rpm"
+          },
+          "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/z/zlib-1.2.11-26.fc34.aarch64.rpm"
+          },
+          "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/filesystem-3.14-5.fc34.aarch64.rpm"
+          },
+          "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm"
+          },
+          "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-common-34-39.noarch.rpm"
+          },
+          "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch.rpm"
+          },
+          "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/findutils-4.8.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bzip2-libs-1.0.8-6.fc34.aarch64.rpm"
+          },
+          "sha256:820fee96d610178c7c7b8ce2b115bd02063d2f6dfcae5da4bf5d411de0b575f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-attrs-20.3.0-2.fc34.noarch.rpm"
+          },
+          "sha256:82b51ca6bec551d74a6d8c43194b0fd4e8bfdf19d1d68b58c1787723edd88bd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-en-3.0-14.fc34.noarch.rpm"
+          },
+          "sha256:82cbc5e0339e832d2fc0160541c30f3dee59b3d28d83907ae7b55e22d5092c51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-core-font-en-3.0-14.fc34.noarch.rpm"
+          },
+          "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-common-8.32-30.fc34.aarch64.rpm"
+          },
+          "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-29-2.fc34.aarch64.rpm"
+          },
+          "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:86cb1e5e80642b1575df57287c9549749603bf94b1ba652995b59ea45ac4272b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libldb-2.3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-libs-1.02.175-1.fc34.aarch64.rpm"
+          },
+          "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pam-1.5.1-7.fc34.aarch64.rpm"
+          },
+          "sha256:87749765dbe5ce8f098279170c39bb8a89abbf3f8430c2a6dbfb973117e11dfa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-libsemanage-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libidn2-2.3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.aarch64.rpm"
+          },
+          "sha256:8ab032e2a86f300d978e521ab030db1e7bb7eeccca205a5d2a4d68b51566f43f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc34.noarch.rpm"
+          },
+          "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openldap-2.4.57-6.fc34.aarch64.rpm"
+          },
+          "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libs-3.9.9-2.fc34.aarch64.rpm"
+          },
+          "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre-8.44-3.fc34.1.aarch64.rpm"
+          },
+          "sha256:8fbfbaf3b107b540428634c19c4cb05e7c46f9672cfbf14d1f44306ed3413a46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/efi-filesystem-5-4.fc34.noarch.rpm"
+          },
+          "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm"
+          },
+          "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc34.aarch64.rpm"
+          },
+          "sha256:92e42b63fcc56dd21984abb722e8fa7ebbb58f6d54c529ac11871b4bbc63b290": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pyyaml-5.4.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gmp-6.2.0-6.fc34.aarch64.rpm"
+          },
+          "sha256:96c7a26b707d4038a50b4ab0fd8d79ba3997466bed543f13c10d30e7ec256b5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/net-tools-2.0-0.59.20160912git.fc34.aarch64.rpm"
+          },
+          "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm"
+          },
+          "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/basesystem-11-11.fc34.noarch.rpm"
+          },
+          "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-5.2.5-5.fc34.aarch64.rpm"
+          },
+          "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/openssl-pkcs11-0.4.11-2.fc34.aarch64.rpm"
+          },
+          "sha256:9aee2549d3ff9e5652dffaaa9b91ab7a243687cc2a85b8e45f4290d53d44702d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc34.aarch64.rpm"
+          },
+          "sha256:9cc240ac305a862146e85d8dcc4ad981f5233a58b6901ecfac691d0b39966b49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jwt+crypto-1.7.1-11.fc34.noarch.rpm"
+          },
+          "sha256:9ce3f0c0904ac22ab5769babebf43e7dcdb488b0ef999b2e9e88a5b5eb424e51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-chardet-4.0.0-1.fc34.noarch.rpm"
+          },
+          "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm"
+          },
+          "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsepol-3.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-libs-0.21-4.fc34.aarch64.rpm"
+          },
+          "sha256:9f2f2a20f285a2ac306ce72475beecf967cf92308b426aafca68215a6c3c12ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/jansson-2.13.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-misc-2.4.0-2.fc34.noarch.rpm"
+          },
+          "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.aarch64.rpm"
+          },
+          "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm"
+          },
+          "sha256:a0f1b653f889bb95e6edec2c525dfc71e280076b29394cf9c06ffa81ecd8b9fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/efivar-libs-37-15.fc34.aarch64.rpm"
+          },
+          "sha256:a1a996e8da4733b14c449b69e34484fe4f2b88c0f2963145bf0402cf04baf30e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpath_utils-0.2.1-47.fc34.aarch64.rpm"
+          },
+          "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc34.noarch.rpm"
+          },
+          "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-gpg-keys-34-2.noarch.rpm"
+          },
+          "sha256:a60e3e035883de829c5778417d316ffc47a0b4a304953e3fdc44def8f2f172ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/linux-atm-libs-2.5.1-28.fc34.aarch64.rpm"
+          },
+          "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:a72bb74400b447af71600da141aebdc46da7776ef875abfdd635881f939891d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtevent-0.11.0-0.fc34.aarch64.rpm"
+          },
+          "sha256:a86ec8f7284ee01574bb06bba726d8609e464f41d003215097e626c583f73ed0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-python-plugin-1.9.5p2-1.fc34.aarch64.rpm"
+          },
+          "sha256:a9828dc2c4215e6bcb9aa14370d854f24637b0510e4b1a63709135049314e2b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rsync-3.2.3-5.fc34.aarch64.rpm"
+          },
+          "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-2.33-20.fc34.aarch64.rpm"
+          },
+          "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssl-libs-1.1.1l-2.fc34.aarch64.rpm"
+          },
+          "sha256:ac901ae730144d1e75b86d9991c1c6a9d6d0a44ce6e52b4d330df3a26d09e1ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/u/util-linux-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnsl2-1.3.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm"
+          },
+          "sha256:adb1b49ec7038eec956edd77d0ad2a72179b4f37c14548e3c9637d8a75c276a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.33-20.fc34.aarch64.rpm"
+          },
+          "sha256:adcd36cb0e582f5fb2d0465cf88bb813ffac17d25d6ec8aa608b647d008bebc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.3755-1.fc34.noarch.rpm"
+          },
+          "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-networkd-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/policycoreutils-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm"
+          },
+          "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libgpg-error-1.42-1.fc34.aarch64.rpm"
+          },
+          "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/os-prober-1.77-7.fc34.aarch64.rpm"
+          },
+          "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-pam-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-libs-5.2.5-5.fc34.aarch64.rpm"
+          },
+          "sha256:b30db4e3d9605e7263387ff91f91508667693d28e8b8835a2b7fcefd64f24388": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-oauthlib+signedtoken-3.0.2-9.fc34.noarch.rpm"
+          },
+          "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm"
+          },
+          "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-lib-0.3.15-2.fc34.aarch64.rpm"
+          },
+          "sha256:b5d5e7255c85c3aa9d63598ef140de35843ab2485adf1cb9a9130be80aa0297f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-six-1.15.0-5.fc34.noarch.rpm"
+          },
+          "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:b6687e9977e337e5d029de0d42cb79d57bd44f2f642450440756ba1a0494a113": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libedit-3.1-38.20210714cvs.fc34.aarch64.rpm"
+          },
+          "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libattr-2.5.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.aarch64.rpm"
+          },
+          "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cpio-2.13-10.fc34.aarch64.rpm"
+          },
+          "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-1.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm"
+          },
+          "sha256:bab19da8b6f553325decae00748f88fc0924b918136f065ab8995e1ebf5bde5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc34.noarch.rpm"
+          },
+          "sha256:bb078ccf6e7372cf22e55901c005517daff0b8cffa14fa3dec5e9804b4f65897": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmaxminddb-1.5.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm"
+          },
+          "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm"
+          },
+          "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mkpasswd-5.5.10-1.fc34.aarch64.rpm"
+          },
+          "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-syntax-10.36-4.fc34.noarch.rpm"
+          },
+          "sha256:bfd008fce37b2ec17dc4142c38a6e808c2e0031eed802a0253fca812989845d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iproute-tc-5.10.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:c04a67670d45f576c5a8b23fe64d5ce31b04ddf4792cbf78448fd4c96899f9c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnfnetlink-1.0.1-19.fc34.aarch64.rpm"
+          },
+          "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-rpm-macros-248.9-1.fc34.noarch.rpm"
+          },
+          "sha256:c20caffb4d2a500416dab0e8418a24ae5e25c02c831ae02ee10f97a0dcc80374": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-core-en-3.0-14.fc34.noarch.rpm"
+          },
+          "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm"
+          },
+          "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc34.aarch64.rpm"
+          },
+          "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-2.48-2.fc34.aarch64.rpm"
+          },
+          "sha256:c814f83bcf3cfc590d84897c810a087354cfb0c961dd232af5031cfe8bd63a37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-client-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-10.36-4.fc34.aarch64.rpm"
+          },
+          "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm"
+          },
+          "sha256:ca8f4843c8b23ce16b957143550d8dc83ae630cd64587fa2dd127e4ecbe9bb23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnetfilter_conntrack-1.0.8-2.fc34.aarch64.rpm"
+          },
+          "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.aarch64.rpm"
+          },
+          "sha256:cc4401d1e292b28d771a2038081b929b342ffa3b60358aed91697fdbc668546a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-prettytable-0.7.2-25.fc34.noarch.rpm"
+          },
+          "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.aarch64.rpm"
+          },
+          "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcrypt-1.9.3-3.fc34.aarch64.rpm"
+          },
+          "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-0.9.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc34.noarch.rpm"
+          },
+          "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsigsegv-2.13-2.fc34.aarch64.rpm"
+          },
+          "sha256:cf18d61c8f526fe86cd24073dfdce942b6a463ea909ed5a59a5cc4378d9101a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcollection-0.7.0-47.fc34.aarch64.rpm"
+          },
+          "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/memstrack-0.2.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pigz-2.5-1.fc34.aarch64.rpm"
+          },
+          "sha256:d1c8a2302e64fc856aff6a05a78140986e89eddd8f110deb9ba78d44aebcd411": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/psmisc-23.4-1.fc34.aarch64.rpm"
+          },
+          "sha256:d2bac91a1969f555ea2641b161bb23fa0aaaffaba3284d9973ad696594b73f18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-motdgen-0.21.2-1.fc34.noarch.rpm"
+          },
+          "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-libs-29-2.fc34.aarch64.rpm"
+          },
+          "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bash-5.1.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:d54b628e6d0b7813ec0b4cc0beb1b8f3f8510ffbaff8ae1d9c4b9993095e4edf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-cloud-34-39.noarch.rpm"
+          },
+          "sha256:d5d622f60e97d43b095a98f2bb46982d91451e4e6018492da20944b294480af3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.6p1-5.fc34.aarch64.rpm"
+          },
+          "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.3.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:d6810c97f24d93cd54a61bb288ada8591a94e4083b5165e0719915bceb637504": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonschema-3.2.0-9.fc34.noarch.rpm"
+          },
+          "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/readline-8.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mpfr-4.1.0-7.fc34.aarch64.rpm"
+          },
+          "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-libs-3.0.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-9.fc34.aarch64.rpm"
+          },
+          "sha256:dbf3fb9e356236575a06e4fdcd532331f418236aa4ff4e024260c24be2b9a7cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-libselinux-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/json-c-0.14-8.fc34.aarch64.rpm"
+          },
+          "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/alternatives-1.15-2.fc34.aarch64.rpm"
+          },
+          "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/acl-2.3.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:e035a5041c721ea40e47cbbc19eb1b91c520183f85137ee1dd3ed3b42a47c180": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-cloud-34-39.noarch.rpm"
+          },
+          "sha256:e0dffa204780c20c16357a51b992351aa1cf9f9cdda6182939ecd0cd7ab2c2bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonpatch-1.21-14.fc34.noarch.rpm"
+          },
+          "sha256:e1e89027213f00ae1014bbb1253058ed8d5d476e7246921f03736ea129d2a162": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iproute-5.10.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:e1f1b9c4b78fe9d84a87d7de67fdd8559fe2bea9969ca1632d137de635d7e898": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-setools-4.4.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-0.3.15-2.fc34.aarch64.rpm"
+          },
+          "sha256:e530795e5c9bc27de609fcbbacdc43c226026fee95e47a1f783f1c03ba5d48ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-distro-1.5.0-5.fc34.noarch.rpm"
+          },
+          "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libutempter-1.2.1-4.fc34.aarch64.rpm"
+          },
+          "sha256:e76f1401d9e119eae4cc461c8b68e9eae075d4b69f61870cb5c19ba7d69cf1a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-policycoreutils-3.2-1.fc34.noarch.rpm"
+          },
+          "sha256:e7d1d0b85ac49d8b0c9dd3fce4613e6229ac8720cfb74c80a496b9f0beaa7a22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cloud-init-20.4-2.fc34.noarch.rpm"
+          },
+          "sha256:e9814c1b1a22b8cbd39413dc4f0eab452ef7380ce01f05ecab0e41e2d00ba3c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libdhash-0.5.0-47.fc34.aarch64.rpm"
+          },
+          "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm"
+          },
+          "sha256:ea8067f2310d30b31f7b1f13825b2a5a5e679c114fefd072267b6c369a365a63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-cryptography-3.4.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:eab8d30db6004f8c21247689cac52f143e1bde1da817db9761420cf3cf855c38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/initscripts-10.09-1.fc34.aarch64.rpm"
+          },
+          "sha256:eb88e660b9fd02e695a90c0266831b79e513c2f65ba5d6353e82726af96e9752": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-modular-34-2.noarch.rpm"
+          },
+          "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/krb5-libs-1.19.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:ebd4a9473543a5ca50ec5f9de069fc0c240527516ae262cf3e28a5d914b99cb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-libs-1.8.7-8.fc34.aarch64.rpm"
+          },
+          "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-1.02.175-1.fc34.aarch64.rpm"
+          },
+          "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:ee147f5a7017de1c77abfbb79dd32eb97c923fc7c1b74c32bda6020b9025938c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpipeline-1.5.3-2.fc34.aarch64.rpm"
+          },
+          "sha256:eecc86b828ad436a9f397d2f7acdf5705bfd36bcad3edd2da73f3acc94363411": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc34.noarch.rpm"
+          },
+          "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-5.39-7.fc34.aarch64.rpm"
+          },
+          "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm"
+          },
+          "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grubby-8.40-51.fc34.aarch64.rpm"
+          },
+          "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.25.10-5.fc34.noarch.rpm"
+          },
+          "sha256:f3c940f33c6c8edb73b98527e0fff17aa211e823f06e3f732762d0c86cc0268c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-100.fc34.aarch64.rpm"
+          },
+          "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-doc-2.33-20.fc34.noarch.rpm"
+          },
+          "sha256:f68c93c0461c149bb17282dededf421cbc1fbfa5ac133b59bd362526f59e0d57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-idna-2.10-3.fc34.noarch.rpm"
+          },
+          "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:f695ed244a1d9f3eb814947fb1da343d7d6fb3aaa2bf72965235e4b45a58a784": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.30.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm"
+          },
+          "sha256:f7c7dc1d8e5cf4776a1fde155871a2bb1fdd0676f897a43334cfbb60eb69e52a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/mokutil-0.4.0-4.fc34.aarch64.rpm"
+          },
+          "sha256:f7f8832ccaedd7ddad064956309478b9bf366f0576517356ee68481e196236cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-configobj-5.0.6-23.fc34.noarch.rpm"
+          },
+          "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm"
+          },
+          "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:f9b2e7232d0b2d33bf52993c31b43b31520601f52f44fe792acd6dee4d84afc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-oauthlib-3.0.2-9.fc34.noarch.rpm"
+          },
+          "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfdisk-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:fbf45cda87a05418a72f4bf3877da5ebcabbe68d393bc5bec007a8b01ef6bafe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-markupsafe-1.1.1-10.fc34.aarch64.rpm"
+          },
+          "sha256:fc4104e014beee44b5003e72a32e45e689936a4ffdcf07e119b02be3ed4ab8d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.17.3-6.fc34.aarch64.rpm"
+          },
+          "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lz4-libs-1.9.3-2.fc34.aarch64.rpm"
+          },
+          "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.8.1-10.fc34.aarch64.rpm"
+          },
+          "sha256:fd7dc918a1e3ad0114ecaa41d78c6652cc559271ad6653e5bba0bc780af35faa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libuser-0.63-4.fc34.aarch64.rpm"
+          },
+          "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.aarch64.rpm"
+          }
+        }
+      }
+    },
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.rpm",
+              "options": {
+                "gpgkeys": [
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n"
+                ],
+                "packages": [
+                  {
+                    "checksum": "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3e69e8412d5914ec01c5e82264833698e92a1b88a7c7b5ed9b1f0351fc91f5d2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6d1c024b295c423746b44f120cf36ceb0fd898f8ce5a276813d7c78a3c8ece52",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:adb1b49ec7038eec956edd77d0ad2a72179b4f37c14548e3c9637d8a75c276a1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
+                    "check_gpg": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "org.osbuild.selinux",
+              "options": {
+                "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+                "labels": {
+                  "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+                }
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.fedora33"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8"
+          }
+        },
+        {
+          "name": "org.osbuild.rpm",
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "packages": [
+              {
+                "checksum": "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:33b878000610ca3ba875b72f2a454e4fac9471f80579824304ca81e6f3e3f79d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e7d1d0b85ac49d8b0c9dd3fce4613e6229ac8720cfb74c80a496b9f0beaa7a22",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6d1b95e06ec98f6d65c64e18fec693d379b98128a3e94b4dec8929321354c549",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1877af369228dd661ae1adfc43bbb8d53d3464d59ead0f5bcf6c2be88f8e8685",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3f7bde703045c2651fbd4142131ea1e303a565269388a08e2312af0eb83307a4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d2bac91a1969f555ea2641b161bb23fa0aaaffaba3284d9973ad696594b73f18",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:424f73b97c7d7541d35685108bdcddb03100cd0f3d6e0fd9def576462ca65b59",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:79834af7f95c0d1e5dcf85b794819bd854197a52d2966594abdb3c3de0fcceb6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0f9ebdf7f08a506a8d1d6c4b4788dd7ca3dbb832509072b66def4da5b86d7862",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a0f1b653f889bb95e6edec2c525dfc71e280076b29394cf9c06ffa81ecd8b9fa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3fb05067cbd7fcf3283f2ab306c2dae668d818d3a69422e729c2ef62974810a5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:37cda2c179e4311a1aeeb0ea8d07d3eacc8ea8bf97d122ec22cd596c61b8e770",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:47c92a952b162b7bafbe49a7e409a7a81825adc77b3e139651913d52d8aa84fb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6d3301f6e99d9728698822e81fc2d170694cc367b7e7fea5c7a019f7b1a6073b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eab8d30db6004f8c21247689cac52f143e1bde1da817db9761420cf3cf855c38",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e1e89027213f00ae1014bbb1253058ed8d5d476e7246921f03736ea129d2a162",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bfd008fce37b2ec17dc4142c38a6e808c2e0031eed802a0253fca812989845d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4b65dc9856b0d0ce555dd9bce88dcfb680ba689a2c6b88ae9f84b016553d96af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9f2f2a20f285a2ac306ce72475beecf967cf92308b426aafca68215a6c3c12ca",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c20caffb4d2a500416dab0e8418a24ae5e25c02c831ae02ee10f97a0dcc80374",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:82cbc5e0339e832d2fc0160541c30f3dee59b3d28d83907ae7b55e22d5092c51",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:82b51ca6bec551d74a6d8c43194b0fd4e8bfdf19d1d68b58c1787723edd88bd0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:12b7666d61e7bd8b3b5b1a7c57539964531802287e592e33449e039799ea2071",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6046f881a5c0822c30bd037aec040c65594b6328b1c0d72b6681fe1575eac765",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cf18d61c8f526fe86cd24073dfdce942b6a463ea909ed5a59a5cc4378d9101a1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e9814c1b1a22b8cbd39413dc4f0eab452ef7380ce01f05ecab0e41e2d00ba3c0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1014763656c1578ae96b38fd3e87c4d07b548cb8423688cc928d0f9762d43a44",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:45d38ed1d2247e17e3e8faf7d6755216c5ef4422736129f55b712f160532d8f2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bb078ccf6e7372cf22e55901c005517daff0b8cffa14fa3dec5e9804b4f65897",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:79864051052858a1c95538888ca61a43b509b6eae4ae269ae6ea7bf8b076a2b8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11a0c09b716f8071f0484278bec326fb82e93d987376c8b38188d1febcd5381d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ca8f4843c8b23ce16b957143550d8dc83ae630cd64587fa2dd127e4ecbe9bb23",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c04a67670d45f576c5a8b23fe64d5ce31b04ddf4792cbf78448fd4c96899f9c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a1a996e8da4733b14c449b69e34484fe4f2b88c0f2963145bf0402cf04baf30e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ee147f5a7017de1c77abfbb79dd32eb97c923fc7c1b74c32bda6020b9025938c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:686e015d81c1be2e6b88c7e8a50d45109d7273143a034caa9c935ecd014e1c62",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:56634e58fc7499d719a3f431dd188e8f2655ebfa402e94ce105794a47debf45b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2027da420b35a0b70ae5045d2fd79cdccb820f03e5ff4018a2205d3d413ff1af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a60e3e035883de829c5778417d316ffc47a0b4a304953e3fdc44def8f2f172ab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7721bc647c521d96e07e665f7da306326d3bd1499d610c58552317815aaf3c45",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61ba1ecff8f8578cbd3445df596d001067bb0281745191ac168fcc6079d8e1cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f7c7dc1d8e5cf4776a1fde155871a2bb1fdd0676f897a43334cfbb60eb69e52a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:96c7a26b707d4038a50b4ab0fd8d79ba3997466bed543f13c10d30e7ec256b5e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:27920113489e3260e58d4a033d31401c6ae22ded72895c6b8c0e43ebf89a62df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6a864bec34b7d39de3e6ae1e39ec07fa3a2d21837a9a2d7151228d7f0ac38e73",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d1c8a2302e64fc856aff6a05a78140986e89eddd8f110deb9ba78d44aebcd411",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:820fee96d610178c7c7b8ce2b115bd02063d2f6dfcae5da4bf5d411de0b575f7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7d00ccbb224617a00f58053afd88e7a49062446f1306ba39c72b78d20aeee1ef",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9ce3f0c0904ac22ab5769babebf43e7dcdb488b0ef999b2e9e88a5b5eb424e51",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f7f8832ccaedd7ddad064956309478b9bf366f0576517356ee68481e196236cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ea8067f2310d30b31f7b1f13825b2a5a5e679c114fefd072267b6c369a365a63",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d2c28837f0573ae2647b8fbba85f7c502f9c3da0a3eab1c9ba121de4a1a6cee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e530795e5c9bc27de609fcbbacdc43c226026fee95e47a1f783f1c03ba5d48ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f68c93c0461c149bb17282dededf421cbc1fbfa5ac133b59bd362526f59e0d57",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2414cb7345bc193f7ff7983c020c8b0e706aab013ee30af5d457d35c4de4a698",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e0dffa204780c20c16357a51b992351aa1cf9f9cdda6182939ecd0cd7ab2c2bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1b1af6b54050ec223c3289b107a9695a686c9d46d17a80ec9cd5d0201ec5d544",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d6810c97f24d93cd54a61bb288ada8591a94e4083b5165e0719915bceb637504",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9cc240ac305a862146e85d8dcc4ad981f5233a58b6901ecfac691d0b39966b49",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:131adc47f044c9f600f5295ded0f5431cda57fa7276100c3ec81c9d1ce3fa6f7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dbf3fb9e356236575a06e4fdcd532331f418236aa4ff4e024260c24be2b9a7cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:87749765dbe5ce8f098279170c39bb8a89abbf3f8430c2a6dbfb973117e11dfa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fbf45cda87a05418a72f4bf3877da5ebcabbe68d393bc5bec007a8b01ef6bafe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b30db4e3d9605e7263387ff91f91508667693d28e8b8835a2b7fcefd64f24388",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f9b2e7232d0b2d33bf52993c31b43b31520601f52f44fe792acd6dee4d84afc8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:23e3ed871799a9209915359f71660babf451b0b44902e3ed488b7b22aff37718",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e76f1401d9e119eae4cc461c8b68e9eae075d4b69f61870cb5c19ba7d69cf1a3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cc4401d1e292b28d771a2038081b929b342ffa3b60358aed91697fdbc668546a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:32220dc513a6ebcd4994e7140ecb5859108baf44d12fe6b1f0c0459dbefc54e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:70a90c6c682016e91fb4745eedbd23f28e150a38b01d18f85ce4e50fb4e0ca6c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4a74ae08a713e9b4e74ff27bfaf57374312370402f90e2796e66c504557ae189",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:92e42b63fcc56dd21984abb722e8fa7ebbb58f6d54c529ac11871b4bbc63b290",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6297d7eee103c679a0f1ea411568d3940af3fe8f38e19388a1544df70bda8b3c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e1f1b9c4b78fe9d84a87d7de67fdd8559fe2bea9969ca1632d137de635d7e898",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5d5e7255c85c3aa9d63598ef140de35843ab2485adf1cb9a9130be80aa0297f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:164e1c0e3e8c89aeda4f272b3158932649a69b16aea058105117a64d3cdef517",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a9828dc2c4215e6bcb9aa14370d854f24637b0510e4b1a63709135049314e2b3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:23a539a271c92906ac0a12c7d877c7f4d0ad8e6b9bbd8642b5232f861b79ed22",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:40e231991444a589b17e0b5b338be8874d071e3d17e210aba6f6639620775f79",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a86ec8f7284ee01574bb06bba726d8609e464f41d003215097e626c583f73ed0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3228a36807658c7e4d881013aa26f877353388bf3bac6c948984f751c264a359",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4baf8ba6a5ed4609695f79a8bbc8324d7efa322a3573c8c5fa3942361eac0f1c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f695ed244a1d9f3eb814947fb1da343d7d6fb3aaa2bf72965235e4b45a58a784",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:148aea26e381b33badde0ac2ae716a78f7b565f54f0b6970189a89713f335eaf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7c24e53e12891046bb6721e624cf9effd1946c0d076464427c2a86b29671318e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61a9dbd9020e29012947978acf33a0c1150e6c3e078de372f1e38fb9c4ef529a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2968703dd232a37620a0ae12146c9d1ec5220f62c40bfb0ecfc60b621d8e1eac",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0ac62147585be2dae960ed37a3a0c3eb2f8a95d0fd0993991c8bf7238b1d5e27",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11cd6fae157eb9e4800163633b57bcce21d59a1df4b86a99ba03707b6cee0cfc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1feb6a045cb3e95e3c8e0112ecb4b8ffeb9986a503b52c5497fefce217846b90",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9aee2549d3ff9e5652dffaaa9b91ab7a243687cc2a85b8e45f4290d53d44702d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8fbfbaf3b107b540428634c19c4cb05e7c46f9672cfbf14d1f44306ed3413a46",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d54b628e6d0b7813ec0b4cc0beb1b8f3f8510ffbaff8ae1d9c4b9993095e4edf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e035a5041c721ea40e47cbbc19eb1b91c520183f85137ee1dd3ed3b42a47c180",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eb88e660b9fd02e695a90c0266831b79e513c2f65ba5d6353e82726af96e9752",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:059f825547fe257247656c29049ebc7bfa1d54a17479f3dcfeff37fbab7084bd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:71427f6f8f3f6370dccde81a76d566ff17144e7e375381ef13e04a661e63cba1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:69de3dd68dc2b76e2a85c710a51e9c8acefe595d6ac5d9f19113c4062a5f0d92",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ebd4a9473543a5ca50ec5f9de069fc0c240527516ae262cf3e28a5d914b99cb1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:55833f669ed1dbd32e79f494824c309b71bc373d2bf28eb5cdb663459dc6f7cd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0176b42c6b51fb3c829f168571527a3559b6a9c8cc5f847b70e3c40fb69f89e4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3c940f33c6c8edb73b98527e0fff17aa211e823f06e3f732762d0c86cc0268c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7cc0891a9e7c19757c03cba6c8155738d9db9f5774380c412106adf0eca44077",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b6687e9977e337e5d029de0d42cb79d57bd44f2f642450440756ba1a0494a113",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:86cb1e5e80642b1575df57287c9549749603bf94b1ba652995b59ea45ac4272b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:330a36b1dabaf76daafeff3f7fd7a276880bf65d790ee84cb823a1958a4d99d7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b3bba1d61529a1dde47f234f34d0fdee07a38aa5958d87e30357ea04bbff142",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac901ae730144d1e75b86d9991c1c6a9d6d0a44ce6e52b4d330df3a26d09e1ff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3fdab509a59e0a765364d6f119c38c796a4420cc49b46595a37d98eb649d6c80",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:60ddc7b15e9742ff9995d1b336489b92721e21a45034d20f20d2fc800e419d1c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4123331b5d06f91ff31d147e4769806052f59b620e7677f69b0073eaf7beccb6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a72bb74400b447af71600da141aebdc46da7776ef875abfdd635881f939891d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fd7dc918a1e3ad0114ecaa41d78c6652cc559271ad6653e5bba0bc780af35faa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8ab032e2a86f300d978e521ab030db1e7bb7eeccca205a5d2a4d68b51566f43f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5dcac7772d73ad1523f87cbeb1dc76dd62af4d2bb73dd06896a47d2bcf503e5e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d5d622f60e97d43b095a98f2bb46982d91451e4e6018492da20944b294480af3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:39160ef65b3519a70f14f992edc5967380ef86a6940896751db681781961903d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:139b9453b2038e52767d0102def782d58d558ca0603757eb0c97ddda28af1466",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59cc4d563ecb4c8b517f5dd7505f1cda297f950f32fc700344aa7789b69ca99c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:00c29524aad123ec44056e60b9625e75ac428a6c751878a05fadbca7e956c249",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bab19da8b6f553325decae00748f88fc0924b918136f065ab8995e1ebf5bde5b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fc4104e014beee44b5003e72a32e45e689936a4ffdcf07e119b02be3ed4ab8d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eecc86b828ad436a9f397d2f7acdf5705bfd36bcad3edd2da73f3acc94363411",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c814f83bcf3cfc590d84897c810a087354cfb0c961dd232af5031cfe8bd63a37",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:668a30c6f526e51705af9cb9d98fd11f279f5e86f7d905876ae9a86f486a8c36",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7285fcc290a8af2cf845beb845e661cd4c06c2275417b15eb507824dedec7c69",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0db1be9a78e5f329a519066a7b37379f6c73fe579154e0a6a26b2dcb4154ccd6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:43b0b5d425a2041daeb6b41db2858abda1f92ecc38c6125f7de3b7502580a9f7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:adcd36cb0e582f5fb2d0465cf88bb813ffac17d25d6ec8aa608b647d008bebc3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1af86c0a8c11e44958b022bf7dad5f48ad974fa8537cf41a12d5b0643444b1dc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30bc3583e503e0f459e323b27551f7b9a8ab784de15437b5b29f447b31f8d9cd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
+                "check_gpg": true
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.hostname",
+          "options": {
+            "hostname": "localhost.localdomain"
+          }
+        },
+        {
+          "name": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              },
+              {
+                "uuid": "46BB-8120",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "umask=0077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "uefi": {
+              "vendor": "fedora"
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
+        "options": {
+          "format": "qcow2",
+          "filename": "disk.qcow2",
+          "size": 2147483648,
+          "ptuuid": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
+          "pttype": "gpt",
+          "partitions": [
+            {
+              "start": 2048,
+              "size": 972800,
+              "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+              "uuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
+              "filesystem": {
+                "type": "vfat",
+                "uuid": "46BB-8120",
+                "label": "EFI-SYSTEM",
+                "mountpoint": "/boot/efi"
+              }
+            },
+            {
+              "start": 976896,
+              "uuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build-packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/acl-2.3.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/alternatives-1.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/basesystem-11-11.fc34.noarch.rpm",
+        "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bash-5.1.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bzip2-libs-1.0.8-6.fc34.aarch64.rpm",
+        "checksum": "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cpio-2.13-10.fc34.aarch64.rpm",
+        "checksum": "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cyrus-sasl-lib-2.1.27-8.fc34.aarch64.rpm",
+        "checksum": "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-1.12.20-3.fc34.aarch64.rpm",
+        "checksum": "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-common-1.12.20-3.fc34.noarch.rpm",
+        "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm",
+        "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm",
+        "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-1.02.175-1.fc34.aarch64.rpm",
+        "checksum": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-libs-1.02.175-1.fc34.aarch64.rpm",
+        "checksum": "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/filesystem-3.14-5.fc34.aarch64.rpm",
+        "checksum": "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/findutils-4.8.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "11.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fuse-libs-2.9.9-11.fc34.aarch64.rpm",
+        "checksum": "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-all-langpacks-5.1.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.19",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gdbm-libs-1.19-2.fc34.aarch64.rpm",
+        "checksum": "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-libs-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gmp-6.2.0-6.fc34.aarch64.rpm",
+        "checksum": "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm",
+        "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grep-3.6-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "51.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grubby-8.40-51.fc34.aarch64.rpm",
+        "checksum": "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm",
+        "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.14",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/json-c-0.14-8.fc34.aarch64.rpm",
+        "checksum": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-misc-2.4.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/keyutils-libs-1.6.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.5",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "11.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.aarch64.rpm",
+        "checksum": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.aarch64.rpm",
+        "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libattr-2.5.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libblkid-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbrotli-1.0.9-4.fc34.aarch64.rpm",
+        "checksum": "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-2.48-2.fc34.aarch64.rpm",
+        "checksum": "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-ng-0.8.2-4.fc34.aarch64.rpm",
+        "checksum": "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm",
+        "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfdisk-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "28.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.aarch64.rpm",
+        "checksum": "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.42",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libgpg-error-1.42-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-1.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.43.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnghttp2-1.43.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnl3-3.5.0-6.fc34.aarch64.rpm",
+        "checksum": "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnsl2-1.3.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpsl-0.21.1-3.fc34.aarch64.rpm",
+        "checksum": "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm",
+        "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsemanage-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsigsegv-2.13-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.17",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm",
+        "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtasn1-4.16.0-4.fc34.aarch64.rpm",
+        "checksum": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
+        "check_gpg": true
+      },
+      {
+        "name": "libtextstyle",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtextstyle-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.aarch64.rpm",
+        "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
+        "check_gpg": true
+      },
+      {
+        "name": "liburing",
+        "epoch": 0,
+        "version": "0.7",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm",
+        "checksum": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
+        "check_gpg": true
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libutempter-1.2.1-4.fc34.aarch64.rpm",
+        "checksum": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libuuid-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lz4-libs-1.9.3-2.fc34.aarch64.rpm",
+        "checksum": "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/memstrack-0.2.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-6.2-4.20200222.fc34.aarch64.rpm",
+        "checksum": "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm",
+        "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm",
+        "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm",
+        "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/openssl-pkcs11-0.4.11-2.fc34.aarch64.rpm",
+        "checksum": "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/os-prober-1.77-7.fc34.aarch64.rpm",
+        "checksum": "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-0.23.22-3.fc34.aarch64.rpm",
+        "checksum": "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-trust-0.23.22-3.fc34.aarch64.rpm",
+        "checksum": "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.44",
+        "release": "3.fc34.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre-8.44-3.fc34.1.aarch64.rpm",
+        "checksum": "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-10.36-4.fc34.aarch64.rpm",
+        "checksum": "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-syntax-10.36-4.fc34.noarch.rpm",
+        "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pigz-2.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/policycoreutils-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/popt-1.18-4.fc34.aarch64.rpm",
+        "checksum": "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm",
+        "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20190417",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
+        "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/readline-8.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sed-4.8-7.fc34.aarch64.rpm",
+        "checksum": "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.7",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/setup-2.13.7-3.fc34.noarch.rpm",
+        "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.34.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm",
+        "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-0.3.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-lib-0.3.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/u/util-linux-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-5.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-libs-5.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "26.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/z/zlib-1.2.11-26.fc34.aarch64.rpm",
+        "checksum": "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-libs-3.0.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm",
+        "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-8.32-30.fc34.aarch64.rpm",
+        "checksum": "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-common-8.32-30.fc34.aarch64.rpm",
+        "checksum": "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-2.9.6-27.fc34.aarch64.rpm",
+        "checksum": "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.3.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/curl-7.76.1-12.fc34.aarch64.rpm",
+        "checksum": "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc34.aarch64.rpm",
+        "checksum": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc34.noarch.rpm",
+        "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-gpg-keys-34-2.noarch.rpm",
+        "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-34-39.noarch.rpm",
+        "checksum": "sha256:3e69e8412d5914ec01c5e82264833698e92a1b88a7c7b5ed9b1f0351fc91f5d2",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-common-34-39.noarch.rpm",
+        "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-34-39.noarch.rpm",
+        "checksum": "sha256:6d1c024b295c423746b44f120cf36ceb0fd898f8ce5a276813d7c78a3c8ece52",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-34-2.noarch.rpm",
+        "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-5.39-7.fc34.aarch64.rpm",
+        "checksum": "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.aarch64.rpm",
+        "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.68.4",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.aarch64.rpm",
+        "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-common-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-doc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-doc-2.33-20.fc34.noarch.rpm",
+        "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:adb1b49ec7038eec956edd77d0ad2a72179b4f37c14548e3c9637d8a75c276a1",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/gnutls-3.7.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm",
+        "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-legacy-libs-1.8.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-libs-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/krb5-libs-1.19.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.aarch64.rpm",
+        "checksum": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "49.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm",
+        "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcrypt-1.9.3-3.fc34.aarch64.rpm",
+        "checksum": "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "37.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libibverbs-37.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libidn2-2.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpcap-1.10.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm",
+        "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
+        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsepol-3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-0.9.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-config-0.9.6-1.fc34.noarch.rpm",
+        "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "0.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtirpc-1.3.2-0.fc34.aarch64.rpm",
+        "checksum": "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc34.aarch64.rpm",
+        "checksum": "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxkbcommon-1.3.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxml2-2.9.12-4.fc34.aarch64.rpm",
+        "checksum": "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mkpasswd-5.5.10-1.fc34.aarch64.rpm",
+        "checksum": "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mpfr-4.1.0-7.fc34.aarch64.rpm",
+        "checksum": "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/nettle-3.7.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.57",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openldap-2.4.57-6.fc34.aarch64.rpm",
+        "checksum": "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssl-libs-1.1.1l-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pam-1.5.1-7.fc34.aarch64.rpm",
+        "checksum": "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "1.fc34.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/procps-ng-3.3.17-1.fc34.1.aarch64.rpm",
+        "checksum": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-setuptools-wheel-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.9.9-2.fc34.noarch.rpm",
+        "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-3.9.9-2.fc34.aarch64.rpm",
+        "checksum": "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libs-3.9.9-2.fc34.aarch64.rpm",
+        "checksum": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pip-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
+        "check_gpg": true
+      },
+      {
+        "name": "qemu-img",
+        "epoch": 2,
+        "version": "5.2.0",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm",
+        "checksum": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.8.1",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.8.1-10.fc34.aarch64.rpm",
+        "checksum": "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-networkd-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-pam-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-rpm-macros",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-rpm-macros-248.9-1.fc34.noarch.rpm",
+        "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
+        "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "26.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/which-2.21-26.fc34.aarch64.rpm",
+        "checksum": "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/whois-nls-5.5.10-1.fc34.noarch.rpm",
+        "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
+        "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm",
+        "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
+        "check_gpg": true
+      }
+    ],
+    "packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/acl-2.3.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/alternatives-1.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/basesystem-11-11.fc34.noarch.rpm",
+        "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bash-5.1.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bzip2-libs-1.0.8-6.fc34.aarch64.rpm",
+        "checksum": "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4",
+        "check_gpg": true
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/checkpolicy-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:33b878000610ca3ba875b72f2a454e4fac9471f80579824304ca81e6f3e3f79d",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "20.4",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cloud-init-20.4-2.fc34.noarch.rpm",
+        "checksum": "sha256:e7d1d0b85ac49d8b0c9dd3fce4613e6229ac8720cfb74c80a496b9f0beaa7a22",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-utils-growpart",
+        "epoch": 0,
+        "version": "0.31",
+        "release": "8.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cloud-utils-growpart-0.31-8.fc34.noarch.rpm",
+        "checksum": "sha256:6d1b95e06ec98f6d65c64e18fec693d379b98128a3e94b4dec8929321354c549",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-0.21.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:1877af369228dd661ae1adfc43bbb8d53d3464d59ead0f5bcf6c2be88f8e8685",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-issuegen",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-issuegen-0.21.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:3f7bde703045c2651fbd4142131ea1e303a565269388a08e2312af0eb83307a4",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-motdgen",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-motdgen-0.21.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:d2bac91a1969f555ea2641b161bb23fa0aaaffaba3284d9973ad696594b73f18",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-profile",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-profile-0.21.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:424f73b97c7d7541d35685108bdcddb03100cd0f3d6e0fd9def576462ca65b59",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cpio-2.13-10.fc34.aarch64.rpm",
+        "checksum": "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cyrus-sasl-lib-2.1.27-8.fc34.aarch64.rpm",
+        "checksum": "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-1.12.20-3.fc34.aarch64.rpm",
+        "checksum": "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-common-1.12.20-3.fc34.noarch.rpm",
+        "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm",
+        "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
+        "check_gpg": true
+      },
+      {
+        "name": "dejavu-sans-fonts",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "16.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dejavu-sans-fonts-2.37-16.fc34.noarch.rpm",
+        "checksum": "sha256:79834af7f95c0d1e5dcf85b794819bd854197a52d2966594abdb3c3de0fcceb6",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm",
+        "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-1.02.175-1.fc34.aarch64.rpm",
+        "checksum": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-libs-1.02.175-1.fc34.aarch64.rpm",
+        "checksum": "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/efibootmgr-16-10.fc34.aarch64.rpm",
+        "checksum": "sha256:0f9ebdf7f08a506a8d1d6c4b4788dd7ca3dbb832509072b66def4da5b86d7862",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "37",
+        "release": "15.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/efivar-libs-37-15.fc34.aarch64.rpm",
+        "checksum": "sha256:a0f1b653f889bb95e6edec2c525dfc71e280076b29394cf9c06ffa81ecd8b9fa",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/filesystem-3.14-5.fc34.aarch64.rpm",
+        "checksum": "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/findutils-4.8.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501",
+        "check_gpg": true
+      },
+      {
+        "name": "fonts-filesystem",
+        "epoch": 1,
+        "version": "2.0.5",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fonts-filesystem-2.0.5-5.fc34.noarch.rpm",
+        "checksum": "sha256:3fb05067cbd7fcf3283f2ab306c2dae668d818d3a69422e729c2ef62974810a5",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "11.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fuse-libs-2.9.9-11.fc34.aarch64.rpm",
+        "checksum": "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-all-langpacks-5.1.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.19",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gdbm-libs-1.19-2.fc34.aarch64.rpm",
+        "checksum": "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-libs-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gmp-6.2.0-6.fc34.aarch64.rpm",
+        "checksum": "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm",
+        "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grep-3.6-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/groff-base-1.22.4-7.fc34.aarch64.rpm",
+        "checksum": "sha256:37cda2c179e4311a1aeeb0ea8d07d3eacc8ea8bf97d122ec22cd596c61b8e770",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "51.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grubby-8.40-51.fc34.aarch64.rpm",
+        "checksum": "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm",
+        "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/h/hostname-3.23-4.fc34.aarch64.rpm",
+        "checksum": "sha256:47c92a952b162b7bafbe49a7e409a7a81825adc77b3e139651913d52d8aa84fb",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "49",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/inih-49-3.fc34.aarch64.rpm",
+        "checksum": "sha256:6d3301f6e99d9728698822e81fc2d170694cc367b7e7fea5c7a019f7b1a6073b",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.09",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/initscripts-10.09-1.fc34.aarch64.rpm",
+        "checksum": "sha256:eab8d30db6004f8c21247689cac52f143e1bde1da817db9761420cf3cf855c38",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.10.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iproute-5.10.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e1e89027213f00ae1014bbb1253058ed8d5d476e7246921f03736ea129d2a162",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute-tc",
+        "epoch": 0,
+        "version": "5.10.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iproute-tc-5.10.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:bfd008fce37b2ec17dc4142c38a6e808c2e0031eed802a0253fca812989845d1",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20210202",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iputils-20210202-2.fc34.aarch64.rpm",
+        "checksum": "sha256:4b65dc9856b0d0ce555dd9bce88dcfb680ba689a2c6b88ae9f84b016553d96af",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/jansson-2.13.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:9f2f2a20f285a2ac306ce72475beecf967cf92308b426aafca68215a6c3c12ca",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.14",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/json-c-0.14-8.fc34.aarch64.rpm",
+        "checksum": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-misc-2.4.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/keyutils-libs-1.6.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.5",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-core-en-3.0-14.fc34.noarch.rpm",
+        "checksum": "sha256:c20caffb4d2a500416dab0e8418a24ae5e25c02c831ae02ee10f97a0dcc80374",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-font-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-core-font-en-3.0-14.fc34.noarch.rpm",
+        "checksum": "sha256:82cbc5e0339e832d2fc0160541c30f3dee59b3d28d83907ae7b55e22d5092c51",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-en-3.0-14.fc34.noarch.rpm",
+        "checksum": "sha256:82b51ca6bec551d74a6d8c43194b0fd4e8bfdf19d1d68b58c1787723edd88bd0",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.aarch64.rpm",
+        "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libattr-2.5.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbasicobjects-0.1.1-47.fc34.aarch64.rpm",
+        "checksum": "sha256:12b7666d61e7bd8b3b5b1a7c57539964531802287e592e33449e039799ea2071",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libblkid-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbrotli-1.0.9-4.fc34.aarch64.rpm",
+        "checksum": "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-2.48-2.fc34.aarch64.rpm",
+        "checksum": "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-ng-0.8.2-4.fc34.aarch64.rpm",
+        "checksum": "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcbor-0.7.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:6046f881a5c0822c30bd037aec040c65594b6328b1c0d72b6681fe1575eac765",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcollection-0.7.0-47.fc34.aarch64.rpm",
+        "checksum": "sha256:cf18d61c8f526fe86cd24073dfdce942b6a463ea909ed5a59a5cc4378d9101a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libdhash-0.5.0-47.fc34.aarch64.rpm",
+        "checksum": "sha256:e9814c1b1a22b8cbd39413dc4f0eab452ef7380ce01f05ecab0e41e2d00ba3c0",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm",
+        "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfdisk-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "28.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.aarch64.rpm",
+        "checksum": "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfido2-1.6.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:1014763656c1578ae96b38fd3e87c4d07b548cb8423688cc928d0f9762d43a44",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.42",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libgpg-error-1.42-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libini_config-1.3.1-47.fc34.aarch64.rpm",
+        "checksum": "sha256:45d38ed1d2247e17e3e8faf7d6755216c5ef4422736129f55b712f160532d8f2",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-1.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmaxminddb-1.5.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bb078ccf6e7372cf22e55901c005517daff0b8cffa14fa3dec5e9804b4f65897",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "13.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmnl-1.0.4-13.fc34.aarch64.rpm",
+        "checksum": "sha256:79864051052858a1c95538888ca61a43b509b6eae4ae269ae6ea7bf8b076a2b8",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.7",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libndp-1.7-7.fc34.aarch64.rpm",
+        "checksum": "sha256:11a0c09b716f8071f0484278bec326fb82e93d987376c8b38188d1febcd5381d",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnetfilter_conntrack-1.0.8-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ca8f4843c8b23ce16b957143550d8dc83ae630cd64587fa2dd127e4ecbe9bb23",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "19.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnfnetlink-1.0.1-19.fc34.aarch64.rpm",
+        "checksum": "sha256:c04a67670d45f576c5a8b23fe64d5ce31b04ddf4792cbf78448fd4c96899f9c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.43.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnghttp2-1.43.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnl3-3.5.0-6.fc34.aarch64.rpm",
+        "checksum": "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnsl2-1.3.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpath_utils-0.2.1-47.fc34.aarch64.rpm",
+        "checksum": "sha256:a1a996e8da4733b14c449b69e34484fe4f2b88c0f2963145bf0402cf04baf30e",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpipeline-1.5.3-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ee147f5a7017de1c77abfbb79dd32eb97c923fc7c1b74c32bda6020b9025938c",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpsl-0.21.1-3.fc34.aarch64.rpm",
+        "checksum": "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libref_array-0.1.5-47.fc34.aarch64.rpm",
+        "checksum": "sha256:686e015d81c1be2e6b88c7e8a50d45109d7273143a034caa9c935ecd014e1c62",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm",
+        "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsemanage-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsigsegv-2.13-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.17",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm",
+        "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtalloc-2.3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:56634e58fc7499d719a3f431dd188e8f2655ebfa402e94ce105794a47debf45b",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtasn1-4.16.0-4.fc34.aarch64.rpm",
+        "checksum": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.3",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtdb-1.4.3-6.fc34.aarch64.rpm",
+        "checksum": "sha256:2027da420b35a0b70ae5045d2fd79cdccb820f03e5ff4018a2205d3d413ff1af",
+        "check_gpg": true
+      },
+      {
+        "name": "libtextstyle",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtextstyle-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.aarch64.rpm",
+        "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
+        "check_gpg": true
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libutempter-1.2.1-4.fc34.aarch64.rpm",
+        "checksum": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libuuid-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-atm-libs",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "28.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/linux-atm-libs-2.5.1-28.fc34.aarch64.rpm",
+        "checksum": "sha256:a60e3e035883de829c5778417d316ffc47a0b4a304953e3fdc44def8f2f172ab",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lmdb-libs-0.9.29-1.fc34.aarch64.rpm",
+        "checksum": "sha256:7721bc647c521d96e07e665f7da306326d3bd1499d610c58552317815aaf3c45",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lz4-libs-1.9.3-2.fc34.aarch64.rpm",
+        "checksum": "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.9.3",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/man-db-2.9.3-3.fc34.aarch64.rpm",
+        "checksum": "sha256:61ba1ecff8f8578cbd3445df596d001067bb0281745191ac168fcc6079d8e1cf",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/memstrack-0.2.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.4.0",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/mokutil-0.4.0-4.fc34.aarch64.rpm",
+        "checksum": "sha256:f7c7dc1d8e5cf4776a1fde155871a2bb1fdd0676f897a43334cfbb60eb69e52a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-6.2-4.20200222.fc34.aarch64.rpm",
+        "checksum": "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm",
+        "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm",
+        "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
+        "check_gpg": true
+      },
+      {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.59.20160912git.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/net-tools-2.0-0.59.20160912git.fc34.aarch64.rpm",
+        "checksum": "sha256:96c7a26b707d4038a50b4ab0fd8d79ba3997466bed543f13c10d30e7ec256b5e",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm",
+        "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/openssl-pkcs11-0.4.11-2.fc34.aarch64.rpm",
+        "checksum": "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/os-prober-1.77-7.fc34.aarch64.rpm",
+        "checksum": "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-0.23.22-3.fc34.aarch64.rpm",
+        "checksum": "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-trust-0.23.22-3.fc34.aarch64.rpm",
+        "checksum": "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/parted-3.4-2.fc34.aarch64.rpm",
+        "checksum": "sha256:27920113489e3260e58d4a033d31401c6ae22ded72895c6b8c0e43ebf89a62df",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/passwd-0.80-10.fc34.aarch64.rpm",
+        "checksum": "sha256:6a864bec34b7d39de3e6ae1e39ec07fa3a2d21837a9a2d7151228d7f0ac38e73",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.44",
+        "release": "3.fc34.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre-8.44-3.fc34.1.aarch64.rpm",
+        "checksum": "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-10.36-4.fc34.aarch64.rpm",
+        "checksum": "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-syntax-10.36-4.fc34.noarch.rpm",
+        "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pigz-2.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/policycoreutils-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/popt-1.18-4.fc34.aarch64.rpm",
+        "checksum": "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm",
+        "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/psmisc-23.4-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d1c8a2302e64fc856aff6a05a78140986e89eddd8f110deb9ba78d44aebcd411",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20190417",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
+        "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-attrs",
+        "epoch": 0,
+        "version": "20.3.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-attrs-20.3.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:820fee96d610178c7c7b8ce2b115bd02063d2f6dfcae5da4bf5d411de0b575f7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cffi",
+        "epoch": 0,
+        "version": "1.14.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-cffi-1.14.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:7d00ccbb224617a00f58053afd88e7a49062446f1306ba39c72b78d20aeee1ef",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-chardet-4.0.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:9ce3f0c0904ac22ab5769babebf43e7dcdb488b0ef999b2e9e88a5b5eb424e51",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-configobj",
+        "epoch": 0,
+        "version": "5.0.6",
+        "release": "23.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-configobj-5.0.6-23.fc34.noarch.rpm",
+        "checksum": "sha256:f7f8832ccaedd7ddad064956309478b9bf366f0576517356ee68481e196236cf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cryptography",
+        "epoch": 0,
+        "version": "3.4.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-cryptography-3.4.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:ea8067f2310d30b31f7b1f13825b2a5a5e679c114fefd072267b6c369a365a63",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-dateutil-2.8.1-3.fc34.noarch.rpm",
+        "checksum": "sha256:5d2c28837f0573ae2647b8fbba85f7c502f9c3da0a3eab1c9ba121de4a1a6cee",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-distro-1.5.0-5.fc34.noarch.rpm",
+        "checksum": "sha256:e530795e5c9bc27de609fcbbacdc43c226026fee95e47a1f783f1c03ba5d48ae",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-idna-2.10-3.fc34.noarch.rpm",
+        "checksum": "sha256:f68c93c0461c149bb17282dededf421cbc1fbfa5ac133b59bd362526f59e0d57",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jinja2",
+        "epoch": 0,
+        "version": "2.11.3",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jinja2-2.11.3-1.fc34.noarch.rpm",
+        "checksum": "sha256:2414cb7345bc193f7ff7983c020c8b0e706aab013ee30af5d457d35c4de4a698",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpatch",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonpatch-1.21-14.fc34.noarch.rpm",
+        "checksum": "sha256:e0dffa204780c20c16357a51b992351aa1cf9f9cdda6182939ecd0cd7ab2c2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpointer",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonpointer-2.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:1b1af6b54050ec223c3289b107a9695a686c9d46d17a80ec9cd5d0201ec5d544",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonschema",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonschema-3.2.0-9.fc34.noarch.rpm",
+        "checksum": "sha256:d6810c97f24d93cd54a61bb288ada8591a94e4083b5165e0719915bceb637504",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt+crypto",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jwt+crypto-1.7.1-11.fc34.noarch.rpm",
+        "checksum": "sha256:9cc240ac305a862146e85d8dcc4ad981f5233a58b6901ecfac691d0b39966b49",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jwt-1.7.1-11.fc34.noarch.rpm",
+        "checksum": "sha256:131adc47f044c9f600f5295ded0f5431cda57fa7276100c3ec81c9d1ce3fa6f7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libselinux",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-libselinux-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:dbf3fb9e356236575a06e4fdcd532331f418236aa4ff4e024260c24be2b9a7cf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-libsemanage-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:87749765dbe5ce8f098279170c39bb8a89abbf3f8430c2a6dbfb973117e11dfa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-markupsafe-1.1.1-10.fc34.aarch64.rpm",
+        "checksum": "sha256:fbf45cda87a05418a72f4bf3877da5ebcabbe68d393bc5bec007a8b01ef6bafe",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib+signedtoken",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-oauthlib+signedtoken-3.0.2-9.fc34.noarch.rpm",
+        "checksum": "sha256:b30db4e3d9605e7263387ff91f91508667693d28e8b8835a2b7fcefd64f24388",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-oauthlib-3.0.2-9.fc34.noarch.rpm",
+        "checksum": "sha256:f9b2e7232d0b2d33bf52993c31b43b31520601f52f44fe792acd6dee4d84afc8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ply",
+        "epoch": 0,
+        "version": "3.11",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-ply-3.11-11.fc34.noarch.rpm",
+        "checksum": "sha256:23e3ed871799a9209915359f71660babf451b0b44902e3ed488b7b22aff37718",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-policycoreutils-3.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:e76f1401d9e119eae4cc461c8b68e9eae075d4b69f61870cb5c19ba7d69cf1a3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "25.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-prettytable-0.7.2-25.fc34.noarch.rpm",
+        "checksum": "sha256:cc4401d1e292b28d771a2038081b929b342ffa3b60358aed91697fdbc668546a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pycparser",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pycparser-2.20-3.fc34.noarch.rpm",
+        "checksum": "sha256:32220dc513a6ebcd4994e7140ecb5859108baf44d12fe6b1f0c0459dbefc54e7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyserial",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "10.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pyserial-3.4-10.fc34.noarch.rpm",
+        "checksum": "sha256:70a90c6c682016e91fb4745eedbd23f28e150a38b01d18f85ce4e50fb4e0ca6c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "8.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pysocks-1.7.1-8.fc34.noarch.rpm",
+        "checksum": "sha256:4a74ae08a713e9b4e74ff27bfaf57374312370402f90e2796e66c504557ae189",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pyyaml-5.4.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:92e42b63fcc56dd21984abb722e8fa7ebbb58f6d54c529ac11871b4bbc63b290",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-requests-2.25.1-1.fc34.noarch.rpm",
+        "checksum": "sha256:6297d7eee103c679a0f1ea411568d3940af3fe8f38e19388a1544df70bda8b3c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.4.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-setools-4.4.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:e1f1b9c4b78fe9d84a87d7de67fdd8559fe2bea9969ca1632d137de635d7e898",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-six-1.15.0-5.fc34.noarch.rpm",
+        "checksum": "sha256:b5d5e7255c85c3aa9d63598ef140de35843ab2485adf1cb9a9130be80aa0297f",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/readline-8.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "29.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rootfiles-8.1-29.fc34.noarch.rpm",
+        "checksum": "sha256:164e1c0e3e8c89aeda4f272b3158932649a69b16aea058105117a64d3cdef517",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
+        "check_gpg": true
+      },
+      {
+        "name": "rsync",
+        "epoch": 0,
+        "version": "3.2.3",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rsync-3.2.3-5.fc34.aarch64.rpm",
+        "checksum": "sha256:a9828dc2c4215e6bcb9aa14370d854f24637b0510e4b1a63709135049314e2b3",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sed-4.8-7.fc34.aarch64.rpm",
+        "checksum": "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.7",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/setup-2.13.7-3.fc34.noarch.rpm",
+        "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.4",
+        "release": "4",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shim-aa64-15.4-4.aarch64.rpm",
+        "checksum": "sha256:23a539a271c92906ac0a12c7d877c7f4d0ad8e6b9bbd8642b5232f861b79ed22",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.34.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.5p2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-1.9.5p2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:40e231991444a589b17e0b5b338be8874d071e3d17e210aba6f6639620775f79",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.5p2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-python-plugin-1.9.5p2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:a86ec8f7284ee01574bb06bba726d8609e464f41d003215097e626c583f73ed0",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm",
+        "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-0.3.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-lib-0.3.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/u/util-linux-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.10.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xfsprogs-5.10.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3228a36807658c7e4d881013aa26f877353388bf3bac6c948984f751c264a359",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-5.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-libs-5.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "26.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/z/zlib-1.2.11-26.fc34.aarch64.rpm",
+        "checksum": "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.30.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.30.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4baf8ba6a5ed4609695f79a8bbc8324d7efa322a3573c8c5fa3942361eac0f1c",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.30.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.30.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f695ed244a1d9f3eb814947fb1da343d7d6fb3aaa2bf72965235e4b45a58a784",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-3.0.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:148aea26e381b33badde0ac2ae716a78f7b565f54f0b6970189a89713f335eaf",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-libs-3.0.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/c-ares-1.17.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:7c24e53e12891046bb6721e624cf9effd1946c0d076464427c2a86b29671318e",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm",
+        "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+        "check_gpg": true
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/chrony-4.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:61a9dbd9020e29012947978acf33a0c1150e6c3e078de372f1e38fb9c4ef529a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-8.32-30.fc34.aarch64.rpm",
+        "checksum": "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-common-8.32-30.fc34.aarch64.rpm",
+        "checksum": "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-2.9.6-27.fc34.aarch64.rpm",
+        "checksum": "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-dicts-2.9.6-27.fc34.aarch64.rpm",
+        "checksum": "sha256:2968703dd232a37620a0ae12146c9d1ec5220f62c40bfb0ecfc60b621d8e1eac",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.3.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/curl-7.76.1-12.fc34.aarch64.rpm",
+        "checksum": "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "11.b1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dhcp-client-4.4.2-11.b1.fc34.aarch64.rpm",
+        "checksum": "sha256:0ac62147585be2dae960ed37a3a0c3eb2f8a95d0fd0993991c8bf7238b1d5e27",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "11.b1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dhcp-common-4.4.2-11.b1.fc34.noarch.rpm",
+        "checksum": "sha256:11cd6fae157eb9e4800163633b57bcce21d59a1df4b86a99ba03707b6cee0cfc",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc34.noarch.rpm",
+        "checksum": "sha256:1feb6a045cb3e95e3c8e0112ecb4b8ffeb9986a503b52c5497fefce217846b90",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc34.aarch64.rpm",
+        "checksum": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc34.aarch64.rpm",
+        "checksum": "sha256:9aee2549d3ff9e5652dffaaa9b91ab7a243687cc2a85b8e45f4290d53d44702d",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/efi-filesystem-5-4.fc34.noarch.rpm",
+        "checksum": "sha256:8fbfbaf3b107b540428634c19c4cb05e7c46f9672cfbf14d1f44306ed3413a46",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc34.noarch.rpm",
+        "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-gpg-keys-34-2.noarch.rpm",
+        "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-cloud",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-cloud-34-39.noarch.rpm",
+        "checksum": "sha256:d54b628e6d0b7813ec0b4cc0beb1b8f3f8510ffbaff8ae1d9c4b9993095e4edf",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-common-34-39.noarch.rpm",
+        "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-cloud",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-cloud-34-39.noarch.rpm",
+        "checksum": "sha256:e035a5041c721ea40e47cbbc19eb1b91c520183f85137ee1dd3ed3b42a47c180",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-34-2.noarch.rpm",
+        "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-modular-34-2.noarch.rpm",
+        "checksum": "sha256:eb88e660b9fd02e695a90c0266831b79e513c2f65ba5d6353e82726af96e9752",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-5.39-7.fc34.aarch64.rpm",
+        "checksum": "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.aarch64.rpm",
+        "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.68.4",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.aarch64.rpm",
+        "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-common-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-doc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-doc-2.33-20.fc34.noarch.rpm",
+        "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-langpack-en",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:059f825547fe257247656c29049ebc7bfa1d54a17479f3dcfeff37fbab7084bd",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/gnutls-3.7.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm",
+        "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:71427f6f8f3f6370dccde81a76d566ff17144e7e375381ef13e04a661e63cba1",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/ipcalc-1.0.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:69de3dd68dc2b76e2a85c710a51e9c8acefe595d6ac5d9f19113c4062a5f0d92",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-legacy-libs-1.8.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-libs-1.8.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:ebd4a9473543a5ca50ec5f9de069fc0c240527516ae262cf3e28a5d914b99cb1",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "100.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-100.fc34.aarch64.rpm",
+        "checksum": "sha256:55833f669ed1dbd32e79f494824c309b71bc373d2bf28eb5cdb663459dc6f7cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "100.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-100.fc34.aarch64.rpm",
+        "checksum": "sha256:0176b42c6b51fb3c829f168571527a3559b6a9c8cc5f847b70e3c40fb69f89e4",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "100.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-100.fc34.aarch64.rpm",
+        "checksum": "sha256:f3c940f33c6c8edb73b98527e0fff17aa211e823f06e3f732762d0c86cc0268c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-libs-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/krb5-libs-1.19.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/less-590-2.fc34.aarch64.rpm",
+        "checksum": "sha256:7cc0891a9e7c19757c03cba6c8155738d9db9f5774380c412106adf0eca44077",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.aarch64.rpm",
+        "checksum": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "49.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm",
+        "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "38.20210714cvs.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libedit-3.1-38.20210714cvs.fc34.aarch64.rpm",
+        "checksum": "sha256:b6687e9977e337e5d029de0d42cb79d57bd44f2f642450440756ba1a0494a113",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcrypt-1.9.3-3.fc34.aarch64.rpm",
+        "checksum": "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "37.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libibverbs-37.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libidn2-2.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libldb-2.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:86cb1e5e80642b1575df57287c9549749603bf94b1ba652995b59ea45ac4272b",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.5.4",
+        "release": "2.rc3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libnfsidmap-2.5.4-2.rc3.fc34.aarch64.rpm",
+        "checksum": "sha256:330a36b1dabaf76daafeff3f7fd7a276880bf65d790ee84cb823a1958a4d99d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpcap-1.10.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm",
+        "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
+        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsepol-3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-0.9.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-config-0.9.6-1.fc34.noarch.rpm",
+        "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3b3bba1d61529a1dde47f234f34d0fdee07a38aa5958d87e30357ea04bbff142",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ac901ae730144d1e75b86d9991c1c6a9d6d0a44ce6e52b4d330df3a26d09e1ff",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3fdab509a59e0a765364d6f119c38c796a4420cc49b46595a37d98eb649d6c80",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:60ddc7b15e9742ff9995d1b336489b92721e21a45034d20f20d2fc800e419d1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:4123331b5d06f91ff31d147e4769806052f59b620e7677f69b0073eaf7beccb6",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "0.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtevent-0.11.0-0.fc34.aarch64.rpm",
+        "checksum": "sha256:a72bb74400b447af71600da141aebdc46da7776ef875abfdd635881f939891d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "0.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtirpc-1.3.2-0.fc34.aarch64.rpm",
+        "checksum": "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libuser-0.63-4.fc34.aarch64.rpm",
+        "checksum": "sha256:fd7dc918a1e3ad0114ecaa41d78c6652cc559271ad6653e5bba0bc780af35faa",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc34.aarch64.rpm",
+        "checksum": "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxkbcommon-1.3.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxml2-2.9.12-4.fc34.aarch64.rpm",
+        "checksum": "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc34.noarch.rpm",
+        "checksum": "sha256:8ab032e2a86f300d978e521ab030db1e7bb7eeccca205a5d2a4d68b51566f43f",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc34.noarch.rpm",
+        "checksum": "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mkpasswd-5.5.10-1.fc34.aarch64.rpm",
+        "checksum": "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mpfr-4.1.0-7.fc34.aarch64.rpm",
+        "checksum": "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/nettle-3.7.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.57",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openldap-2.4.57-6.fc34.aarch64.rpm",
+        "checksum": "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.6p1",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-8.6p1-5.fc34.aarch64.rpm",
+        "checksum": "sha256:5dcac7772d73ad1523f87cbeb1dc76dd62af4d2bb73dd06896a47d2bcf503e5e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.6p1",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.6p1-5.fc34.aarch64.rpm",
+        "checksum": "sha256:d5d622f60e97d43b095a98f2bb46982d91451e4e6018492da20944b294480af3",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.6p1",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-server-8.6p1-5.fc34.aarch64.rpm",
+        "checksum": "sha256:39160ef65b3519a70f14f992edc5967380ef86a6940896751db681781961903d",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssl-libs-1.1.1l-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pam-1.5.1-7.fc34.aarch64.rpm",
+        "checksum": "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "1.fc34.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/procps-ng-3.3.17-1.fc34.1.aarch64.rpm",
+        "checksum": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-setuptools-wheel-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.9.9-2.fc34.noarch.rpm",
+        "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-3.9.9-2.fc34.aarch64.rpm",
+        "checksum": "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-audit-3.0.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:139b9453b2038e52767d0102def782d58d558ca0603757eb0c97ddda28af1466",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-babel",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-babel-2.9.1-1.fc34.noarch.rpm",
+        "checksum": "sha256:59cc4d563ecb4c8b517f5dd7505f1cda297f950f32fc700344aa7789b69ca99c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dbus-1.2.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:00c29524aad123ec44056e60b9625e75ac428a6c751878a05fadbca7e956c249",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc34.noarch.rpm",
+        "checksum": "sha256:bab19da8b6f553325decae00748f88fc0924b918136f065ab8995e1ebf5bde5b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libs-3.9.9-2.fc34.aarch64.rpm",
+        "checksum": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pip-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyrsistent",
+        "epoch": 0,
+        "version": "0.17.3",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.17.3-6.fc34.aarch64.rpm",
+        "checksum": "sha256:fc4104e014beee44b5003e72a32e45e689936a4ffdcf07e119b02be3ed4ab8d9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pytz",
+        "epoch": 0,
+        "version": "2021.3",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc34.noarch.rpm",
+        "checksum": "sha256:eecc86b828ad436a9f397d2f7acdf5705bfd36bcad3edd2da73f3acc94363411",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.25.10",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.25.10-5.fc34.noarch.rpm",
+        "checksum": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.8.1",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.8.1-10.fc34.aarch64.rpm",
+        "checksum": "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-client-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:c814f83bcf3cfc590d84897c810a087354cfb0c961dd232af5031cfe8bd63a37",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-common-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:668a30c6f526e51705af9cb9d98fd11f279f5e86f7d905876ae9a86f486a8c36",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:7285fcc290a8af2cf845beb845e661cd4c06c2275417b15eb507824dedec7c69",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:0db1be9a78e5f329a519066a7b37379f6c73fe579154e0a6a26b2dcb4154ccd6",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-networkd-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:43b0b5d425a2041daeb6b41db2858abda1f92ecc38c6125f7de3b7502580a9f7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-pam-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-rpm-macros",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-rpm-macros-248.9-1.fc34.noarch.rpm",
+        "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
+        "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.3755",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.3755-1.fc34.noarch.rpm",
+        "checksum": "sha256:adcd36cb0e582f5fb2d0465cf88bb813ffac17d25d6ec8aa608b647d008bebc3",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.3755",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.3755-1.fc34.aarch64.rpm",
+        "checksum": "sha256:1af86c0a8c11e44958b022bf7dad5f48ad974fa8537cf41a12d5b0643444b1dc",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "26.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/which-2.21-26.fc34.aarch64.rpm",
+        "checksum": "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/whois-nls-5.5.10-1.fc34.noarch.rpm",
+        "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
+        "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/y/yum-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:30bc3583e503e0f459e323b27551f7b9a8ab784de15437b5b29f447b31f8d9cd",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm",
+        "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
+        "check_gpg": true
+      }
+    ]
+  },
+  "image-info": {
+    "/etc/resolv.conf": [],
+    "boot-environment": {
+      "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+    },
+    "bootloader": "unknown",
+    "bootmenu": [
+      {
+        "grub_arg": "--unrestricted",
+        "grub_class": "fedora",
+        "grub_users": "$grub_users",
+        "initrd": "/boot/initramfs-5.15.13-100.fc34.aarch64.img",
+        "linux": "/boot/vmlinuz-5.15.13-100.fc34.aarch64",
+        "options": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8",
+        "title": "Fedora (5.15.13-100.fc34.aarch64) 34 (Cloud Edition)",
+        "version": "5.15.13-100.fc34.aarch64"
+      }
+    ],
+    "chrony": {
+      "leapsectz": [
+        "right/UTC"
+      ],
+      "pool": [
+        "2.fedora.pool.ntp.org iburst"
+      ]
+    },
+    "cloud-init": {
+      "/etc/cloud": {
+        "cloud.cfg": {
+          "cloud_config_modules": [
+            "ssh-import-id",
+            "locale",
+            "set-passwords",
+            "spacewalk",
+            "yum-add-repo",
+            "ntp",
+            "timezone",
+            "disable-ec2-metadata",
+            "runcmd"
+          ],
+          "cloud_final_modules": [
+            "package-update-upgrade-install",
+            "puppet",
+            "chef",
+            "mcollective",
+            "salt-minion",
+            "reset_rmc",
+            "refresh_rmc_and_interface",
+            "rightscale_userdata",
+            "scripts-vendor",
+            "scripts-per-once",
+            "scripts-per-boot",
+            "scripts-per-instance",
+            "scripts-user",
+            "ssh-authkey-fingerprints",
+            "keys-to-console",
+            "phone-home",
+            "final-message",
+            "power-state-change"
+          ],
+          "cloud_init_modules": [
+            "migrator",
+            "seed_random",
+            "bootcmd",
+            "write-files",
+            "growpart",
+            "resizefs",
+            "disk_setup",
+            "mounts",
+            "set_hostname",
+            "update_hostname",
+            "update_etc_hosts",
+            "ca-certs",
+            "rsyslog",
+            "users-groups",
+            "ssh"
+          ],
+          "disable_root": true,
+          "mount_default_fields": [
+            null,
+            null,
+            "auto",
+            "defaults,nofail",
+            "0",
+            "2"
+          ],
+          "preserve_hostname": false,
+          "resize_rootfs_tmp": "/dev",
+          "ssh_pwauth": 0,
+          "system_info": {
+            "default_user": {
+              "gecos": "fedora Cloud User",
+              "groups": [
+                "wheel",
+                "adm",
+                "systemd-journal"
+              ],
+              "lock_passwd": true,
+              "name": "fedora",
+              "shell": "/bin/bash",
+              "sudo": [
+                "ALL=(ALL) NOPASSWD:ALL"
+              ]
+            },
+            "distro": "fedora",
+            "paths": {
+              "cloud_dir": "/var/lib/cloud/",
+              "templates_dir": "/etc/cloud/templates/"
+            },
+            "ssh_svcname": "sshd"
+          },
+          "users": [
+            "default"
+          ]
+        }
+      },
+      "/etc/cloud/cloud.cfg.d": {
+        "05_logging.cfg": {
+          "_log": [
+            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
+            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
+          ],
+          "log_cfgs": [
+            [
+              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
+            ]
+          ],
+          "output": {
+            "all": "| tee -a /var/log/cloud-init-output.log"
+          }
+        }
+      }
+    },
+    "default-target": "graphical.target",
+    "dracut": {
+      "/usr/lib/dracut/dracut.conf.d": {
+        "01-dist.conf": {
+          "dbus": "/usr/share/dbus-1",
+          "dbusconfdir": "/etc/dbus-1",
+          "dbusinterfaces": "/usr/share/dbus-1/interfaces",
+          "dbusinterfacesconfdir": "/etc/dbus-1/interfaces",
+          "dbusservices": "/usr/share/dbus-1/services",
+          "dbusservicesconfdir": "/etc/dbus-1/services",
+          "dbussession": "/usr/share/dbus-1/session.d",
+          "dbussessionconfdir": "/etc/dbus-1/session.d",
+          "dbussystem": "confdir/etc/dbus-1/system.d",
+          "dbussystemservices": "/usr/share/dbus-1/system-services",
+          "dbussystemservicesconfdir": "/etc/dbus-1/system-services",
+          "early_microcode": "yes",
+          "environment": "/usr/lib/environment.d",
+          "environmentconfdir": "/etc/environment.d",
+          "hostonly": "yes",
+          "hostonly_cmdline": "no",
+          "i18n_default_font": "eurlatgr",
+          "i18n_install_all": "yes",
+          "i18n_vars": "/etc/sysconfig/keyboard:KEYTABLE-KEYMAP /etc/sysconfig/i18n:SYSFONT-FONT,FONTACM-FONT_MAP,FONT_UNIMAP",
+          "install_optional_items": " vi /etc/virc ps grep cat rm ",
+          "prefix": "/",
+          "reproducible": "yes",
+          "stdloglvl": "3",
+          "sysctlconfdir": "/etc/sysctl.d",
+          "sysctld": "/usr/lib/sysctl.d",
+          "sysloglvl": "5",
+          "systemdcatalog": "/usr/lib/systemd/catalog",
+          "systemdntpunits": "/usr/lib/systemd/ntp-units.d",
+          "systemdntpunitsconfdir": "/etc/systemd/ntp-units.d",
+          "systemdportable": "/usr/lib/systemd/portable",
+          "systemdportableconfdir": "/etc/systemd/portable",
+          "systemdsystemconfdir": "/etc/systemd/system",
+          "systemdsystemunitdir": "/usr/lib/systemd/system",
+          "systemduser": "/usr/lib/systemd/user",
+          "systemduserconfdir": "/etc/systemd/user",
+          "systemdutilconfdir": "/etc/systemd",
+          "systemdutildir": "/usr/lib/systemd",
+          "sysusers": "/usr/lib/sysusers.d",
+          "sysusersconfdir": "/etc/sysusers.d",
+          "udevdir": "/usr/lib/udev"
+        },
+        "02-generic-image.conf": {
+          "hostonly": "no"
+        }
+      }
+    },
+    "fstab": [
+      [
+        "UUID=46BB-8120",
+        "/boot/efi",
+        "vfat",
+        "umask=0077,shortname=winnt",
+        "0",
+        "2"
+      ],
+      [
+        "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+        "/",
+        "ext4",
+        "defaults",
+        "1",
+        "1"
+      ]
+    ],
+    "groups": [
+      "adm:x:4:",
+      "audio:x:63:",
+      "bin:x:1:",
+      "cdrom:x:11:",
+      "chrony:x:994:",
+      "daemon:x:2:",
+      "dbus:x:81:",
+      "dialout:x:18:",
+      "disk:x:6:",
+      "floppy:x:19:",
+      "ftp:x:50:",
+      "games:x:20:",
+      "input:x:104:",
+      "kmem:x:9:",
+      "kvm:x:36:",
+      "lock:x:54:",
+      "lp:x:7:",
+      "mail:x:12:",
+      "man:x:15:",
+      "mem:x:8:",
+      "nobody:x:65534:",
+      "render:x:105:",
+      "root:x:0:",
+      "sgx:x:106:",
+      "ssh_keys:x:996:",
+      "sshd:x:74:",
+      "sys:x:3:",
+      "systemd-coredump:x:999:",
+      "systemd-journal:x:190:",
+      "systemd-network:x:192:",
+      "systemd-oom:x:998:",
+      "systemd-resolve:x:193:",
+      "systemd-timesync:x:997:",
+      "tape:x:33:",
+      "tss:x:59:",
+      "tty:x:5:",
+      "unbound:x:995:",
+      "users:x:100:",
+      "utempter:x:35:",
+      "utmp:x:22:",
+      "video:x:39:",
+      "wheel:x:10:"
+    ],
+    "hostname": "localhost.localdomain",
+    "hosts": [
+      "127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4",
+      "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
+    ],
+    "image-format": {
+      "compat": "1.1",
+      "type": "qcow2"
+    },
+    "locale": {
+      "LANG": "en_US"
+    },
+    "machine-id": "",
+    "os-release": {
+      "ANSI_COLOR": "0;38;2;60;110;180",
+      "BUG_REPORT_URL": "https://bugzilla.redhat.com/",
+      "CPE_NAME": "cpe:/o:fedoraproject:fedora:34",
+      "DOCUMENTATION_URL": "https://docs.fedoraproject.org/en-US/fedora/f34/system-administrators-guide/",
+      "HOME_URL": "https://fedoraproject.org/",
+      "ID": "fedora",
+      "LOGO": "fedora-logo-icon",
+      "NAME": "Fedora",
+      "PLATFORM_ID": "platform:f34",
+      "PRETTY_NAME": "Fedora 34 (Cloud Edition)",
+      "PRIVACY_POLICY_URL": "https://fedoraproject.org/wiki/Legal:PrivacyPolicy",
+      "REDHAT_BUGZILLA_PRODUCT": "Fedora",
+      "REDHAT_BUGZILLA_PRODUCT_VERSION": "34",
+      "REDHAT_SUPPORT_PRODUCT": "Fedora",
+      "REDHAT_SUPPORT_PRODUCT_VERSION": "34",
+      "SUPPORT_URL": "https://fedoraproject.org/wiki/Communicating_and_getting_help",
+      "VARIANT": "Cloud Edition",
+      "VARIANT_ID": "cloud",
+      "VERSION": "34 (Cloud Edition)",
+      "VERSION_CODENAME": "",
+      "VERSION_ID": "34"
+    },
+    "packages": [
+      "NetworkManager-1.30.6-1.fc34.aarch64",
+      "NetworkManager-libnm-1.30.6-1.fc34.aarch64",
+      "acl-2.3.1-1.fc34.aarch64",
+      "alternatives-1.15-2.fc34.aarch64",
+      "audit-3.0.6-1.fc34.aarch64",
+      "audit-libs-3.0.6-1.fc34.aarch64",
+      "basesystem-11-11.fc34.noarch",
+      "bash-5.1.0-2.fc34.aarch64",
+      "bzip2-libs-1.0.8-6.fc34.aarch64",
+      "c-ares-1.17.2-1.fc34.aarch64",
+      "ca-certificates-2021.2.52-1.0.fc34.noarch",
+      "checkpolicy-3.2-1.fc34.aarch64",
+      "chrony-4.1-1.fc34.aarch64",
+      "cloud-init-20.4-2.fc34.noarch",
+      "cloud-utils-growpart-0.31-8.fc34.noarch",
+      "console-login-helper-messages-0.21.2-1.fc34.noarch",
+      "console-login-helper-messages-issuegen-0.21.2-1.fc34.noarch",
+      "console-login-helper-messages-motdgen-0.21.2-1.fc34.noarch",
+      "console-login-helper-messages-profile-0.21.2-1.fc34.noarch",
+      "coreutils-8.32-30.fc34.aarch64",
+      "coreutils-common-8.32-30.fc34.aarch64",
+      "cpio-2.13-10.fc34.aarch64",
+      "cracklib-2.9.6-27.fc34.aarch64",
+      "cracklib-dicts-2.9.6-27.fc34.aarch64",
+      "crypto-policies-20210213-1.git5c710c0.fc34.noarch",
+      "crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch",
+      "cryptsetup-libs-2.3.6-1.fc34.aarch64",
+      "curl-7.76.1-12.fc34.aarch64",
+      "cyrus-sasl-lib-2.1.27-8.fc34.aarch64",
+      "dbus-1.12.20-3.fc34.aarch64",
+      "dbus-broker-29-2.fc34.aarch64",
+      "dbus-common-1.12.20-3.fc34.noarch",
+      "dbus-libs-1.12.20-3.fc34.aarch64",
+      "dejavu-sans-fonts-2.37-16.fc34.noarch",
+      "deltarpm-3.6.2-8.fc34.aarch64",
+      "device-mapper-1.02.175-1.fc34.aarch64",
+      "device-mapper-libs-1.02.175-1.fc34.aarch64",
+      "dhcp-client-4.4.2-11.b1.fc34.aarch64",
+      "dhcp-common-4.4.2-11.b1.fc34.noarch",
+      "diffutils-3.7-8.fc34.aarch64",
+      "dnf-4.9.0-1.fc34.noarch",
+      "dnf-data-4.9.0-1.fc34.noarch",
+      "dnf-plugins-core-4.0.24-1.fc34.noarch",
+      "dracut-055-6.fc34.aarch64",
+      "dracut-config-generic-055-6.fc34.aarch64",
+      "e2fsprogs-1.45.6-5.fc34.aarch64",
+      "e2fsprogs-libs-1.45.6-5.fc34.aarch64",
+      "efi-filesystem-5-4.fc34.noarch",
+      "efibootmgr-16-10.fc34.aarch64",
+      "efivar-libs-37-15.fc34.aarch64",
+      "elfutils-debuginfod-client-0.186-1.fc34.aarch64",
+      "elfutils-default-yama-scope-0.186-1.fc34.noarch",
+      "elfutils-libelf-0.186-1.fc34.aarch64",
+      "elfutils-libs-0.186-1.fc34.aarch64",
+      "expat-2.4.1-1.fc34.aarch64",
+      "fedora-gpg-keys-34-2.noarch",
+      "fedora-release-cloud-34-39.noarch",
+      "fedora-release-common-34-39.noarch",
+      "fedora-release-identity-cloud-34-39.noarch",
+      "fedora-repos-34-2.noarch",
+      "fedora-repos-modular-34-2.noarch",
+      "file-5.39-7.fc34.aarch64",
+      "file-libs-5.39-7.fc34.aarch64",
+      "filesystem-3.14-5.fc34.aarch64",
+      "findutils-4.8.0-2.fc34.aarch64",
+      "fonts-filesystem-2.0.5-5.fc34.noarch",
+      "fuse-libs-2.9.9-11.fc34.aarch64",
+      "gawk-5.1.0-3.fc34.aarch64",
+      "gawk-all-langpacks-5.1.0-3.fc34.aarch64",
+      "gdbm-libs-1.19-2.fc34.aarch64",
+      "gettext-0.21-4.fc34.aarch64",
+      "gettext-libs-0.21-4.fc34.aarch64",
+      "glib2-2.68.4-1.fc34.aarch64",
+      "glibc-2.33-20.fc34.aarch64",
+      "glibc-common-2.33-20.fc34.aarch64",
+      "glibc-doc-2.33-20.fc34.noarch",
+      "glibc-langpack-en-2.33-20.fc34.aarch64",
+      "gmp-6.2.0-6.fc34.aarch64",
+      "gnupg2-2.2.27-4.fc34.aarch64",
+      "gnupg2-smime-2.2.27-4.fc34.aarch64",
+      "gnutls-3.7.2-1.fc34.aarch64",
+      "gpg-pubkey-45719a39-5f2c0192",
+      "gpgme-1.15.1-2.fc34.aarch64",
+      "grep-3.6-2.fc34.aarch64",
+      "groff-base-1.22.4-7.fc34.aarch64",
+      "grub2-common-2.06-9.fc34.noarch",
+      "grub2-efi-aa64-2.06-9.fc34.aarch64",
+      "grub2-tools-2.06-9.fc34.aarch64",
+      "grub2-tools-minimal-2.06-9.fc34.aarch64",
+      "grubby-8.40-51.fc34.aarch64",
+      "gzip-1.10-4.fc34.aarch64",
+      "hostname-3.23-4.fc34.aarch64",
+      "ima-evm-utils-1.3.2-2.fc34.aarch64",
+      "inih-49-3.fc34.aarch64",
+      "initscripts-10.09-1.fc34.aarch64",
+      "ipcalc-1.0.1-1.fc34.aarch64",
+      "iproute-5.10.0-2.fc34.aarch64",
+      "iproute-tc-5.10.0-2.fc34.aarch64",
+      "iptables-legacy-libs-1.8.7-8.fc34.aarch64",
+      "iptables-libs-1.8.7-8.fc34.aarch64",
+      "iputils-20210202-2.fc34.aarch64",
+      "jansson-2.13.1-2.fc34.aarch64",
+      "json-c-0.14-8.fc34.aarch64",
+      "kbd-2.4.0-2.fc34.aarch64",
+      "kbd-misc-2.4.0-2.fc34.noarch",
+      "kernel-5.15.13-100.fc34.aarch64",
+      "kernel-core-5.15.13-100.fc34.aarch64",
+      "kernel-modules-5.15.13-100.fc34.aarch64",
+      "keyutils-libs-1.6.1-2.fc34.aarch64",
+      "kmod-29-2.fc34.aarch64",
+      "kmod-libs-29-2.fc34.aarch64",
+      "kpartx-0.8.5-4.fc34.aarch64",
+      "krb5-libs-1.19.2-2.fc34.aarch64",
+      "langpacks-core-en-3.0-14.fc34.noarch",
+      "langpacks-core-font-en-3.0-14.fc34.noarch",
+      "langpacks-en-3.0-14.fc34.noarch",
+      "less-590-2.fc34.aarch64",
+      "libacl-2.3.1-1.fc34.aarch64",
+      "libarchive-3.5.2-2.fc34.aarch64",
+      "libargon2-20171227-6.fc34.aarch64",
+      "libassuan-2.5.5-1.fc34.aarch64",
+      "libattr-2.5.1-1.fc34.aarch64",
+      "libbasicobjects-0.1.1-47.fc34.aarch64",
+      "libblkid-2.36.2-1.fc34.aarch64",
+      "libbrotli-1.0.9-4.fc34.aarch64",
+      "libcap-2.48-2.fc34.aarch64",
+      "libcap-ng-0.8.2-4.fc34.aarch64",
+      "libcbor-0.7.0-3.fc34.aarch64",
+      "libcollection-0.7.0-47.fc34.aarch64",
+      "libcom_err-1.45.6-5.fc34.aarch64",
+      "libcomps-0.1.18-1.fc34.aarch64",
+      "libcurl-7.76.1-12.fc34.aarch64",
+      "libdb-5.3.28-49.fc34.aarch64",
+      "libdhash-0.5.0-47.fc34.aarch64",
+      "libdnf-0.64.0-1.fc34.aarch64",
+      "libeconf-0.4.0-1.fc34.aarch64",
+      "libedit-3.1-38.20210714cvs.fc34.aarch64",
+      "libevent-2.1.12-3.fc34.aarch64",
+      "libfdisk-2.36.2-1.fc34.aarch64",
+      "libffi-3.1-28.fc34.aarch64",
+      "libfido2-1.6.0-2.fc34.aarch64",
+      "libgcc-11.2.1-1.fc34.aarch64",
+      "libgcrypt-1.9.3-3.fc34.aarch64",
+      "libgomp-11.2.1-1.fc34.aarch64",
+      "libgpg-error-1.42-1.fc34.aarch64",
+      "libibverbs-37.0-1.fc34.aarch64",
+      "libidn2-2.3.2-1.fc34.aarch64",
+      "libini_config-1.3.1-47.fc34.aarch64",
+      "libkcapi-1.2.1-1.fc34.aarch64",
+      "libkcapi-hmaccalc-1.2.1-1.fc34.aarch64",
+      "libksba-1.5.0-2.fc34.aarch64",
+      "libldb-2.3.2-1.fc34.aarch64",
+      "libmaxminddb-1.5.2-1.fc34.aarch64",
+      "libmnl-1.0.4-13.fc34.aarch64",
+      "libmodulemd-2.13.0-2.fc34.aarch64",
+      "libmount-2.36.2-1.fc34.aarch64",
+      "libndp-1.7-7.fc34.aarch64",
+      "libnetfilter_conntrack-1.0.8-2.fc34.aarch64",
+      "libnfnetlink-1.0.1-19.fc34.aarch64",
+      "libnfsidmap-2.5.4-2.rc3.fc34.aarch64",
+      "libnghttp2-1.43.0-2.fc34.aarch64",
+      "libnl3-3.5.0-6.fc34.aarch64",
+      "libnsl2-1.3.0-2.fc34.aarch64",
+      "libpath_utils-0.2.1-47.fc34.aarch64",
+      "libpcap-1.10.1-1.fc34.aarch64",
+      "libpipeline-1.5.3-2.fc34.aarch64",
+      "libpsl-0.21.1-3.fc34.aarch64",
+      "libpwquality-1.4.4-6.fc34.aarch64",
+      "libref_array-0.1.5-47.fc34.aarch64",
+      "librepo-1.14.2-1.fc34.aarch64",
+      "libreport-filesystem-2.15.2-2.fc34.noarch",
+      "libseccomp-2.5.3-1.fc34.aarch64",
+      "libsecret-0.20.4-2.fc34.aarch64",
+      "libselinux-3.2-1.fc34.aarch64",
+      "libselinux-utils-3.2-1.fc34.aarch64",
+      "libsemanage-3.2-1.fc34.aarch64",
+      "libsepol-3.2-2.fc34.aarch64",
+      "libsigsegv-2.13-2.fc34.aarch64",
+      "libsmartcols-2.36.2-1.fc34.aarch64",
+      "libsolv-0.7.17-3.fc34.aarch64",
+      "libss-1.45.6-5.fc34.aarch64",
+      "libssh-0.9.6-1.fc34.aarch64",
+      "libssh-config-0.9.6-1.fc34.noarch",
+      "libsss_autofs-2.5.2-2.fc34.aarch64",
+      "libsss_certmap-2.5.2-2.fc34.aarch64",
+      "libsss_idmap-2.5.2-2.fc34.aarch64",
+      "libsss_nss_idmap-2.5.2-2.fc34.aarch64",
+      "libsss_sudo-2.5.2-2.fc34.aarch64",
+      "libstdc++-11.2.1-1.fc34.aarch64",
+      "libtalloc-2.3.2-2.fc34.aarch64",
+      "libtasn1-4.16.0-4.fc34.aarch64",
+      "libtdb-1.4.3-6.fc34.aarch64",
+      "libtevent-0.11.0-0.fc34.aarch64",
+      "libtextstyle-0.21-4.fc34.aarch64",
+      "libtirpc-1.3.2-0.fc34.aarch64",
+      "libunistring-0.9.10-10.fc34.aarch64",
+      "libusbx-1.0.24-2.fc34.aarch64",
+      "libuser-0.63-4.fc34.aarch64",
+      "libutempter-1.2.1-4.fc34.aarch64",
+      "libuuid-2.36.2-1.fc34.aarch64",
+      "libverto-0.3.2-1.fc34.aarch64",
+      "libxcrypt-4.4.27-1.fc34.aarch64",
+      "libxkbcommon-1.3.0-1.fc34.aarch64",
+      "libxml2-2.9.12-4.fc34.aarch64",
+      "libyaml-0.2.5-5.fc34.aarch64",
+      "libzstd-1.5.0-1.fc34.aarch64",
+      "linux-atm-libs-2.5.1-28.fc34.aarch64",
+      "linux-firmware-20211216-127.fc34.noarch",
+      "linux-firmware-whence-20211216-127.fc34.noarch",
+      "lmdb-libs-0.9.29-1.fc34.aarch64",
+      "lua-libs-5.4.3-1.fc34.aarch64",
+      "lz4-libs-1.9.3-2.fc34.aarch64",
+      "man-db-2.9.3-3.fc34.aarch64",
+      "memstrack-0.2.2-1.fc34.aarch64",
+      "mkpasswd-5.5.10-1.fc34.aarch64",
+      "mokutil-0.4.0-4.fc34.aarch64",
+      "mpfr-4.1.0-7.fc34.aarch64",
+      "ncurses-6.2-4.20200222.fc34.aarch64",
+      "ncurses-base-6.2-4.20200222.fc34.noarch",
+      "ncurses-libs-6.2-4.20200222.fc34.aarch64",
+      "net-tools-2.0-0.59.20160912git.fc34.aarch64",
+      "nettle-3.7.3-1.fc34.aarch64",
+      "npth-1.6-6.fc34.aarch64",
+      "openldap-2.4.57-6.fc34.aarch64",
+      "openssh-8.6p1-5.fc34.aarch64",
+      "openssh-clients-8.6p1-5.fc34.aarch64",
+      "openssh-server-8.6p1-5.fc34.aarch64",
+      "openssl-libs-1.1.1l-2.fc34.aarch64",
+      "openssl-pkcs11-0.4.11-2.fc34.aarch64",
+      "os-prober-1.77-7.fc34.aarch64",
+      "p11-kit-0.23.22-3.fc34.aarch64",
+      "p11-kit-trust-0.23.22-3.fc34.aarch64",
+      "pam-1.5.1-7.fc34.aarch64",
+      "parted-3.4-2.fc34.aarch64",
+      "passwd-0.80-10.fc34.aarch64",
+      "pcre-8.44-3.fc34.1.aarch64",
+      "pcre2-10.36-4.fc34.aarch64",
+      "pcre2-syntax-10.36-4.fc34.noarch",
+      "pigz-2.5-1.fc34.aarch64",
+      "pinentry-1.2.0-1.fc34.aarch64",
+      "policycoreutils-3.2-1.fc34.aarch64",
+      "popt-1.18-4.fc34.aarch64",
+      "procps-ng-3.3.17-1.fc34.1.aarch64",
+      "protobuf-c-1.3.3-7.fc34.aarch64",
+      "psmisc-23.4-1.fc34.aarch64",
+      "publicsuffix-list-dafsa-20190417-5.fc34.noarch",
+      "python-pip-wheel-21.0.1-4.fc34.noarch",
+      "python-setuptools-wheel-53.0.0-2.fc34.noarch",
+      "python-unversioned-command-3.9.9-2.fc34.noarch",
+      "python3-3.9.9-2.fc34.aarch64",
+      "python3-attrs-20.3.0-2.fc34.noarch",
+      "python3-audit-3.0.6-1.fc34.aarch64",
+      "python3-babel-2.9.1-1.fc34.noarch",
+      "python3-cffi-1.14.5-1.fc34.aarch64",
+      "python3-chardet-4.0.0-1.fc34.noarch",
+      "python3-configobj-5.0.6-23.fc34.noarch",
+      "python3-cryptography-3.4.6-1.fc34.aarch64",
+      "python3-dateutil-2.8.1-3.fc34.noarch",
+      "python3-dbus-1.2.18-1.fc34.aarch64",
+      "python3-distro-1.5.0-5.fc34.noarch",
+      "python3-dnf-4.9.0-1.fc34.noarch",
+      "python3-dnf-plugins-core-4.0.24-1.fc34.noarch",
+      "python3-gpg-1.15.1-2.fc34.aarch64",
+      "python3-hawkey-0.64.0-1.fc34.aarch64",
+      "python3-idna-2.10-3.fc34.noarch",
+      "python3-jinja2-2.11.3-1.fc34.noarch",
+      "python3-jsonpatch-1.21-14.fc34.noarch",
+      "python3-jsonpointer-2.0-2.fc34.noarch",
+      "python3-jsonschema-3.2.0-9.fc34.noarch",
+      "python3-jwt+crypto-1.7.1-11.fc34.noarch",
+      "python3-jwt-1.7.1-11.fc34.noarch",
+      "python3-libcomps-0.1.18-1.fc34.aarch64",
+      "python3-libdnf-0.64.0-1.fc34.aarch64",
+      "python3-libs-3.9.9-2.fc34.aarch64",
+      "python3-libselinux-3.2-1.fc34.aarch64",
+      "python3-libsemanage-3.2-1.fc34.aarch64",
+      "python3-markupsafe-1.1.1-10.fc34.aarch64",
+      "python3-oauthlib+signedtoken-3.0.2-9.fc34.noarch",
+      "python3-oauthlib-3.0.2-9.fc34.noarch",
+      "python3-pip-21.0.1-4.fc34.noarch",
+      "python3-ply-3.11-11.fc34.noarch",
+      "python3-policycoreutils-3.2-1.fc34.noarch",
+      "python3-prettytable-0.7.2-25.fc34.noarch",
+      "python3-pycparser-2.20-3.fc34.noarch",
+      "python3-pyrsistent-0.17.3-6.fc34.aarch64",
+      "python3-pyserial-3.4-10.fc34.noarch",
+      "python3-pysocks-1.7.1-8.fc34.noarch",
+      "python3-pytz-2021.3-1.fc34.noarch",
+      "python3-pyyaml-5.4.1-2.fc34.aarch64",
+      "python3-requests-2.25.1-1.fc34.noarch",
+      "python3-rpm-4.16.1.3-1.fc34.aarch64",
+      "python3-setools-4.4.0-1.fc34.aarch64",
+      "python3-setuptools-53.0.0-2.fc34.noarch",
+      "python3-six-1.15.0-5.fc34.noarch",
+      "python3-unbound-1.13.2-1.fc34.aarch64",
+      "python3-urllib3-1.25.10-5.fc34.noarch",
+      "qrencode-libs-4.1.1-1.fc34.aarch64",
+      "readline-8.1-2.fc34.aarch64",
+      "rootfiles-8.1-29.fc34.noarch",
+      "rpm-4.16.1.3-1.fc34.aarch64",
+      "rpm-build-libs-4.16.1.3-1.fc34.aarch64",
+      "rpm-libs-4.16.1.3-1.fc34.aarch64",
+      "rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64",
+      "rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64",
+      "rpm-sign-libs-4.16.1.3-1.fc34.aarch64",
+      "rsync-3.2.3-5.fc34.aarch64",
+      "sed-4.8-7.fc34.aarch64",
+      "selinux-policy-34.23-1.fc34.noarch",
+      "selinux-policy-targeted-34.23-1.fc34.noarch",
+      "setup-2.13.7-3.fc34.noarch",
+      "shadow-utils-4.8.1-10.fc34.aarch64",
+      "shared-mime-info-2.1-2.fc34.aarch64",
+      "shim-aa64-15.4-4.aarch64",
+      "sqlite-libs-3.34.1-2.fc34.aarch64",
+      "sssd-client-2.5.2-2.fc34.aarch64",
+      "sssd-common-2.5.2-2.fc34.aarch64",
+      "sssd-kcm-2.5.2-2.fc34.aarch64",
+      "sssd-nfs-idmap-2.5.2-2.fc34.aarch64",
+      "sudo-1.9.5p2-1.fc34.aarch64",
+      "sudo-python-plugin-1.9.5p2-1.fc34.aarch64",
+      "systemd-248.9-1.fc34.aarch64",
+      "systemd-libs-248.9-1.fc34.aarch64",
+      "systemd-networkd-248.9-1.fc34.aarch64",
+      "systemd-oomd-defaults-248.9-1.fc34.aarch64",
+      "systemd-pam-248.9-1.fc34.aarch64",
+      "systemd-rpm-macros-248.9-1.fc34.noarch",
+      "systemd-udev-248.9-1.fc34.aarch64",
+      "tar-1.34-1.fc34.aarch64",
+      "tpm2-tss-3.1.0-1.fc34.aarch64",
+      "trousers-0.3.15-2.fc34.aarch64",
+      "trousers-lib-0.3.15-2.fc34.aarch64",
+      "tzdata-2021e-1.fc34.noarch",
+      "unbound-libs-1.13.2-1.fc34.aarch64",
+      "util-linux-2.36.2-1.fc34.aarch64",
+      "vim-data-8.2.3755-1.fc34.noarch",
+      "vim-minimal-8.2.3755-1.fc34.aarch64",
+      "which-2.21-26.fc34.aarch64",
+      "whois-nls-5.5.10-1.fc34.noarch",
+      "xfsprogs-5.10.0-2.fc34.aarch64",
+      "xkeyboard-config-2.33-1.fc34.noarch",
+      "xz-5.2.5-5.fc34.aarch64",
+      "xz-libs-5.2.5-5.fc34.aarch64",
+      "yum-4.9.0-1.fc34.noarch",
+      "zchunk-libs-1.1.15-1.fc34.aarch64",
+      "zlib-1.2.11-26.fc34.aarch64"
+    ],
+    "partition-table": "gpt",
+    "partition-table-id": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
+    "partitions": [
+      {
+        "bootable": false,
+        "fstype": "vfat",
+        "label": "EFI-SYSTEM",
+        "partuuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
+        "size": 498073600,
+        "start": 1048576,
+        "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+        "uuid": "46BB-8120"
+      },
+      {
+        "bootable": false,
+        "fstype": "ext4",
+        "label": null,
+        "partuuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
+        "size": 1647296000,
+        "start": 500170752,
+        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+        "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+      }
+    ],
+    "passwd": [
+      "adm:x:3:4:adm:/var/adm:/sbin/nologin",
+      "bin:x:1:1:bin:/bin:/sbin/nologin",
+      "chrony:x:995:994::/var/lib/chrony:/sbin/nologin",
+      "daemon:x:2:2:daemon:/sbin:/sbin/nologin",
+      "dbus:x:81:81:System message bus:/:/sbin/nologin",
+      "ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin",
+      "games:x:12:100:games:/usr/games:/sbin/nologin",
+      "halt:x:7:0:halt:/sbin:/sbin/halt",
+      "lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin",
+      "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
+      "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
+      "operator:x:11:0:operator:/root:/sbin/nologin",
+      "root:x:0:0:root:/root:/bin/bash",
+      "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
+      "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
+      "sync:x:5:0:sync:/sbin:/bin/sync",
+      "systemd-coredump:x:999:999:systemd Core Dumper:/:/sbin/nologin",
+      "systemd-network:x:192:192:systemd Network Management:/:/sbin/nologin",
+      "systemd-oom:x:998:998:systemd Userspace OOM Killer:/:/sbin/nologin",
+      "systemd-resolve:x:193:193:systemd Resolver:/:/sbin/nologin",
+      "systemd-timesync:x:997:997:systemd Time Synchronization:/:/sbin/nologin",
+      "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
+      "unbound:x:996:995:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
+    ],
+    "rpm-verify": {
+      "changed": {
+        "/boot/efi/EFI": ".M.......",
+        "/boot/efi/EFI/fedora/grubaa64.efi": ".......T.",
+        "/etc/machine-id": ".M.......",
+        "/etc/udev/hwdb.bin": ".M.......",
+        "/proc": ".M.......",
+        "/sys": ".M.......",
+        "/var/log/lastlog": ".M....G.."
+      },
+      "missing": []
+    },
+    "selinux": {
+      "context-mismatch": [
+        {
+          "actual": "system_u:object_r:unlabeled_t:s0",
+          "expected": "system_u:object_r:lost_found_t:s0",
+          "filename": "/lost+found"
+        }
+      ],
+      "policy": {
+        "SELINUX": "enforcing",
+        "SELINUXTYPE": "targeted"
+      }
+    },
+    "services-disabled": [
+      "arp-ethers.service",
+      "chrony-wait.service",
+      "console-getty.service",
+      "console-login-helper-messages-gensnippet-os-release.service",
+      "console-login-helper-messages-gensnippet-ssh-keys.service",
+      "debug-shell.service",
+      "exit.target",
+      "halt.target",
+      "kexec.target",
+      "loadmodules.service",
+      "man-db-restart-cache-update.service",
+      "nis-domainname.service",
+      "poweroff.target",
+      "proc-sys-fs-binfmt_misc.mount",
+      "rdisc.service",
+      "remote-cryptsetup.target",
+      "remote-veritysetup.target",
+      "runlevel0.target",
+      "selinux-check-proper-disable.service",
+      "serial-getty@.service",
+      "sshd-keygen@.service",
+      "sshd.socket",
+      "sssd-autofs.socket",
+      "sssd-nss.socket",
+      "sssd-pac.socket",
+      "sssd-pam-priv.socket",
+      "sssd-pam.socket",
+      "sssd-ssh.socket",
+      "sssd-sudo.socket",
+      "systemd-boot-check-no-failures.service",
+      "systemd-network-generator.service",
+      "systemd-networkd-wait-online.service",
+      "systemd-networkd.service",
+      "systemd-networkd.socket",
+      "systemd-pstore.service",
+      "systemd-sysext.service",
+      "systemd-time-wait-sync.service",
+      "systemd-timesyncd.service",
+      "tcsd.service"
+    ],
+    "services-enabled": [
+      "NetworkManager-dispatcher.service",
+      "NetworkManager-wait-online.service",
+      "NetworkManager.service",
+      "auditd.service",
+      "autovt@.service",
+      "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
+      "ctrl-alt-del.target",
+      "dbus-broker.service",
+      "dbus-org.freedesktop.home1.service",
+      "dbus-org.freedesktop.nm-dispatcher.service",
+      "dbus-org.freedesktop.oom1.service",
+      "dbus-org.freedesktop.resolve1.service",
+      "dbus.service",
+      "dbus.socket",
+      "dnf-makecache.timer",
+      "fstrim.timer",
+      "getty@.service",
+      "import-state.service",
+      "reboot.target",
+      "remote-fs.target",
+      "rpmdb-rebuild.service",
+      "runlevel6.target",
+      "selinux-autorelabel-mark.service",
+      "sshd.service",
+      "sssd-kcm.socket",
+      "sssd.service",
+      "systemd-homed-activate.service",
+      "systemd-homed.service",
+      "systemd-oomd.service",
+      "systemd-resolved.service",
+      "systemd-userdbd.socket",
+      "unbound-anchor.timer"
+    ],
+    "sudoers": {
+      "/etc/sudoers": [
+        "Defaults   !visiblepw",
+        "Defaults    always_set_home",
+        "Defaults    match_group_by_gid",
+        "Defaults    always_query_group_plugin",
+        "Defaults    env_reset",
+        "Defaults    env_keep =  \"COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS\"",
+        "Defaults    env_keep += \"MAIL QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE\"",
+        "Defaults    env_keep += \"LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES\"",
+        "Defaults    env_keep += \"LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE\"",
+        "Defaults    env_keep += \"LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY\"",
+        "Defaults    secure_path = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+        "root\tALL=(ALL) \tALL",
+        "%wheel\tALL=(ALL)\tALL"
+      ]
+    },
+    "sysctl.d": {
+      "/usr/lib/sysctl.d": {
+        "10-default-yama-scope.conf": [
+          "kernel.yama.ptrace_scope = 0"
+        ],
+        "50-coredump.conf": [
+          "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h",
+          "kernel.core_pipe_limit=16",
+          "fs.suid_dumpable=2"
+        ],
+        "50-default.conf": [
+          "kernel.sysrq = 16",
+          "kernel.core_uses_pid = 1",
+          "net.ipv4.conf.default.rp_filter = 2",
+          "net.ipv4.conf.*.rp_filter = 2",
+          "-net.ipv4.conf.all.rp_filter",
+          "net.ipv4.conf.default.accept_source_route = 0",
+          "net.ipv4.conf.*.accept_source_route = 0",
+          "-net.ipv4.conf.all.accept_source_route",
+          "net.ipv4.conf.default.promote_secondaries = 1",
+          "net.ipv4.conf.*.promote_secondaries = 1",
+          "-net.ipv4.conf.all.promote_secondaries",
+          "-net.ipv4.ping_group_range = 0 2147483647",
+          "-net.core.default_qdisc = fq_codel",
+          "fs.protected_hardlinks = 1",
+          "fs.protected_symlinks = 1",
+          "fs.protected_regular = 1",
+          "fs.protected_fifos = 1"
+        ],
+        "50-libkcapi-optmem_max.conf": [
+          "net.core.optmem_max = 81920"
+        ],
+        "50-pid-max.conf": [
+          "kernel.pid_max = 4194304"
+        ]
+      }
+    },
+    "systemd-service-dropins": {
+      "/usr/lib/systemd/system": {
+        "systemd-hostnamed.service.d": {
+          "Service": {
+            "PrivateDevices": "no"
+          }
+        },
+        "systemd-logind.service.d": {
+          "Service": {
+            "Environment": "SYSTEMD_REBOOT_TO_BOOT_LOADER_MENU=true"
+          }
+        },
+        "systemd-udev-trigger.service.d": {
+          "Unit": {
+            "RefuseManualStop": "true"
+          }
+        },
+        "user@.service.d": {
+          "Service": {
+            "ManagedOOMMemoryPressure": "kill",
+            "ManagedOOMMemoryPressureLimit": "50%"
+          }
+        }
+      }
+    },
+    "timezone": "UTC",
+    "tmpfiles.d": {
+      "/usr/lib/tmpfiles.d": {
+        "cloud-init.conf": [
+          "d /run/cloud-init 0700 root root - -"
+        ],
+        "console-login-helper-messages-issuegen.conf": [
+          "r /etc/issue.d/*_clhm_*.issue - - - - -"
+        ],
+        "console-login-helper-messages-motdgen.conf": [
+          "d /run/motd.d - - - - -"
+        ],
+        "console-login-helper-messages-profile.conf": [
+          "L /etc/profile.d/console-login-helper-messages-profile.sh - - - - ../../usr/share/console-login-helper-messages/profile.sh"
+        ],
+        "console-login-helper-messages.conf": [
+          "d /run/console-login-helper-messages - - - - -"
+        ],
+        "cryptsetup.conf": [
+          "d /run/cryptsetup 0700 root root -"
+        ],
+        "dnf.conf": [
+          "R /var/tmp/dnf*/locks/*",
+          "r /var/cache/dnf/download_lock.pid",
+          "r /var/cache/dnf/metadata_lock.pid",
+          "r /var/lib/dnf/rpmdb_lock.pid",
+          "r /var/log/log_lock.pid"
+        ],
+        "etc.conf": [
+          "L /etc/os-release - - - - ../usr/lib/os-release",
+          "L+ /etc/mtab - - - - ../proc/self/mounts",
+          "L! /etc/resolv.conf - - - - ../run/systemd/resolve/stub-resolv.conf",
+          "C! /etc/nsswitch.conf - - - -",
+          "C! /etc/pam.d - - - -",
+          "C! /etc/issue - - - -"
+        ],
+        "home.conf": [
+          "Q /home 0755 - - -",
+          "q /srv 0755 - - -"
+        ],
+        "journal-nocow.conf": [
+          "h /var/log/journal - - - - +C",
+          "h /var/log/journal/%m - - - - +C",
+          "h /var/log/journal/remote - - - - +C"
+        ],
+        "legacy.conf": [
+          "d /run/lock 0755 root root -",
+          "L /var/lock - - - - ../run/lock",
+          "d /run/lock/subsys 0755 root root -",
+          "r! /forcefsck",
+          "r! /fastboot",
+          "r! /forcequotacheck"
+        ],
+        "libselinux.conf": [
+          "d /run/setrans 0755 root root"
+        ],
+        "man-db.conf": [
+          "d /var/cache/man 0755 root root 1w"
+        ],
+        "pam.conf": [
+          "d /run/console 0755 root root -",
+          "d /run/faillock 0755 root root -",
+          "d /run/sepermit 0755 root root -",
+          "d /run/motd.d 0755 root root -",
+          "f /var/log/tallylog 0600 root root -"
+        ],
+        "portables.conf": [
+          "Q /var/lib/portables 0700"
+        ],
+        "selinux-policy.conf": [
+          "z /sys/devices/system/cpu/online - - -",
+          "Z /sys/class/net - - -",
+          "z /sys/kernel/uevent_helper - - -",
+          "w /sys/fs/selinux/checkreqprot - - - - 0"
+        ],
+        "setup.conf": [
+          "f /run/motd 0644 root root -",
+          "d /run/motd.d 0755 root root -"
+        ],
+        "static-nodes-permissions.conf": [
+          "z /dev/snd/seq      0660 - audio -",
+          "z /dev/snd/timer    0660 - audio -",
+          "z /dev/loop-control 0660 - disk  -",
+          "z /dev/net/tun      0666 - -     -",
+          "z /dev/fuse         0666 - -     -",
+          "z /dev/kvm          0666 - kvm -",
+          "z /dev/vhost-net    0666 - kvm -",
+          "z /dev/vhost-vsock  0666 - kvm -"
+        ],
+        "sudo.conf": [
+          "d /run/sudo 0711 root root",
+          "D /run/sudo/ts 0700 root root"
+        ],
+        "systemd-nologin.conf": [
+          "F! /run/nologin 0644 - - - \"System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8).\""
+        ],
+        "systemd-pstore.conf": [
+          "d /var/lib/systemd/pstore 0755 root root 14d"
+        ],
+        "systemd-tmp.conf": [
+          "x /tmp/systemd-private-%b-*",
+          "X /tmp/systemd-private-%b-*/tmp",
+          "x /var/tmp/systemd-private-%b-*",
+          "X /var/tmp/systemd-private-%b-*/tmp",
+          "R! /tmp/systemd-private-*",
+          "R! /var/tmp/systemd-private-*",
+          "x  /var/lib/systemd/coredump/.#core*.%b*",
+          "r! /var/lib/systemd/coredump/.#*"
+        ],
+        "systemd.conf": [
+          "d /run/user 0755 root root -",
+          "F! /run/utmp 0664 root utmp -",
+          "d /run/systemd/ask-password 0755 root root -",
+          "d /run/systemd/seats 0755 root root -",
+          "d /run/systemd/sessions 0755 root root -",
+          "d /run/systemd/users 0755 root root -",
+          "d /run/systemd/machines 0755 root root -",
+          "d /run/systemd/shutdown 0755 root root -",
+          "d /run/systemd/netif 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/links 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/leases 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/lldp 0755 systemd-network systemd-network -",
+          "d /run/log 0755 root root -",
+          "z /run/log/journal 2755 root systemd-journal - -",
+          "Z /run/log/journal/%m ~2750 root systemd-journal - -",
+          "a+ /run/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m/*.journal* - - - - group:adm:r--,group:wheel:r--",
+          "z /var/log/journal 2755 root systemd-journal - -",
+          "z /var/log/journal/%m 2755 root systemd-journal - -",
+          "z /var/log/journal/%m/system.journal 0640 root systemd-journal - -",
+          "a+ /var/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m/system.journal - - - - group:adm:r--,group:wheel:r--",
+          "d /var/lib/systemd 0755 root root -",
+          "d /var/lib/systemd/coredump 0755 root root 3d",
+          "d /var/lib/private 0700 root root -",
+          "d /var/log/private 0700 root root -",
+          "d /var/cache/private 0700 root root -"
+        ],
+        "tmp.conf": [
+          "q /tmp 1777 root root 10d",
+          "q /var/tmp 1777 root root 30d"
+        ],
+        "tpm2-tss-fapi.conf": [
+          "d       /var/lib/tpm2-tss/system/keystore   2775 tss  tss   -           -",
+          "a+      /var/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx",
+          "d       /run/tpm2-tss/eventlog                2775 tss  tss   -           -",
+          "a+      /run/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx"
+        ],
+        "var.conf": [
+          "q /var 0755 - - -",
+          "L /var/run - - - - ../run",
+          "d /var/log 0755 - - -",
+          "f /var/log/wtmp 0664 root utmp -",
+          "f /var/log/btmp 0660 root utmp -",
+          "f /var/log/lastlog 0664 root utmp -",
+          "d /var/cache 0755 - - -",
+          "d /var/lib 0755 - - -",
+          "d /var/spool 0755 - - -"
+        ],
+        "x11.conf": [
+          "D! /tmp/.X11-unix 1777 root root 10d",
+          "D! /tmp/.ICE-unix 1777 root root 10d",
+          "D! /tmp/.XIM-unix 1777 root root 10d",
+          "D! /tmp/.font-unix 1777 root root 10d",
+          "D! /tmp/.Test-unix 1777 root root 10d",
+          "r! /tmp/.X[0-9]*-lock"
+        ]
+      }
+    }
+  }
+}

--- a/test/data/manifests/fedora_34-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-openstack-boot.json
@@ -1,0 +1,10730 @@
+{
+  "boot": {
+    "type": "openstack"
+  },
+  "compose-request": {
+    "distro": "fedora-34",
+    "arch": "aarch64",
+    "image-type": "openstack",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-modular-20210512/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-modular-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      }
+    ],
+    "filename": "disk.qcow2",
+    "blueprint": {
+      "name": "openstack-boot-test",
+      "description": "Image for boot test",
+      "packages": [],
+      "modules": [],
+      "groups": [],
+      "customizations": {
+        "user": [
+          {
+            "name": "redhat",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+          }
+        ]
+      }
+    }
+  },
+  "manifest": {
+    "sources": {
+      "org.osbuild.files": {
+        "urls": {
+          "sha256:007f1604e1a0a51b226a758934efcce905cd5d285437068847c4995821513f1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/nftables-0.9.8-3.fc34.aarch64.rpm"
+          },
+          "sha256:00c29524aad123ec44056e60b9625e75ac428a6c751878a05fadbca7e956c249": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dbus-1.2.18-1.fc34.aarch64.rpm"
+          },
+          "sha256:0176b42c6b51fb3c829f168571527a3559b6a9c8cc5f847b70e3c40fb69f89e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-100.fc34.aarch64.rpm"
+          },
+          "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-legacy-libs-1.8.7-8.fc34.aarch64.rpm"
+          },
+          "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-9.fc34.aarch64.rpm"
+          },
+          "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc34.aarch64.rpm"
+          },
+          "sha256:059f825547fe257247656c29049ebc7bfa1d54a17479f3dcfeff37fbab7084bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.33-20.fc34.aarch64.rpm"
+          },
+          "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libibverbs-37.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc34.aarch64.rpm"
+          },
+          "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.aarch64.rpm"
+          },
+          "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm"
+          },
+          "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pip-21.0.1-4.fc34.noarch.rpm"
+          },
+          "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cyrus-sasl-lib-2.1.27-8.fc34.aarch64.rpm"
+          },
+          "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxml2-2.9.12-4.fc34.aarch64.rpm"
+          },
+          "sha256:0ac62147585be2dae960ed37a3a0c3eb2f8a95d0fd0993991c8bf7238b1d5e27": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dhcp-client-4.4.2-11.b1.fc34.aarch64.rpm"
+          },
+          "sha256:0db1be9a78e5f329a519066a7b37379f6c73fe579154e0a6a26b2dcb4154ccd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-common-2.33-20.fc34.aarch64.rpm"
+          },
+          "sha256:0e23d7345b89f14f69026da5aa9c730b601b78f8e2fb6c9ead7d5af4ecb1cc92": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/h/hwdata-0.354-1.fc34.noarch.rpm"
+          },
+          "sha256:0f2589fcd0d6387a2c13d7533b627b53e9d8f0b92ac497d95926646896ac1e6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/gobject-introspection-1.68.0-4.fc34.aarch64.rpm"
+          },
+          "sha256:0f9ebdf7f08a506a8d1d6c4b4788dd7ca3dbb832509072b66def4da5b86d7862": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/efibootmgr-16-10.fc34.aarch64.rpm"
+          },
+          "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm"
+          },
+          "sha256:1014763656c1578ae96b38fd3e87c4d07b548cb8423688cc928d0f9762d43a44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfido2-1.6.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libblkid-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:11a0c09b716f8071f0484278bec326fb82e93d987376c8b38188d1febcd5381d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libndp-1.7-7.fc34.aarch64.rpm"
+          },
+          "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:11cd6fae157eb9e4800163633b57bcce21d59a1df4b86a99ba03707b6cee0cfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dhcp-common-4.4.2-11.b1.fc34.noarch.rpm"
+          },
+          "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libuuid-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm"
+          },
+          "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-ng-0.8.2-4.fc34.aarch64.rpm"
+          },
+          "sha256:12b7666d61e7bd8b3b5b1a7c57539964531802287e592e33449e039799ea2071": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbasicobjects-0.1.1-47.fc34.aarch64.rpm"
+          },
+          "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/which-2.21-26.fc34.aarch64.rpm"
+          },
+          "sha256:131adc47f044c9f600f5295ded0f5431cda57fa7276100c3ec81c9d1ce3fa6f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jwt-1.7.1-11.fc34.noarch.rpm"
+          },
+          "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:139b9453b2038e52767d0102def782d58d558ca0603757eb0c97ddda28af1466": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-audit-3.0.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:148aea26e381b33badde0ac2ae716a78f7b565f54f0b6970189a89713f335eaf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-3.0.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:164e1c0e3e8c89aeda4f272b3158932649a69b16aea058105117a64d3cdef517": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rootfiles-8.1-29.fc34.noarch.rpm"
+          },
+          "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm"
+          },
+          "sha256:1af86c0a8c11e44958b022bf7dad5f48ad974fa8537cf41a12d5b0643444b1dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.3755-1.fc34.aarch64.rpm"
+          },
+          "sha256:1b1af6b54050ec223c3289b107a9695a686c9d46d17a80ec9cd5d0201ec5d544": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonpointer-2.0-2.fc34.noarch.rpm"
+          },
+          "sha256:1bbb7ec72916bb641b7c477a7bbd7b2ad57325f368846e34c26c592bc11a6d8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/firewalld-filesystem-0.9.4-1.fc34.noarch.rpm"
+          },
+          "sha256:1c01e888717888901aef3fee5c02841a83f83b3d9d962bc3cd495a88a5e3ab5c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-slip-dbus-0.6.4-22.fc34.noarch.rpm"
+          },
+          "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.aarch64.rpm"
+          },
+          "sha256:1feb6a045cb3e95e3c8e0112ecb4b8ffeb9986a503b52c5497fefce217846b90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc34.noarch.rpm"
+          },
+          "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.aarch64.rpm"
+          },
+          "sha256:2027da420b35a0b70ae5045d2fd79cdccb820f03e5ff4018a2205d3d413ff1af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtdb-1.4.3-6.fc34.aarch64.rpm"
+          },
+          "sha256:217b9e2d44c03ba92900f5b517b21358cee4c764e104515e55efd5ef9d838f22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/plymouth-0.9.5-2.20210331git1ea1020.fc34.aarch64.rpm"
+          },
+          "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm"
+          },
+          "sha256:2371cf0854393fc6c8ab6457b8e662f1046b654cc01ae65407b09be704c5f2eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnftnl-1.1.9-2.fc34.aarch64.rpm"
+          },
+          "sha256:23a539a271c92906ac0a12c7d877c7f4d0ad8e6b9bbd8642b5232f861b79ed22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shim-aa64-15.4-4.aarch64.rpm"
+          },
+          "sha256:23e3ed871799a9209915359f71660babf451b0b44902e3ed488b7b22aff37718": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-ply-3.11-11.fc34.noarch.rpm"
+          },
+          "sha256:23f7cc188684a9e9ba8f0ffbcd9ecb28aaeba9a6e596e1c56362d8a1f51a492d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-decorator-4.4.2-4.fc34.noarch.rpm"
+          },
+          "sha256:2414cb7345bc193f7ff7983c020c8b0e706aab013ee30af5d457d35c4de4a698": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jinja2-2.11.3-1.fc34.noarch.rpm"
+          },
+          "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/whois-nls-5.5.10-1.fc34.noarch.rpm"
+          },
+          "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpsl-0.21.1-3.fc34.aarch64.rpm"
+          },
+          "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm"
+          },
+          "sha256:27920113489e3260e58d4a033d31401c6ae22ded72895c6b8c0e43ebf89a62df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/parted-3.4-2.fc34.aarch64.rpm"
+          },
+          "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/nettle-3.7.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-all-langpacks-5.1.0-3.fc34.aarch64.rpm"
+          },
+          "sha256:2968703dd232a37620a0ae12146c9d1ec5220f62c40bfb0ecfc60b621d8e1eac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-dicts-2.9.6-27.fc34.aarch64.rpm"
+          },
+          "sha256:2aa0bf433e2f3c7d09613dd1f9b2853a8946bc26051ba9e747cd29518679958f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-firewall-0.9.4-1.fc34.noarch.rpm"
+          },
+          "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-34.23-1.fc34.noarch.rpm"
+          },
+          "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-8.32-30.fc34.aarch64.rpm"
+          },
+          "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxkbcommon-1.3.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:30bc3583e503e0f459e323b27551f7b9a8ab784de15437b5b29f447b31f8d9cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/y/yum-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.aarch64.rpm"
+          },
+          "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:32220dc513a6ebcd4994e7140ecb5859108baf44d12fe6b1f0c0459dbefc54e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pycparser-2.20-3.fc34.noarch.rpm"
+          },
+          "sha256:3228a36807658c7e4d881013aa26f877353388bf3bac6c948984f751c264a359": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xfsprogs-5.10.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:32d76b30fca1050db004ab86e4e2079c3b3bf13765d3a1d6d0f5a5c2a41c91c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/plymouth-scripts-0.9.5-2.20210331git1ea1020.fc34.aarch64.rpm"
+          },
+          "sha256:330a36b1dabaf76daafeff3f7fd7a276880bf65d790ee84cb823a1958a4d99d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libnfsidmap-2.5.4-2.rc3.fc34.aarch64.rpm"
+          },
+          "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-6.2-4.20200222.fc34.aarch64.rpm"
+          },
+          "sha256:3381367f7142fca98999f2bf737ff1dcc895af2e2550fe35538dd03718964c45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ipset-7.11-1.fc34.aarch64.rpm"
+          },
+          "sha256:33b878000610ca3ba875b72f2a454e4fac9471f80579824304ca81e6f3e3f79d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/checkpolicy-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-20210213-1.git5c710c0.fc34.noarch.rpm"
+          },
+          "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm"
+          },
+          "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-setuptools-wheel-53.0.0-2.fc34.noarch.rpm"
+          },
+          "sha256:37cda2c179e4311a1aeeb0ea8d07d3eacc8ea8bf97d122ec22cd596c61b8e770": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/groff-base-1.22.4-7.fc34.aarch64.rpm"
+          },
+          "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.aarch64.rpm"
+          },
+          "sha256:3901de67d83f50b24768e660ac9633f8ebdf97ba3dcd22726927ff3e2c0ddb68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libX11-1.7.2-3.fc34.aarch64.rpm"
+          },
+          "sha256:39160ef65b3519a70f14f992edc5967380ef86a6940896751db681781961903d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-server-8.6p1-5.fc34.aarch64.rpm"
+          },
+          "sha256:394ddf6f634c70dcd1ba5763af7be37145b5ac1749160e199f95b524767eef82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-guest-agent-5.2.0-8.fc34.aarch64.rpm"
+          },
+          "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sed-4.8-7.fc34.aarch64.rpm"
+          },
+          "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.aarch64.rpm"
+          },
+          "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grep-3.6-2.fc34.aarch64.rpm"
+          },
+          "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.0.1-4.fc34.noarch.rpm"
+          },
+          "sha256:3b3bba1d61529a1dde47f234f34d0fdee07a38aa5958d87e30357ea04bbff142": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.aarch64.rpm"
+          },
+          "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/keyutils-libs-1.6.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-0.21-4.fc34.aarch64.rpm"
+          },
+          "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/setup-2.13.7-3.fc34.noarch.rpm"
+          },
+          "sha256:3e69e8412d5914ec01c5e82264833698e92a1b88a7c7b5ed9b1f0351fc91f5d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-34-39.noarch.rpm"
+          },
+          "sha256:3e81f34c490661423c064fb9426cbacfc4a1f5c254aa40f98343d7cdc0f07603": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdrm-2.4.109-1.fc34.aarch64.rpm"
+          },
+          "sha256:3fb05067cbd7fcf3283f2ab306c2dae668d818d3a69422e729c2ef62974810a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fonts-filesystem-2.0.5-5.fc34.noarch.rpm"
+          },
+          "sha256:3fdab509a59e0a765364d6f119c38c796a4420cc49b46595a37d98eb649d6c80": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm"
+          },
+          "sha256:40e231991444a589b17e0b5b338be8874d071e3d17e210aba6f6639620775f79": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-1.9.5p2-1.fc34.aarch64.rpm"
+          },
+          "sha256:4123331b5d06f91ff31d147e4769806052f59b620e7677f69b0073eaf7beccb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.aarch64.rpm"
+          },
+          "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.9.9-2.fc34.noarch.rpm"
+          },
+          "sha256:43b0b5d425a2041daeb6b41db2858abda1f92ecc38c6125f7de3b7502580a9f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:45d38ed1d2247e17e3e8faf7d6755216c5ef4422736129f55b712f160532d8f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libini_config-1.3.1-47.fc34.aarch64.rpm"
+          },
+          "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm"
+          },
+          "sha256:47c92a952b162b7bafbe49a7e409a7a81825adc77b3e139651913d52d8aa84fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/h/hostname-3.23-4.fc34.aarch64.rpm"
+          },
+          "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsemanage-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnl3-3.5.0-6.fc34.aarch64.rpm"
+          },
+          "sha256:4a74ae08a713e9b4e74ff27bfaf57374312370402f90e2796e66c504557ae189": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pysocks-1.7.1-8.fc34.noarch.rpm"
+          },
+          "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:4b65dc9856b0d0ce555dd9bce88dcfb680ba689a2c6b88ae9f84b016553d96af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iputils-20210202-2.fc34.aarch64.rpm"
+          },
+          "sha256:4baf8ba6a5ed4609695f79a8bbc8324d7efa322a3573c8c5fa3942361eac0f1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.30.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-1.12.20-3.fc34.aarch64.rpm"
+          },
+          "sha256:4e45f4c24997b231cb6fb8d31e9d7e0aae40c1135337194d62ce98c197547dbf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-slip-0.6.4-22.fc34.noarch.rpm"
+          },
+          "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-2.9.6-27.fc34.aarch64.rpm"
+          },
+          "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/curl-7.76.1-12.fc34.aarch64.rpm"
+          },
+          "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-common-1.12.20-3.fc34.noarch.rpm"
+          },
+          "sha256:50f8013df88ebb6fbe7ef8a7720815196bced2e81e6e78d8932f53b990f73e1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-nftables-0.9.8-3.fc34.aarch64.rpm"
+          },
+          "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gdbm-libs-1.19-2.fc34.aarch64.rpm"
+          },
+          "sha256:51247521cd48b5605859881a22ca9be89c80d0a27b98d1b80c17ad821c79f679": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ipset-libs-7.11-1.fc34.aarch64.rpm"
+          },
+          "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/gnutls-3.7.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:55833f669ed1dbd32e79f494824c309b71bc373d2bf28eb5cdb663459dc6f7cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-100.fc34.aarch64.rpm"
+          },
+          "sha256:5595c4bc0ad8072173df3858efdebea0fabb0fdf74a5ca2edb020af66e0f3716": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libxcb-1.13.1-7.fc34.aarch64.rpm"
+          },
+          "sha256:56634e58fc7499d719a3f431dd188e8f2655ebfa402e94ce105794a47debf45b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtalloc-2.3.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.aarch64.rpm"
+          },
+          "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc34.aarch64.rpm"
+          },
+          "sha256:59cc4d563ecb4c8b517f5dd7505f1cda297f950f32fc700344aa7789b69ca99c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-babel-2.9.1-1.fc34.noarch.rpm"
+          },
+          "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:5d2c28837f0573ae2647b8fbba85f7c502f9c3da0a3eab1c9ba121de4a1a6cee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-dateutil-2.8.1-3.fc34.noarch.rpm"
+          },
+          "sha256:5dcac7772d73ad1523f87cbeb1dc76dd62af4d2bb73dd06896a47d2bcf503e5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-8.6p1-5.fc34.aarch64.rpm"
+          },
+          "sha256:5e0a71bc53cae651289a962699fc17fd9f16a474398cb6b7dfe3d239876b6ed4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/alsa-lib-1.2.6.1-3.fc34.aarch64.rpm"
+          },
+          "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm"
+          },
+          "sha256:6046f881a5c0822c30bd037aec040c65594b6328b1c0d72b6681fe1575eac765": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcbor-0.7.0-3.fc34.aarch64.rpm"
+          },
+          "sha256:60ddc7b15e9742ff9995d1b336489b92721e21a45034d20f20d2fc800e419d1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/popt-1.18-4.fc34.aarch64.rpm"
+          },
+          "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:61a9dbd9020e29012947978acf33a0c1150e6c3e078de372f1e38fb9c4ef529a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/chrony-4.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:61ba1ecff8f8578cbd3445df596d001067bb0281745191ac168fcc6079d8e1cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/man-db-2.9.3-3.fc34.aarch64.rpm"
+          },
+          "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-3.9.9-2.fc34.aarch64.rpm"
+          },
+          "sha256:6297d7eee103c679a0f1ea411568d3940af3fe8f38e19388a1544df70bda8b3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-requests-2.25.1-1.fc34.noarch.rpm"
+          },
+          "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpcap-1.10.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-0.23.22-3.fc34.aarch64.rpm"
+          },
+          "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbrotli-1.0.9-4.fc34.aarch64.rpm"
+          },
+          "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-libs-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm"
+          },
+          "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtirpc-1.3.2-0.fc34.aarch64.rpm"
+          },
+          "sha256:668a30c6f526e51705af9cb9d98fd11f279f5e86f7d905876ae9a86f486a8c36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-common-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm"
+          },
+          "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm"
+          },
+          "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-34.23-1.fc34.noarch.rpm"
+          },
+          "sha256:686e015d81c1be2e6b88c7e8a50d45109d7273143a034caa9c935ecd014e1c62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libref_array-0.1.5-47.fc34.aarch64.rpm"
+          },
+          "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-trust-0.23.22-3.fc34.aarch64.rpm"
+          },
+          "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/procps-ng-3.3.17-1.fc34.1.aarch64.rpm"
+          },
+          "sha256:69de3dd68dc2b76e2a85c710a51e9c8acefe595d6ac5d9f19113c4062a5f0d92": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/ipcalc-1.0.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:6a864bec34b7d39de3e6ae1e39ec07fa3a2d21837a9a2d7151228d7f0ac38e73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/passwd-0.80-10.fc34.aarch64.rpm"
+          },
+          "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-34-2.noarch.rpm"
+          },
+          "sha256:6ccc5b659a2b8328a7a80e63cf8b4b9e819aa8de1f64b7c6ab5e76b5f45586d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libX11-common-1.7.2-3.fc34.noarch.rpm"
+          },
+          "sha256:6d1c024b295c423746b44f120cf36ceb0fd898f8ce5a276813d7c78a3c8ece52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-34-39.noarch.rpm"
+          },
+          "sha256:6d3301f6e99d9728698822e81fc2d170694cc367b7e7fea5c7a019f7b1a6073b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/inih-49-3.fc34.aarch64.rpm"
+          },
+          "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm"
+          },
+          "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fuse-libs-2.9.9-11.fc34.aarch64.rpm"
+          },
+          "sha256:70a90c6c682016e91fb4745eedbd23f28e150a38b01d18f85ce4e50fb4e0ca6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pyserial-3.4-10.fc34.noarch.rpm"
+          },
+          "sha256:71427f6f8f3f6370dccde81a76d566ff17144e7e375381ef13e04a661e63cba1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-9.fc34.aarch64.rpm"
+          },
+          "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtextstyle-0.21-4.fc34.aarch64.rpm"
+          },
+          "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-config-0.9.6-1.fc34.noarch.rpm"
+          },
+          "sha256:7285fcc290a8af2cf845beb845e661cd4c06c2275417b15eb507824dedec7c69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnghttp2-1.43.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtasn1-4.16.0-4.fc34.aarch64.rpm"
+          },
+          "sha256:7721bc647c521d96e07e665f7da306326d3bd1499d610c58552317815aaf3c45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lmdb-libs-0.9.29-1.fc34.aarch64.rpm"
+          },
+          "sha256:79834af7f95c0d1e5dcf85b794819bd854197a52d2966594abdb3c3de0fcceb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dejavu-sans-fonts-2.37-16.fc34.noarch.rpm"
+          },
+          "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:79864051052858a1c95538888ca61a43b509b6eae4ae269ae6ea7bf8b076a2b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmnl-1.0.4-13.fc34.aarch64.rpm"
+          },
+          "sha256:7a590bbf63577d619629239d6a8719b6d68053649986059dccf3e624fe2a3f03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libXau-1.0.9-6.fc34.aarch64.rpm"
+          },
+          "sha256:7c24e53e12891046bb6721e624cf9effd1946c0d076464427c2a86b29671318e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/c-ares-1.17.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:7cc0891a9e7c19757c03cba6c8155738d9db9f5774380c412106adf0eca44077": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/less-590-2.fc34.aarch64.rpm"
+          },
+          "sha256:7d00ccbb224617a00f58053afd88e7a49062446f1306ba39c72b78d20aeee1ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-cffi-1.14.5-1.fc34.aarch64.rpm"
+          },
+          "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/z/zlib-1.2.11-26.fc34.aarch64.rpm"
+          },
+          "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/filesystem-3.14-5.fc34.aarch64.rpm"
+          },
+          "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm"
+          },
+          "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-common-34-39.noarch.rpm"
+          },
+          "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch.rpm"
+          },
+          "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/findutils-4.8.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bzip2-libs-1.0.8-6.fc34.aarch64.rpm"
+          },
+          "sha256:820fee96d610178c7c7b8ce2b115bd02063d2f6dfcae5da4bf5d411de0b575f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-attrs-20.3.0-2.fc34.noarch.rpm"
+          },
+          "sha256:82b51ca6bec551d74a6d8c43194b0fd4e8bfdf19d1d68b58c1787723edd88bd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-en-3.0-14.fc34.noarch.rpm"
+          },
+          "sha256:82cbc5e0339e832d2fc0160541c30f3dee59b3d28d83907ae7b55e22d5092c51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-core-font-en-3.0-14.fc34.noarch.rpm"
+          },
+          "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-common-8.32-30.fc34.aarch64.rpm"
+          },
+          "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-29-2.fc34.aarch64.rpm"
+          },
+          "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:86cb1e5e80642b1575df57287c9549749603bf94b1ba652995b59ea45ac4272b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libldb-2.3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-libs-1.02.175-1.fc34.aarch64.rpm"
+          },
+          "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pam-1.5.1-7.fc34.aarch64.rpm"
+          },
+          "sha256:87749765dbe5ce8f098279170c39bb8a89abbf3f8430c2a6dbfb973117e11dfa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-libsemanage-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:87fa60c9e5fd73e064450bb155b36501a1da34f06df257773a0ce7eb7e84e5a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/firewalld-0.9.4-1.fc34.noarch.rpm"
+          },
+          "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libidn2-2.3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.aarch64.rpm"
+          },
+          "sha256:8ab032e2a86f300d978e521ab030db1e7bb7eeccca205a5d2a4d68b51566f43f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc34.noarch.rpm"
+          },
+          "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openldap-2.4.57-6.fc34.aarch64.rpm"
+          },
+          "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libs-3.9.9-2.fc34.aarch64.rpm"
+          },
+          "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre-8.44-3.fc34.1.aarch64.rpm"
+          },
+          "sha256:8f2ae60a71d008a9d67c151e088e9b420b07ccbaada55e0d06a66a3b8a1634b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libfdt-1.6.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:8fbfbaf3b107b540428634c19c4cb05e7c46f9672cfbf14d1f44306ed3413a46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/efi-filesystem-5-4.fc34.noarch.rpm"
+          },
+          "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm"
+          },
+          "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc34.aarch64.rpm"
+          },
+          "sha256:92e42b63fcc56dd21984abb722e8fa7ebbb58f6d54c529ac11871b4bbc63b290": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pyyaml-5.4.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:93708bb1a4355a1d3659cd80a8d5650f8d197b8af7c591219d46e2b520214825": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpciaccess-0.16-4.fc34.aarch64.rpm"
+          },
+          "sha256:94f598b1f39bd6e6a212c873d38b4e466b9c5dbea34c6fdbf0c58cf4d9ec4477": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/spice-vdagent-0.21.0-4.fc34.aarch64.rpm"
+          },
+          "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gmp-6.2.0-6.fc34.aarch64.rpm"
+          },
+          "sha256:96c7a26b707d4038a50b4ab0fd8d79ba3997466bed543f13c10d30e7ec256b5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/net-tools-2.0-0.59.20160912git.fc34.aarch64.rpm"
+          },
+          "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm"
+          },
+          "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/basesystem-11-11.fc34.noarch.rpm"
+          },
+          "sha256:98370c7be5b5fc629505843db497c9d82d243234d31c65e2b3afd8538570e9ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/y/yajl-2.1.0-16.fc34.aarch64.rpm"
+          },
+          "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-5.2.5-5.fc34.aarch64.rpm"
+          },
+          "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/openssl-pkcs11-0.4.11-2.fc34.aarch64.rpm"
+          },
+          "sha256:9aee2549d3ff9e5652dffaaa9b91ab7a243687cc2a85b8e45f4290d53d44702d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc34.aarch64.rpm"
+          },
+          "sha256:9cc240ac305a862146e85d8dcc4ad981f5233a58b6901ecfac691d0b39966b49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jwt+crypto-1.7.1-11.fc34.noarch.rpm"
+          },
+          "sha256:9ce3f0c0904ac22ab5769babebf43e7dcdb488b0ef999b2e9e88a5b5eb424e51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-chardet-4.0.0-1.fc34.noarch.rpm"
+          },
+          "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm"
+          },
+          "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsepol-3.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-libs-0.21-4.fc34.aarch64.rpm"
+          },
+          "sha256:9f2f2a20f285a2ac306ce72475beecf967cf92308b426aafca68215a6c3c12ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/jansson-2.13.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-misc-2.4.0-2.fc34.noarch.rpm"
+          },
+          "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.aarch64.rpm"
+          },
+          "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm"
+          },
+          "sha256:a0f1b653f889bb95e6edec2c525dfc71e280076b29394cf9c06ffa81ecd8b9fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/efivar-libs-37-15.fc34.aarch64.rpm"
+          },
+          "sha256:a1a996e8da4733b14c449b69e34484fe4f2b88c0f2963145bf0402cf04baf30e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpath_utils-0.2.1-47.fc34.aarch64.rpm"
+          },
+          "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc34.noarch.rpm"
+          },
+          "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-gpg-keys-34-2.noarch.rpm"
+          },
+          "sha256:a60e3e035883de829c5778417d316ffc47a0b4a304953e3fdc44def8f2f172ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/linux-atm-libs-2.5.1-28.fc34.aarch64.rpm"
+          },
+          "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:a72bb74400b447af71600da141aebdc46da7776ef875abfdd635881f939891d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtevent-0.11.0-0.fc34.aarch64.rpm"
+          },
+          "sha256:a86ec8f7284ee01574bb06bba726d8609e464f41d003215097e626c583f73ed0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-python-plugin-1.9.5p2-1.fc34.aarch64.rpm"
+          },
+          "sha256:aad99c9171fdf21ad93ed55c8aed44beacc5075ff522b2360609a536f7dfc928": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libXrender-0.9.10-14.fc34.aarch64.rpm"
+          },
+          "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-2.33-20.fc34.aarch64.rpm"
+          },
+          "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssl-libs-1.1.1l-2.fc34.aarch64.rpm"
+          },
+          "sha256:ac901ae730144d1e75b86d9991c1c6a9d6d0a44ce6e52b4d330df3a26d09e1ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/u/util-linux-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnsl2-1.3.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm"
+          },
+          "sha256:adb1b49ec7038eec956edd77d0ad2a72179b4f37c14548e3c9637d8a75c276a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.33-20.fc34.aarch64.rpm"
+          },
+          "sha256:adcd36cb0e582f5fb2d0465cf88bb813ffac17d25d6ec8aa608b647d008bebc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.3755-1.fc34.noarch.rpm"
+          },
+          "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-networkd-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/policycoreutils-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm"
+          },
+          "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libgpg-error-1.42-1.fc34.aarch64.rpm"
+          },
+          "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/os-prober-1.77-7.fc34.aarch64.rpm"
+          },
+          "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-pam-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-libs-5.2.5-5.fc34.aarch64.rpm"
+          },
+          "sha256:b30db4e3d9605e7263387ff91f91508667693d28e8b8835a2b7fcefd64f24388": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-oauthlib+signedtoken-3.0.2-9.fc34.noarch.rpm"
+          },
+          "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm"
+          },
+          "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-lib-0.3.15-2.fc34.aarch64.rpm"
+          },
+          "sha256:b5d5e7255c85c3aa9d63598ef140de35843ab2485adf1cb9a9130be80aa0297f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-six-1.15.0-5.fc34.noarch.rpm"
+          },
+          "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:b6687e9977e337e5d029de0d42cb79d57bd44f2f642450440756ba1a0494a113": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libedit-3.1-38.20210714cvs.fc34.aarch64.rpm"
+          },
+          "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libattr-2.5.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.aarch64.rpm"
+          },
+          "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cpio-2.13-10.fc34.aarch64.rpm"
+          },
+          "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-1.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm"
+          },
+          "sha256:bab19da8b6f553325decae00748f88fc0924b918136f065ab8995e1ebf5bde5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc34.noarch.rpm"
+          },
+          "sha256:bb078ccf6e7372cf22e55901c005517daff0b8cffa14fa3dec5e9804b4f65897": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmaxminddb-1.5.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm"
+          },
+          "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm"
+          },
+          "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mkpasswd-5.5.10-1.fc34.aarch64.rpm"
+          },
+          "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-syntax-10.36-4.fc34.noarch.rpm"
+          },
+          "sha256:bfd008fce37b2ec17dc4142c38a6e808c2e0031eed802a0253fca812989845d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iproute-tc-5.10.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:c04a67670d45f576c5a8b23fe64d5ce31b04ddf4792cbf78448fd4c96899f9c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnfnetlink-1.0.1-19.fc34.aarch64.rpm"
+          },
+          "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-rpm-macros-248.9-1.fc34.noarch.rpm"
+          },
+          "sha256:c20caffb4d2a500416dab0e8418a24ae5e25c02c831ae02ee10f97a0dcc80374": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-core-en-3.0-14.fc34.noarch.rpm"
+          },
+          "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm"
+          },
+          "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:c65c8f7313afc060a83bb588bc640bfd87ff609c4ae8fff370a92f992ac91031": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libXinerama-1.1.4-8.fc34.aarch64.rpm"
+          },
+          "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc34.aarch64.rpm"
+          },
+          "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-2.48-2.fc34.aarch64.rpm"
+          },
+          "sha256:c814f83bcf3cfc590d84897c810a087354cfb0c961dd232af5031cfe8bd63a37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-client-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-10.36-4.fc34.aarch64.rpm"
+          },
+          "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm"
+          },
+          "sha256:ca8f4843c8b23ce16b957143550d8dc83ae630cd64587fa2dd127e4ecbe9bb23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnetfilter_conntrack-1.0.8-2.fc34.aarch64.rpm"
+          },
+          "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.aarch64.rpm"
+          },
+          "sha256:cc4401d1e292b28d771a2038081b929b342ffa3b60358aed91697fdbc668546a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-prettytable-0.7.2-25.fc34.noarch.rpm"
+          },
+          "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.aarch64.rpm"
+          },
+          "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcrypt-1.9.3-3.fc34.aarch64.rpm"
+          },
+          "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-0.9.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc34.noarch.rpm"
+          },
+          "sha256:ce6e8e623dcb1ef8f3c1f59e03da39bc173f9555136ba60c6b2c23bc63d6f77b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gobject-base-3.40.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsigsegv-2.13-2.fc34.aarch64.rpm"
+          },
+          "sha256:cf18d61c8f526fe86cd24073dfdce942b6a463ea909ed5a59a5cc4378d9101a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcollection-0.7.0-47.fc34.aarch64.rpm"
+          },
+          "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/memstrack-0.2.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pigz-2.5-1.fc34.aarch64.rpm"
+          },
+          "sha256:d1c8a2302e64fc856aff6a05a78140986e89eddd8f110deb9ba78d44aebcd411": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/psmisc-23.4-1.fc34.aarch64.rpm"
+          },
+          "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-libs-29-2.fc34.aarch64.rpm"
+          },
+          "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bash-5.1.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:d5d622f60e97d43b095a98f2bb46982d91451e4e6018492da20944b294480af3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.6p1-5.fc34.aarch64.rpm"
+          },
+          "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.3.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:d6810c97f24d93cd54a61bb288ada8591a94e4083b5165e0719915bceb637504": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonschema-3.2.0-9.fc34.noarch.rpm"
+          },
+          "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/readline-8.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mpfr-4.1.0-7.fc34.aarch64.rpm"
+          },
+          "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-libs-3.0.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-9.fc34.aarch64.rpm"
+          },
+          "sha256:dbf3fb9e356236575a06e4fdcd532331f418236aa4ff4e024260c24be2b9a7cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-libselinux-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/json-c-0.14-8.fc34.aarch64.rpm"
+          },
+          "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/alternatives-1.15-2.fc34.aarch64.rpm"
+          },
+          "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/acl-2.3.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:e0dffa204780c20c16357a51b992351aa1cf9f9cdda6182939ecd0cd7ab2c2bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonpatch-1.21-14.fc34.noarch.rpm"
+          },
+          "sha256:e1e89027213f00ae1014bbb1253058ed8d5d476e7246921f03736ea129d2a162": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iproute-5.10.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:e1f1b9c4b78fe9d84a87d7de67fdd8559fe2bea9969ca1632d137de635d7e898": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-setools-4.4.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-0.3.15-2.fc34.aarch64.rpm"
+          },
+          "sha256:e530795e5c9bc27de609fcbbacdc43c226026fee95e47a1f783f1c03ba5d48ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-distro-1.5.0-5.fc34.noarch.rpm"
+          },
+          "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libutempter-1.2.1-4.fc34.aarch64.rpm"
+          },
+          "sha256:e76f1401d9e119eae4cc461c8b68e9eae075d4b69f61870cb5c19ba7d69cf1a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-policycoreutils-3.2-1.fc34.noarch.rpm"
+          },
+          "sha256:e7d1d0b85ac49d8b0c9dd3fce4613e6229ac8720cfb74c80a496b9f0beaa7a22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cloud-init-20.4-2.fc34.noarch.rpm"
+          },
+          "sha256:e9814c1b1a22b8cbd39413dc4f0eab452ef7380ce01f05ecab0e41e2d00ba3c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libdhash-0.5.0-47.fc34.aarch64.rpm"
+          },
+          "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm"
+          },
+          "sha256:ea8067f2310d30b31f7b1f13825b2a5a5e679c114fefd072267b6c369a365a63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-cryptography-3.4.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:eab8d30db6004f8c21247689cac52f143e1bde1da817db9761420cf3cf855c38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/initscripts-10.09-1.fc34.aarch64.rpm"
+          },
+          "sha256:eb88e660b9fd02e695a90c0266831b79e513c2f65ba5d6353e82726af96e9752": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-modular-34-2.noarch.rpm"
+          },
+          "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/krb5-libs-1.19.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:ebd4a9473543a5ca50ec5f9de069fc0c240527516ae262cf3e28a5d914b99cb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-libs-1.8.7-8.fc34.aarch64.rpm"
+          },
+          "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-1.02.175-1.fc34.aarch64.rpm"
+          },
+          "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:eddb9515d6d5300d0c0404e9a0cf07fea4a70691bdc2caaf273b9d29842544b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libXrandr-1.5.2-6.fc34.aarch64.rpm"
+          },
+          "sha256:ee147f5a7017de1c77abfbb79dd32eb97c923fc7c1b74c32bda6020b9025938c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpipeline-1.5.3-2.fc34.aarch64.rpm"
+          },
+          "sha256:eeaab0f9ac34c76cfabe75d99510a7c9ffb5b05fc9aba0d44062aaf530b945e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/plymouth-core-libs-0.9.5-2.20210331git1ea1020.fc34.aarch64.rpm"
+          },
+          "sha256:eecc86b828ad436a9f397d2f7acdf5705bfd36bcad3edd2da73f3acc94363411": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc34.noarch.rpm"
+          },
+          "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-5.39-7.fc34.aarch64.rpm"
+          },
+          "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm"
+          },
+          "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grubby-8.40-51.fc34.aarch64.rpm"
+          },
+          "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.25.10-5.fc34.noarch.rpm"
+          },
+          "sha256:f3c940f33c6c8edb73b98527e0fff17aa211e823f06e3f732762d0c86cc0268c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-100.fc34.aarch64.rpm"
+          },
+          "sha256:f444279e2a4c5d7d12a63fd6390345002b5b83013880b40e7bc79631805c74f1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libXext-1.3.4-6.fc34.aarch64.rpm"
+          },
+          "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-doc-2.33-20.fc34.noarch.rpm"
+          },
+          "sha256:f55223761bb4510578ca39cc52f410ca52040d28ad3389e3dc67a0f04a71dfa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libXfixes-6.0.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:f68c93c0461c149bb17282dededf421cbc1fbfa5ac133b59bd362526f59e0d57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-idna-2.10-3.fc34.noarch.rpm"
+          },
+          "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:f695ed244a1d9f3eb814947fb1da343d7d6fb3aaa2bf72965235e4b45a58a784": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.30.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm"
+          },
+          "sha256:f7c7dc1d8e5cf4776a1fde155871a2bb1fdd0676f897a43334cfbb60eb69e52a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/mokutil-0.4.0-4.fc34.aarch64.rpm"
+          },
+          "sha256:f7f8832ccaedd7ddad064956309478b9bf366f0576517356ee68481e196236cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-configobj-5.0.6-23.fc34.noarch.rpm"
+          },
+          "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm"
+          },
+          "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:f9b2e7232d0b2d33bf52993c31b43b31520601f52f44fe792acd6dee4d84afc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-oauthlib-3.0.2-9.fc34.noarch.rpm"
+          },
+          "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfdisk-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:fbe4ab6f2a2dee05ffb6d45519c29366bd50f61937a2792f5e831af1d1e257bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-nft-1.8.7-8.fc34.aarch64.rpm"
+          },
+          "sha256:fbf45cda87a05418a72f4bf3877da5ebcabbe68d393bc5bec007a8b01ef6bafe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-markupsafe-1.1.1-10.fc34.aarch64.rpm"
+          },
+          "sha256:fc4104e014beee44b5003e72a32e45e689936a4ffdcf07e119b02be3ed4ab8d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.17.3-6.fc34.aarch64.rpm"
+          },
+          "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lz4-libs-1.9.3-2.fc34.aarch64.rpm"
+          },
+          "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.8.1-10.fc34.aarch64.rpm"
+          },
+          "sha256:fd7dc918a1e3ad0114ecaa41d78c6652cc559271ad6653e5bba0bc780af35faa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libuser-0.63-4.fc34.aarch64.rpm"
+          },
+          "sha256:fdf6b777dd9639e3e37dca1910aa87b9fedf3ebe92b1911e41861805b0d361c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xen-libs-4.14.3-3.fc34.aarch64.rpm"
+          },
+          "sha256:feeb03f8685db40f81d8eb63e292e5199e667a14c3104b7209557c1b9dd3d638": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xen-licenses-4.14.3-3.fc34.aarch64.rpm"
+          },
+          "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.aarch64.rpm"
+          }
+        }
+      }
+    },
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.rpm",
+              "options": {
+                "gpgkeys": [
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n"
+                ],
+                "packages": [
+                  {
+                    "checksum": "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3e69e8412d5914ec01c5e82264833698e92a1b88a7c7b5ed9b1f0351fc91f5d2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6d1c024b295c423746b44f120cf36ceb0fd898f8ce5a276813d7c78a3c8ece52",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:adb1b49ec7038eec956edd77d0ad2a72179b4f37c14548e3c9637d8a75c276a1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
+                    "check_gpg": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "org.osbuild.selinux",
+              "options": {
+                "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+                "labels": {
+                  "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+                }
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.fedora33"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8"
+          }
+        },
+        {
+          "name": "org.osbuild.rpm",
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "packages": [
+              {
+                "checksum": "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:33b878000610ca3ba875b72f2a454e4fac9471f80579824304ca81e6f3e3f79d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e7d1d0b85ac49d8b0c9dd3fce4613e6229ac8720cfb74c80a496b9f0beaa7a22",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:79834af7f95c0d1e5dcf85b794819bd854197a52d2966594abdb3c3de0fcceb6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0f9ebdf7f08a506a8d1d6c4b4788dd7ca3dbb832509072b66def4da5b86d7862",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a0f1b653f889bb95e6edec2c525dfc71e280076b29394cf9c06ffa81ecd8b9fa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3fb05067cbd7fcf3283f2ab306c2dae668d818d3a69422e729c2ef62974810a5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:37cda2c179e4311a1aeeb0ea8d07d3eacc8ea8bf97d122ec22cd596c61b8e770",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:47c92a952b162b7bafbe49a7e409a7a81825adc77b3e139651913d52d8aa84fb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6d3301f6e99d9728698822e81fc2d170694cc367b7e7fea5c7a019f7b1a6073b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eab8d30db6004f8c21247689cac52f143e1bde1da817db9761420cf3cf855c38",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e1e89027213f00ae1014bbb1253058ed8d5d476e7246921f03736ea129d2a162",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bfd008fce37b2ec17dc4142c38a6e808c2e0031eed802a0253fca812989845d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3381367f7142fca98999f2bf737ff1dcc895af2e2550fe35538dd03718964c45",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:51247521cd48b5605859881a22ca9be89c80d0a27b98d1b80c17ad821c79f679",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4b65dc9856b0d0ce555dd9bce88dcfb680ba689a2c6b88ae9f84b016553d96af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9f2f2a20f285a2ac306ce72475beecf967cf92308b426aafca68215a6c3c12ca",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c20caffb4d2a500416dab0e8418a24ae5e25c02c831ae02ee10f97a0dcc80374",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:82cbc5e0339e832d2fc0160541c30f3dee59b3d28d83907ae7b55e22d5092c51",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:82b51ca6bec551d74a6d8c43194b0fd4e8bfdf19d1d68b58c1787723edd88bd0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7a590bbf63577d619629239d6a8719b6d68053649986059dccf3e624fe2a3f03",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f444279e2a4c5d7d12a63fd6390345002b5b83013880b40e7bc79631805c74f1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c65c8f7313afc060a83bb588bc640bfd87ff609c4ae8fff370a92f992ac91031",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eddb9515d6d5300d0c0404e9a0cf07fea4a70691bdc2caaf273b9d29842544b4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aad99c9171fdf21ad93ed55c8aed44beacc5075ff522b2360609a536f7dfc928",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:12b7666d61e7bd8b3b5b1a7c57539964531802287e592e33449e039799ea2071",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6046f881a5c0822c30bd037aec040c65594b6328b1c0d72b6681fe1575eac765",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cf18d61c8f526fe86cd24073dfdce942b6a463ea909ed5a59a5cc4378d9101a1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e9814c1b1a22b8cbd39413dc4f0eab452ef7380ce01f05ecab0e41e2d00ba3c0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1014763656c1578ae96b38fd3e87c4d07b548cb8423688cc928d0f9762d43a44",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:45d38ed1d2247e17e3e8faf7d6755216c5ef4422736129f55b712f160532d8f2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bb078ccf6e7372cf22e55901c005517daff0b8cffa14fa3dec5e9804b4f65897",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:79864051052858a1c95538888ca61a43b509b6eae4ae269ae6ea7bf8b076a2b8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11a0c09b716f8071f0484278bec326fb82e93d987376c8b38188d1febcd5381d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ca8f4843c8b23ce16b957143550d8dc83ae630cd64587fa2dd127e4ecbe9bb23",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c04a67670d45f576c5a8b23fe64d5ce31b04ddf4792cbf78448fd4c96899f9c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2371cf0854393fc6c8ab6457b8e662f1046b654cc01ae65407b09be704c5f2eb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a1a996e8da4733b14c449b69e34484fe4f2b88c0f2963145bf0402cf04baf30e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:93708bb1a4355a1d3659cd80a8d5650f8d197b8af7c591219d46e2b520214825",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ee147f5a7017de1c77abfbb79dd32eb97c923fc7c1b74c32bda6020b9025938c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:686e015d81c1be2e6b88c7e8a50d45109d7273143a034caa9c935ecd014e1c62",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:56634e58fc7499d719a3f431dd188e8f2655ebfa402e94ce105794a47debf45b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2027da420b35a0b70ae5045d2fd79cdccb820f03e5ff4018a2205d3d413ff1af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5595c4bc0ad8072173df3858efdebea0fabb0fdf74a5ca2edb020af66e0f3716",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a60e3e035883de829c5778417d316ffc47a0b4a304953e3fdc44def8f2f172ab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7721bc647c521d96e07e665f7da306326d3bd1499d610c58552317815aaf3c45",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61ba1ecff8f8578cbd3445df596d001067bb0281745191ac168fcc6079d8e1cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f7c7dc1d8e5cf4776a1fde155871a2bb1fdd0676f897a43334cfbb60eb69e52a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:96c7a26b707d4038a50b4ab0fd8d79ba3997466bed543f13c10d30e7ec256b5e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:27920113489e3260e58d4a033d31401c6ae22ded72895c6b8c0e43ebf89a62df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6a864bec34b7d39de3e6ae1e39ec07fa3a2d21837a9a2d7151228d7f0ac38e73",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:217b9e2d44c03ba92900f5b517b21358cee4c764e104515e55efd5ef9d838f22",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eeaab0f9ac34c76cfabe75d99510a7c9ffb5b05fc9aba0d44062aaf530b945e5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:32d76b30fca1050db004ab86e4e2079c3b3bf13765d3a1d6d0f5a5c2a41c91c0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d1c8a2302e64fc856aff6a05a78140986e89eddd8f110deb9ba78d44aebcd411",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:820fee96d610178c7c7b8ce2b115bd02063d2f6dfcae5da4bf5d411de0b575f7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7d00ccbb224617a00f58053afd88e7a49062446f1306ba39c72b78d20aeee1ef",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9ce3f0c0904ac22ab5769babebf43e7dcdb488b0ef999b2e9e88a5b5eb424e51",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f7f8832ccaedd7ddad064956309478b9bf366f0576517356ee68481e196236cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ea8067f2310d30b31f7b1f13825b2a5a5e679c114fefd072267b6c369a365a63",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d2c28837f0573ae2647b8fbba85f7c502f9c3da0a3eab1c9ba121de4a1a6cee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:23f7cc188684a9e9ba8f0ffbcd9ecb28aaeba9a6e596e1c56362d8a1f51a492d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e530795e5c9bc27de609fcbbacdc43c226026fee95e47a1f783f1c03ba5d48ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ce6e8e623dcb1ef8f3c1f59e03da39bc173f9555136ba60c6b2c23bc63d6f77b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f68c93c0461c149bb17282dededf421cbc1fbfa5ac133b59bd362526f59e0d57",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2414cb7345bc193f7ff7983c020c8b0e706aab013ee30af5d457d35c4de4a698",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e0dffa204780c20c16357a51b992351aa1cf9f9cdda6182939ecd0cd7ab2c2bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1b1af6b54050ec223c3289b107a9695a686c9d46d17a80ec9cd5d0201ec5d544",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d6810c97f24d93cd54a61bb288ada8591a94e4083b5165e0719915bceb637504",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9cc240ac305a862146e85d8dcc4ad981f5233a58b6901ecfac691d0b39966b49",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:131adc47f044c9f600f5295ded0f5431cda57fa7276100c3ec81c9d1ce3fa6f7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dbf3fb9e356236575a06e4fdcd532331f418236aa4ff4e024260c24be2b9a7cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:87749765dbe5ce8f098279170c39bb8a89abbf3f8430c2a6dbfb973117e11dfa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fbf45cda87a05418a72f4bf3877da5ebcabbe68d393bc5bec007a8b01ef6bafe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b30db4e3d9605e7263387ff91f91508667693d28e8b8835a2b7fcefd64f24388",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f9b2e7232d0b2d33bf52993c31b43b31520601f52f44fe792acd6dee4d84afc8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:23e3ed871799a9209915359f71660babf451b0b44902e3ed488b7b22aff37718",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e76f1401d9e119eae4cc461c8b68e9eae075d4b69f61870cb5c19ba7d69cf1a3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cc4401d1e292b28d771a2038081b929b342ffa3b60358aed91697fdbc668546a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:32220dc513a6ebcd4994e7140ecb5859108baf44d12fe6b1f0c0459dbefc54e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:70a90c6c682016e91fb4745eedbd23f28e150a38b01d18f85ce4e50fb4e0ca6c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4a74ae08a713e9b4e74ff27bfaf57374312370402f90e2796e66c504557ae189",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:92e42b63fcc56dd21984abb722e8fa7ebbb58f6d54c529ac11871b4bbc63b290",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6297d7eee103c679a0f1ea411568d3940af3fe8f38e19388a1544df70bda8b3c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e1f1b9c4b78fe9d84a87d7de67fdd8559fe2bea9969ca1632d137de635d7e898",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5d5e7255c85c3aa9d63598ef140de35843ab2485adf1cb9a9130be80aa0297f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4e45f4c24997b231cb6fb8d31e9d7e0aae40c1135337194d62ce98c197547dbf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1c01e888717888901aef3fee5c02841a83f83b3d9d962bc3cd495a88a5e3ab5c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:164e1c0e3e8c89aeda4f272b3158932649a69b16aea058105117a64d3cdef517",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:23a539a271c92906ac0a12c7d877c7f4d0ad8e6b9bbd8642b5232f861b79ed22",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:40e231991444a589b17e0b5b338be8874d071e3d17e210aba6f6639620775f79",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a86ec8f7284ee01574bb06bba726d8609e464f41d003215097e626c583f73ed0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3228a36807658c7e4d881013aa26f877353388bf3bac6c948984f751c264a359",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:98370c7be5b5fc629505843db497c9d82d243234d31c65e2b3afd8538570e9ab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4baf8ba6a5ed4609695f79a8bbc8324d7efa322a3573c8c5fa3942361eac0f1c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f695ed244a1d9f3eb814947fb1da343d7d6fb3aaa2bf72965235e4b45a58a784",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5e0a71bc53cae651289a962699fc17fd9f16a474398cb6b7dfe3d239876b6ed4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:148aea26e381b33badde0ac2ae716a78f7b565f54f0b6970189a89713f335eaf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7c24e53e12891046bb6721e624cf9effd1946c0d076464427c2a86b29671318e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61a9dbd9020e29012947978acf33a0c1150e6c3e078de372f1e38fb9c4ef529a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2968703dd232a37620a0ae12146c9d1ec5220f62c40bfb0ecfc60b621d8e1eac",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0ac62147585be2dae960ed37a3a0c3eb2f8a95d0fd0993991c8bf7238b1d5e27",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11cd6fae157eb9e4800163633b57bcce21d59a1df4b86a99ba03707b6cee0cfc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1feb6a045cb3e95e3c8e0112ecb4b8ffeb9986a503b52c5497fefce217846b90",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9aee2549d3ff9e5652dffaaa9b91ab7a243687cc2a85b8e45f4290d53d44702d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8fbfbaf3b107b540428634c19c4cb05e7c46f9672cfbf14d1f44306ed3413a46",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3e69e8412d5914ec01c5e82264833698e92a1b88a7c7b5ed9b1f0351fc91f5d2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6d1c024b295c423746b44f120cf36ceb0fd898f8ce5a276813d7c78a3c8ece52",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eb88e660b9fd02e695a90c0266831b79e513c2f65ba5d6353e82726af96e9752",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:87fa60c9e5fd73e064450bb155b36501a1da34f06df257773a0ce7eb7e84e5a3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1bbb7ec72916bb641b7c477a7bbd7b2ad57325f368846e34c26c592bc11a6d8e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:059f825547fe257247656c29049ebc7bfa1d54a17479f3dcfeff37fbab7084bd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0f2589fcd0d6387a2c13d7533b627b53e9d8f0b92ac497d95926646896ac1e6f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:71427f6f8f3f6370dccde81a76d566ff17144e7e375381ef13e04a661e63cba1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e23d7345b89f14f69026da5aa9c730b601b78f8e2fb6c9ead7d5af4ecb1cc92",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:69de3dd68dc2b76e2a85c710a51e9c8acefe595d6ac5d9f19113c4062a5f0d92",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ebd4a9473543a5ca50ec5f9de069fc0c240527516ae262cf3e28a5d914b99cb1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fbe4ab6f2a2dee05ffb6d45519c29366bd50f61937a2792f5e831af1d1e257bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:55833f669ed1dbd32e79f494824c309b71bc373d2bf28eb5cdb663459dc6f7cd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0176b42c6b51fb3c829f168571527a3559b6a9c8cc5f847b70e3c40fb69f89e4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3c940f33c6c8edb73b98527e0fff17aa211e823f06e3f732762d0c86cc0268c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7cc0891a9e7c19757c03cba6c8155738d9db9f5774380c412106adf0eca44077",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3901de67d83f50b24768e660ac9633f8ebdf97ba3dcd22726927ff3e2c0ddb68",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6ccc5b659a2b8328a7a80e63cf8b4b9e819aa8de1f64b7c6ab5e76b5f45586d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f55223761bb4510578ca39cc52f410ca52040d28ad3389e3dc67a0f04a71dfa5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3e81f34c490661423c064fb9426cbacfc4a1f5c254aa40f98343d7cdc0f07603",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b6687e9977e337e5d029de0d42cb79d57bd44f2f642450440756ba1a0494a113",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8f2ae60a71d008a9d67c151e088e9b420b07ccbaada55e0d06a66a3b8a1634b9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:86cb1e5e80642b1575df57287c9549749603bf94b1ba652995b59ea45ac4272b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:330a36b1dabaf76daafeff3f7fd7a276880bf65d790ee84cb823a1958a4d99d7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b3bba1d61529a1dde47f234f34d0fdee07a38aa5958d87e30357ea04bbff142",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac901ae730144d1e75b86d9991c1c6a9d6d0a44ce6e52b4d330df3a26d09e1ff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3fdab509a59e0a765364d6f119c38c796a4420cc49b46595a37d98eb649d6c80",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:60ddc7b15e9742ff9995d1b336489b92721e21a45034d20f20d2fc800e419d1c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4123331b5d06f91ff31d147e4769806052f59b620e7677f69b0073eaf7beccb6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a72bb74400b447af71600da141aebdc46da7776ef875abfdd635881f939891d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fd7dc918a1e3ad0114ecaa41d78c6652cc559271ad6653e5bba0bc780af35faa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8ab032e2a86f300d978e521ab030db1e7bb7eeccca205a5d2a4d68b51566f43f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:007f1604e1a0a51b226a758934efcce905cd5d285437068847c4995821513f1f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5dcac7772d73ad1523f87cbeb1dc76dd62af4d2bb73dd06896a47d2bcf503e5e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d5d622f60e97d43b095a98f2bb46982d91451e4e6018492da20944b294480af3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:39160ef65b3519a70f14f992edc5967380ef86a6940896751db681781961903d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:139b9453b2038e52767d0102def782d58d558ca0603757eb0c97ddda28af1466",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59cc4d563ecb4c8b517f5dd7505f1cda297f950f32fc700344aa7789b69ca99c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:00c29524aad123ec44056e60b9625e75ac428a6c751878a05fadbca7e956c249",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bab19da8b6f553325decae00748f88fc0924b918136f065ab8995e1ebf5bde5b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2aa0bf433e2f3c7d09613dd1f9b2853a8946bc26051ba9e747cd29518679958f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:50f8013df88ebb6fbe7ef8a7720815196bced2e81e6e78d8932f53b990f73e1f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fc4104e014beee44b5003e72a32e45e689936a4ffdcf07e119b02be3ed4ab8d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eecc86b828ad436a9f397d2f7acdf5705bfd36bcad3edd2da73f3acc94363411",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:394ddf6f634c70dcd1ba5763af7be37145b5ac1749160e199f95b524767eef82",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:94f598b1f39bd6e6a212c873d38b4e466b9c5dbea34c6fdbf0c58cf4d9ec4477",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c814f83bcf3cfc590d84897c810a087354cfb0c961dd232af5031cfe8bd63a37",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:668a30c6f526e51705af9cb9d98fd11f279f5e86f7d905876ae9a86f486a8c36",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7285fcc290a8af2cf845beb845e661cd4c06c2275417b15eb507824dedec7c69",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0db1be9a78e5f329a519066a7b37379f6c73fe579154e0a6a26b2dcb4154ccd6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:43b0b5d425a2041daeb6b41db2858abda1f92ecc38c6125f7de3b7502580a9f7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:adcd36cb0e582f5fb2d0465cf88bb813ffac17d25d6ec8aa608b647d008bebc3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1af86c0a8c11e44958b022bf7dad5f48ad974fa8537cf41a12d5b0643444b1dc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fdf6b777dd9639e3e37dca1910aa87b9fedf3ebe92b1911e41861805b0d361c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:feeb03f8685db40f81d8eb63e292e5199e667a14c3104b7209557c1b9dd3d638",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30bc3583e503e0f459e323b27551f7b9a8ab784de15437b5b29f447b31f8d9cd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
+                "check_gpg": true
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.hostname",
+          "options": {
+            "hostname": "localhost.localdomain"
+          }
+        },
+        {
+          "name": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "redhat": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              },
+              {
+                "uuid": "46BB-8120",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "umask=0077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "uefi": {
+              "vendor": "fedora"
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
+        "options": {
+          "format": "qcow2",
+          "filename": "disk.qcow2",
+          "size": 2147483648,
+          "ptuuid": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
+          "pttype": "gpt",
+          "partitions": [
+            {
+              "start": 2048,
+              "size": 972800,
+              "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+              "uuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
+              "filesystem": {
+                "type": "vfat",
+                "uuid": "46BB-8120",
+                "label": "EFI-SYSTEM",
+                "mountpoint": "/boot/efi"
+              }
+            },
+            {
+              "start": 976896,
+              "uuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build-packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/acl-2.3.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/alternatives-1.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/basesystem-11-11.fc34.noarch.rpm",
+        "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bash-5.1.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bzip2-libs-1.0.8-6.fc34.aarch64.rpm",
+        "checksum": "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cpio-2.13-10.fc34.aarch64.rpm",
+        "checksum": "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cyrus-sasl-lib-2.1.27-8.fc34.aarch64.rpm",
+        "checksum": "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-1.12.20-3.fc34.aarch64.rpm",
+        "checksum": "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-common-1.12.20-3.fc34.noarch.rpm",
+        "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm",
+        "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm",
+        "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-1.02.175-1.fc34.aarch64.rpm",
+        "checksum": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-libs-1.02.175-1.fc34.aarch64.rpm",
+        "checksum": "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/filesystem-3.14-5.fc34.aarch64.rpm",
+        "checksum": "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/findutils-4.8.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "11.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fuse-libs-2.9.9-11.fc34.aarch64.rpm",
+        "checksum": "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-all-langpacks-5.1.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.19",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gdbm-libs-1.19-2.fc34.aarch64.rpm",
+        "checksum": "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-libs-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gmp-6.2.0-6.fc34.aarch64.rpm",
+        "checksum": "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm",
+        "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grep-3.6-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "51.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grubby-8.40-51.fc34.aarch64.rpm",
+        "checksum": "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm",
+        "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.14",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/json-c-0.14-8.fc34.aarch64.rpm",
+        "checksum": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-misc-2.4.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/keyutils-libs-1.6.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.5",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "11.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.aarch64.rpm",
+        "checksum": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.aarch64.rpm",
+        "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libattr-2.5.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libblkid-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbrotli-1.0.9-4.fc34.aarch64.rpm",
+        "checksum": "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-2.48-2.fc34.aarch64.rpm",
+        "checksum": "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-ng-0.8.2-4.fc34.aarch64.rpm",
+        "checksum": "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm",
+        "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfdisk-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "28.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.aarch64.rpm",
+        "checksum": "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.42",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libgpg-error-1.42-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-1.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.43.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnghttp2-1.43.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnl3-3.5.0-6.fc34.aarch64.rpm",
+        "checksum": "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnsl2-1.3.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpsl-0.21.1-3.fc34.aarch64.rpm",
+        "checksum": "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm",
+        "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsemanage-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsigsegv-2.13-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.17",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm",
+        "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtasn1-4.16.0-4.fc34.aarch64.rpm",
+        "checksum": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
+        "check_gpg": true
+      },
+      {
+        "name": "libtextstyle",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtextstyle-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.aarch64.rpm",
+        "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
+        "check_gpg": true
+      },
+      {
+        "name": "liburing",
+        "epoch": 0,
+        "version": "0.7",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm",
+        "checksum": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
+        "check_gpg": true
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libutempter-1.2.1-4.fc34.aarch64.rpm",
+        "checksum": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libuuid-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lz4-libs-1.9.3-2.fc34.aarch64.rpm",
+        "checksum": "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/memstrack-0.2.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-6.2-4.20200222.fc34.aarch64.rpm",
+        "checksum": "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm",
+        "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm",
+        "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm",
+        "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/openssl-pkcs11-0.4.11-2.fc34.aarch64.rpm",
+        "checksum": "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/os-prober-1.77-7.fc34.aarch64.rpm",
+        "checksum": "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-0.23.22-3.fc34.aarch64.rpm",
+        "checksum": "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-trust-0.23.22-3.fc34.aarch64.rpm",
+        "checksum": "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.44",
+        "release": "3.fc34.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre-8.44-3.fc34.1.aarch64.rpm",
+        "checksum": "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-10.36-4.fc34.aarch64.rpm",
+        "checksum": "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-syntax-10.36-4.fc34.noarch.rpm",
+        "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pigz-2.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/policycoreutils-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/popt-1.18-4.fc34.aarch64.rpm",
+        "checksum": "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm",
+        "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20190417",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
+        "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/readline-8.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sed-4.8-7.fc34.aarch64.rpm",
+        "checksum": "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.7",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/setup-2.13.7-3.fc34.noarch.rpm",
+        "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.34.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm",
+        "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-0.3.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-lib-0.3.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/u/util-linux-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-5.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-libs-5.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "26.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/z/zlib-1.2.11-26.fc34.aarch64.rpm",
+        "checksum": "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-libs-3.0.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm",
+        "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-8.32-30.fc34.aarch64.rpm",
+        "checksum": "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-common-8.32-30.fc34.aarch64.rpm",
+        "checksum": "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-2.9.6-27.fc34.aarch64.rpm",
+        "checksum": "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.3.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/curl-7.76.1-12.fc34.aarch64.rpm",
+        "checksum": "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc34.aarch64.rpm",
+        "checksum": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc34.noarch.rpm",
+        "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-gpg-keys-34-2.noarch.rpm",
+        "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-34-39.noarch.rpm",
+        "checksum": "sha256:3e69e8412d5914ec01c5e82264833698e92a1b88a7c7b5ed9b1f0351fc91f5d2",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-common-34-39.noarch.rpm",
+        "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-34-39.noarch.rpm",
+        "checksum": "sha256:6d1c024b295c423746b44f120cf36ceb0fd898f8ce5a276813d7c78a3c8ece52",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-34-2.noarch.rpm",
+        "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-5.39-7.fc34.aarch64.rpm",
+        "checksum": "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.aarch64.rpm",
+        "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.68.4",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.aarch64.rpm",
+        "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-common-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-doc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-doc-2.33-20.fc34.noarch.rpm",
+        "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:adb1b49ec7038eec956edd77d0ad2a72179b4f37c14548e3c9637d8a75c276a1",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/gnutls-3.7.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm",
+        "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-legacy-libs-1.8.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-libs-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/krb5-libs-1.19.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.aarch64.rpm",
+        "checksum": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "49.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm",
+        "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcrypt-1.9.3-3.fc34.aarch64.rpm",
+        "checksum": "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "37.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libibverbs-37.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libidn2-2.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpcap-1.10.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm",
+        "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
+        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsepol-3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-0.9.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-config-0.9.6-1.fc34.noarch.rpm",
+        "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "0.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtirpc-1.3.2-0.fc34.aarch64.rpm",
+        "checksum": "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc34.aarch64.rpm",
+        "checksum": "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxkbcommon-1.3.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxml2-2.9.12-4.fc34.aarch64.rpm",
+        "checksum": "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mkpasswd-5.5.10-1.fc34.aarch64.rpm",
+        "checksum": "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mpfr-4.1.0-7.fc34.aarch64.rpm",
+        "checksum": "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/nettle-3.7.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.57",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openldap-2.4.57-6.fc34.aarch64.rpm",
+        "checksum": "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssl-libs-1.1.1l-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pam-1.5.1-7.fc34.aarch64.rpm",
+        "checksum": "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "1.fc34.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/procps-ng-3.3.17-1.fc34.1.aarch64.rpm",
+        "checksum": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-setuptools-wheel-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.9.9-2.fc34.noarch.rpm",
+        "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-3.9.9-2.fc34.aarch64.rpm",
+        "checksum": "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libs-3.9.9-2.fc34.aarch64.rpm",
+        "checksum": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pip-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
+        "check_gpg": true
+      },
+      {
+        "name": "qemu-img",
+        "epoch": 2,
+        "version": "5.2.0",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm",
+        "checksum": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.8.1",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.8.1-10.fc34.aarch64.rpm",
+        "checksum": "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-networkd-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-pam-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-rpm-macros",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-rpm-macros-248.9-1.fc34.noarch.rpm",
+        "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
+        "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "26.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/which-2.21-26.fc34.aarch64.rpm",
+        "checksum": "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/whois-nls-5.5.10-1.fc34.noarch.rpm",
+        "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
+        "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm",
+        "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
+        "check_gpg": true
+      }
+    ],
+    "packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/acl-2.3.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/alternatives-1.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/basesystem-11-11.fc34.noarch.rpm",
+        "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bash-5.1.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bzip2-libs-1.0.8-6.fc34.aarch64.rpm",
+        "checksum": "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4",
+        "check_gpg": true
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/checkpolicy-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:33b878000610ca3ba875b72f2a454e4fac9471f80579824304ca81e6f3e3f79d",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "20.4",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cloud-init-20.4-2.fc34.noarch.rpm",
+        "checksum": "sha256:e7d1d0b85ac49d8b0c9dd3fce4613e6229ac8720cfb74c80a496b9f0beaa7a22",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cpio-2.13-10.fc34.aarch64.rpm",
+        "checksum": "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cyrus-sasl-lib-2.1.27-8.fc34.aarch64.rpm",
+        "checksum": "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-1.12.20-3.fc34.aarch64.rpm",
+        "checksum": "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-common-1.12.20-3.fc34.noarch.rpm",
+        "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm",
+        "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
+        "check_gpg": true
+      },
+      {
+        "name": "dejavu-sans-fonts",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "16.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dejavu-sans-fonts-2.37-16.fc34.noarch.rpm",
+        "checksum": "sha256:79834af7f95c0d1e5dcf85b794819bd854197a52d2966594abdb3c3de0fcceb6",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm",
+        "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-1.02.175-1.fc34.aarch64.rpm",
+        "checksum": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-libs-1.02.175-1.fc34.aarch64.rpm",
+        "checksum": "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/efibootmgr-16-10.fc34.aarch64.rpm",
+        "checksum": "sha256:0f9ebdf7f08a506a8d1d6c4b4788dd7ca3dbb832509072b66def4da5b86d7862",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "37",
+        "release": "15.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/efivar-libs-37-15.fc34.aarch64.rpm",
+        "checksum": "sha256:a0f1b653f889bb95e6edec2c525dfc71e280076b29394cf9c06ffa81ecd8b9fa",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/filesystem-3.14-5.fc34.aarch64.rpm",
+        "checksum": "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/findutils-4.8.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501",
+        "check_gpg": true
+      },
+      {
+        "name": "fonts-filesystem",
+        "epoch": 1,
+        "version": "2.0.5",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fonts-filesystem-2.0.5-5.fc34.noarch.rpm",
+        "checksum": "sha256:3fb05067cbd7fcf3283f2ab306c2dae668d818d3a69422e729c2ef62974810a5",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "11.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fuse-libs-2.9.9-11.fc34.aarch64.rpm",
+        "checksum": "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-all-langpacks-5.1.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.19",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gdbm-libs-1.19-2.fc34.aarch64.rpm",
+        "checksum": "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-libs-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gmp-6.2.0-6.fc34.aarch64.rpm",
+        "checksum": "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm",
+        "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grep-3.6-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/groff-base-1.22.4-7.fc34.aarch64.rpm",
+        "checksum": "sha256:37cda2c179e4311a1aeeb0ea8d07d3eacc8ea8bf97d122ec22cd596c61b8e770",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "51.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grubby-8.40-51.fc34.aarch64.rpm",
+        "checksum": "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm",
+        "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/h/hostname-3.23-4.fc34.aarch64.rpm",
+        "checksum": "sha256:47c92a952b162b7bafbe49a7e409a7a81825adc77b3e139651913d52d8aa84fb",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "49",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/inih-49-3.fc34.aarch64.rpm",
+        "checksum": "sha256:6d3301f6e99d9728698822e81fc2d170694cc367b7e7fea5c7a019f7b1a6073b",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.09",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/initscripts-10.09-1.fc34.aarch64.rpm",
+        "checksum": "sha256:eab8d30db6004f8c21247689cac52f143e1bde1da817db9761420cf3cf855c38",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.10.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iproute-5.10.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e1e89027213f00ae1014bbb1253058ed8d5d476e7246921f03736ea129d2a162",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute-tc",
+        "epoch": 0,
+        "version": "5.10.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iproute-tc-5.10.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:bfd008fce37b2ec17dc4142c38a6e808c2e0031eed802a0253fca812989845d1",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.11",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ipset-7.11-1.fc34.aarch64.rpm",
+        "checksum": "sha256:3381367f7142fca98999f2bf737ff1dcc895af2e2550fe35538dd03718964c45",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.11",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ipset-libs-7.11-1.fc34.aarch64.rpm",
+        "checksum": "sha256:51247521cd48b5605859881a22ca9be89c80d0a27b98d1b80c17ad821c79f679",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20210202",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iputils-20210202-2.fc34.aarch64.rpm",
+        "checksum": "sha256:4b65dc9856b0d0ce555dd9bce88dcfb680ba689a2c6b88ae9f84b016553d96af",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/jansson-2.13.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:9f2f2a20f285a2ac306ce72475beecf967cf92308b426aafca68215a6c3c12ca",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.14",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/json-c-0.14-8.fc34.aarch64.rpm",
+        "checksum": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-misc-2.4.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/keyutils-libs-1.6.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.5",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-core-en-3.0-14.fc34.noarch.rpm",
+        "checksum": "sha256:c20caffb4d2a500416dab0e8418a24ae5e25c02c831ae02ee10f97a0dcc80374",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-font-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-core-font-en-3.0-14.fc34.noarch.rpm",
+        "checksum": "sha256:82cbc5e0339e832d2fc0160541c30f3dee59b3d28d83907ae7b55e22d5092c51",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-en-3.0-14.fc34.noarch.rpm",
+        "checksum": "sha256:82b51ca6bec551d74a6d8c43194b0fd4e8bfdf19d1d68b58c1787723edd88bd0",
+        "check_gpg": true
+      },
+      {
+        "name": "libXau",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libXau-1.0.9-6.fc34.aarch64.rpm",
+        "checksum": "sha256:7a590bbf63577d619629239d6a8719b6d68053649986059dccf3e624fe2a3f03",
+        "check_gpg": true
+      },
+      {
+        "name": "libXext",
+        "epoch": 0,
+        "version": "1.3.4",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libXext-1.3.4-6.fc34.aarch64.rpm",
+        "checksum": "sha256:f444279e2a4c5d7d12a63fd6390345002b5b83013880b40e7bc79631805c74f1",
+        "check_gpg": true
+      },
+      {
+        "name": "libXinerama",
+        "epoch": 0,
+        "version": "1.1.4",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libXinerama-1.1.4-8.fc34.aarch64.rpm",
+        "checksum": "sha256:c65c8f7313afc060a83bb588bc640bfd87ff609c4ae8fff370a92f992ac91031",
+        "check_gpg": true
+      },
+      {
+        "name": "libXrandr",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libXrandr-1.5.2-6.fc34.aarch64.rpm",
+        "checksum": "sha256:eddb9515d6d5300d0c0404e9a0cf07fea4a70691bdc2caaf273b9d29842544b4",
+        "check_gpg": true
+      },
+      {
+        "name": "libXrender",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libXrender-0.9.10-14.fc34.aarch64.rpm",
+        "checksum": "sha256:aad99c9171fdf21ad93ed55c8aed44beacc5075ff522b2360609a536f7dfc928",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.aarch64.rpm",
+        "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libattr-2.5.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbasicobjects-0.1.1-47.fc34.aarch64.rpm",
+        "checksum": "sha256:12b7666d61e7bd8b3b5b1a7c57539964531802287e592e33449e039799ea2071",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libblkid-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbrotli-1.0.9-4.fc34.aarch64.rpm",
+        "checksum": "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-2.48-2.fc34.aarch64.rpm",
+        "checksum": "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-ng-0.8.2-4.fc34.aarch64.rpm",
+        "checksum": "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcbor-0.7.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:6046f881a5c0822c30bd037aec040c65594b6328b1c0d72b6681fe1575eac765",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcollection-0.7.0-47.fc34.aarch64.rpm",
+        "checksum": "sha256:cf18d61c8f526fe86cd24073dfdce942b6a463ea909ed5a59a5cc4378d9101a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libdhash-0.5.0-47.fc34.aarch64.rpm",
+        "checksum": "sha256:e9814c1b1a22b8cbd39413dc4f0eab452ef7380ce01f05ecab0e41e2d00ba3c0",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm",
+        "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfdisk-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "28.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.aarch64.rpm",
+        "checksum": "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfido2-1.6.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:1014763656c1578ae96b38fd3e87c4d07b548cb8423688cc928d0f9762d43a44",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.42",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libgpg-error-1.42-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libini_config-1.3.1-47.fc34.aarch64.rpm",
+        "checksum": "sha256:45d38ed1d2247e17e3e8faf7d6755216c5ef4422736129f55b712f160532d8f2",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-1.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmaxminddb-1.5.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bb078ccf6e7372cf22e55901c005517daff0b8cffa14fa3dec5e9804b4f65897",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "13.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmnl-1.0.4-13.fc34.aarch64.rpm",
+        "checksum": "sha256:79864051052858a1c95538888ca61a43b509b6eae4ae269ae6ea7bf8b076a2b8",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.7",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libndp-1.7-7.fc34.aarch64.rpm",
+        "checksum": "sha256:11a0c09b716f8071f0484278bec326fb82e93d987376c8b38188d1febcd5381d",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnetfilter_conntrack-1.0.8-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ca8f4843c8b23ce16b957143550d8dc83ae630cd64587fa2dd127e4ecbe9bb23",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "19.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnfnetlink-1.0.1-19.fc34.aarch64.rpm",
+        "checksum": "sha256:c04a67670d45f576c5a8b23fe64d5ce31b04ddf4792cbf78448fd4c96899f9c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.1.9",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnftnl-1.1.9-2.fc34.aarch64.rpm",
+        "checksum": "sha256:2371cf0854393fc6c8ab6457b8e662f1046b654cc01ae65407b09be704c5f2eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.43.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnghttp2-1.43.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnl3-3.5.0-6.fc34.aarch64.rpm",
+        "checksum": "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnsl2-1.3.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpath_utils-0.2.1-47.fc34.aarch64.rpm",
+        "checksum": "sha256:a1a996e8da4733b14c449b69e34484fe4f2b88c0f2963145bf0402cf04baf30e",
+        "check_gpg": true
+      },
+      {
+        "name": "libpciaccess",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpciaccess-0.16-4.fc34.aarch64.rpm",
+        "checksum": "sha256:93708bb1a4355a1d3659cd80a8d5650f8d197b8af7c591219d46e2b520214825",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpipeline-1.5.3-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ee147f5a7017de1c77abfbb79dd32eb97c923fc7c1b74c32bda6020b9025938c",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpsl-0.21.1-3.fc34.aarch64.rpm",
+        "checksum": "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libref_array-0.1.5-47.fc34.aarch64.rpm",
+        "checksum": "sha256:686e015d81c1be2e6b88c7e8a50d45109d7273143a034caa9c935ecd014e1c62",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm",
+        "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsemanage-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsigsegv-2.13-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.17",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm",
+        "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtalloc-2.3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:56634e58fc7499d719a3f431dd188e8f2655ebfa402e94ce105794a47debf45b",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtasn1-4.16.0-4.fc34.aarch64.rpm",
+        "checksum": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.3",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtdb-1.4.3-6.fc34.aarch64.rpm",
+        "checksum": "sha256:2027da420b35a0b70ae5045d2fd79cdccb820f03e5ff4018a2205d3d413ff1af",
+        "check_gpg": true
+      },
+      {
+        "name": "libtextstyle",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtextstyle-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.aarch64.rpm",
+        "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
+        "check_gpg": true
+      },
+      {
+        "name": "liburing",
+        "epoch": 0,
+        "version": "0.7",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm",
+        "checksum": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
+        "check_gpg": true
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libutempter-1.2.1-4.fc34.aarch64.rpm",
+        "checksum": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libuuid-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcb",
+        "epoch": 0,
+        "version": "1.13.1",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libxcb-1.13.1-7.fc34.aarch64.rpm",
+        "checksum": "sha256:5595c4bc0ad8072173df3858efdebea0fabb0fdf74a5ca2edb020af66e0f3716",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-atm-libs",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "28.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/linux-atm-libs-2.5.1-28.fc34.aarch64.rpm",
+        "checksum": "sha256:a60e3e035883de829c5778417d316ffc47a0b4a304953e3fdc44def8f2f172ab",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lmdb-libs-0.9.29-1.fc34.aarch64.rpm",
+        "checksum": "sha256:7721bc647c521d96e07e665f7da306326d3bd1499d610c58552317815aaf3c45",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lz4-libs-1.9.3-2.fc34.aarch64.rpm",
+        "checksum": "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.9.3",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/man-db-2.9.3-3.fc34.aarch64.rpm",
+        "checksum": "sha256:61ba1ecff8f8578cbd3445df596d001067bb0281745191ac168fcc6079d8e1cf",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/memstrack-0.2.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.4.0",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/mokutil-0.4.0-4.fc34.aarch64.rpm",
+        "checksum": "sha256:f7c7dc1d8e5cf4776a1fde155871a2bb1fdd0676f897a43334cfbb60eb69e52a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-6.2-4.20200222.fc34.aarch64.rpm",
+        "checksum": "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm",
+        "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm",
+        "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
+        "check_gpg": true
+      },
+      {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.59.20160912git.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/net-tools-2.0-0.59.20160912git.fc34.aarch64.rpm",
+        "checksum": "sha256:96c7a26b707d4038a50b4ab0fd8d79ba3997466bed543f13c10d30e7ec256b5e",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm",
+        "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/openssl-pkcs11-0.4.11-2.fc34.aarch64.rpm",
+        "checksum": "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/os-prober-1.77-7.fc34.aarch64.rpm",
+        "checksum": "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-0.23.22-3.fc34.aarch64.rpm",
+        "checksum": "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-trust-0.23.22-3.fc34.aarch64.rpm",
+        "checksum": "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/parted-3.4-2.fc34.aarch64.rpm",
+        "checksum": "sha256:27920113489e3260e58d4a033d31401c6ae22ded72895c6b8c0e43ebf89a62df",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/passwd-0.80-10.fc34.aarch64.rpm",
+        "checksum": "sha256:6a864bec34b7d39de3e6ae1e39ec07fa3a2d21837a9a2d7151228d7f0ac38e73",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.44",
+        "release": "3.fc34.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre-8.44-3.fc34.1.aarch64.rpm",
+        "checksum": "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-10.36-4.fc34.aarch64.rpm",
+        "checksum": "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-syntax-10.36-4.fc34.noarch.rpm",
+        "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pigz-2.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "2.20210331git1ea1020.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/plymouth-0.9.5-2.20210331git1ea1020.fc34.aarch64.rpm",
+        "checksum": "sha256:217b9e2d44c03ba92900f5b517b21358cee4c764e104515e55efd5ef9d838f22",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "2.20210331git1ea1020.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/plymouth-core-libs-0.9.5-2.20210331git1ea1020.fc34.aarch64.rpm",
+        "checksum": "sha256:eeaab0f9ac34c76cfabe75d99510a7c9ffb5b05fc9aba0d44062aaf530b945e5",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "2.20210331git1ea1020.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/plymouth-scripts-0.9.5-2.20210331git1ea1020.fc34.aarch64.rpm",
+        "checksum": "sha256:32d76b30fca1050db004ab86e4e2079c3b3bf13765d3a1d6d0f5a5c2a41c91c0",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/policycoreutils-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/popt-1.18-4.fc34.aarch64.rpm",
+        "checksum": "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm",
+        "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/psmisc-23.4-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d1c8a2302e64fc856aff6a05a78140986e89eddd8f110deb9ba78d44aebcd411",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20190417",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
+        "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-attrs",
+        "epoch": 0,
+        "version": "20.3.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-attrs-20.3.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:820fee96d610178c7c7b8ce2b115bd02063d2f6dfcae5da4bf5d411de0b575f7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cffi",
+        "epoch": 0,
+        "version": "1.14.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-cffi-1.14.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:7d00ccbb224617a00f58053afd88e7a49062446f1306ba39c72b78d20aeee1ef",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-chardet-4.0.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:9ce3f0c0904ac22ab5769babebf43e7dcdb488b0ef999b2e9e88a5b5eb424e51",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-configobj",
+        "epoch": 0,
+        "version": "5.0.6",
+        "release": "23.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-configobj-5.0.6-23.fc34.noarch.rpm",
+        "checksum": "sha256:f7f8832ccaedd7ddad064956309478b9bf366f0576517356ee68481e196236cf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cryptography",
+        "epoch": 0,
+        "version": "3.4.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-cryptography-3.4.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:ea8067f2310d30b31f7b1f13825b2a5a5e679c114fefd072267b6c369a365a63",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-dateutil-2.8.1-3.fc34.noarch.rpm",
+        "checksum": "sha256:5d2c28837f0573ae2647b8fbba85f7c502f9c3da0a3eab1c9ba121de4a1a6cee",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-decorator",
+        "epoch": 0,
+        "version": "4.4.2",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-decorator-4.4.2-4.fc34.noarch.rpm",
+        "checksum": "sha256:23f7cc188684a9e9ba8f0ffbcd9ecb28aaeba9a6e596e1c56362d8a1f51a492d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-distro-1.5.0-5.fc34.noarch.rpm",
+        "checksum": "sha256:e530795e5c9bc27de609fcbbacdc43c226026fee95e47a1f783f1c03ba5d48ae",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.40.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gobject-base-3.40.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:ce6e8e623dcb1ef8f3c1f59e03da39bc173f9555136ba60c6b2c23bc63d6f77b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-idna-2.10-3.fc34.noarch.rpm",
+        "checksum": "sha256:f68c93c0461c149bb17282dededf421cbc1fbfa5ac133b59bd362526f59e0d57",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jinja2",
+        "epoch": 0,
+        "version": "2.11.3",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jinja2-2.11.3-1.fc34.noarch.rpm",
+        "checksum": "sha256:2414cb7345bc193f7ff7983c020c8b0e706aab013ee30af5d457d35c4de4a698",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpatch",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonpatch-1.21-14.fc34.noarch.rpm",
+        "checksum": "sha256:e0dffa204780c20c16357a51b992351aa1cf9f9cdda6182939ecd0cd7ab2c2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpointer",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonpointer-2.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:1b1af6b54050ec223c3289b107a9695a686c9d46d17a80ec9cd5d0201ec5d544",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonschema",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonschema-3.2.0-9.fc34.noarch.rpm",
+        "checksum": "sha256:d6810c97f24d93cd54a61bb288ada8591a94e4083b5165e0719915bceb637504",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt+crypto",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jwt+crypto-1.7.1-11.fc34.noarch.rpm",
+        "checksum": "sha256:9cc240ac305a862146e85d8dcc4ad981f5233a58b6901ecfac691d0b39966b49",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jwt-1.7.1-11.fc34.noarch.rpm",
+        "checksum": "sha256:131adc47f044c9f600f5295ded0f5431cda57fa7276100c3ec81c9d1ce3fa6f7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libselinux",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-libselinux-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:dbf3fb9e356236575a06e4fdcd532331f418236aa4ff4e024260c24be2b9a7cf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-libsemanage-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:87749765dbe5ce8f098279170c39bb8a89abbf3f8430c2a6dbfb973117e11dfa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-markupsafe-1.1.1-10.fc34.aarch64.rpm",
+        "checksum": "sha256:fbf45cda87a05418a72f4bf3877da5ebcabbe68d393bc5bec007a8b01ef6bafe",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib+signedtoken",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-oauthlib+signedtoken-3.0.2-9.fc34.noarch.rpm",
+        "checksum": "sha256:b30db4e3d9605e7263387ff91f91508667693d28e8b8835a2b7fcefd64f24388",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-oauthlib-3.0.2-9.fc34.noarch.rpm",
+        "checksum": "sha256:f9b2e7232d0b2d33bf52993c31b43b31520601f52f44fe792acd6dee4d84afc8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ply",
+        "epoch": 0,
+        "version": "3.11",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-ply-3.11-11.fc34.noarch.rpm",
+        "checksum": "sha256:23e3ed871799a9209915359f71660babf451b0b44902e3ed488b7b22aff37718",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-policycoreutils-3.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:e76f1401d9e119eae4cc461c8b68e9eae075d4b69f61870cb5c19ba7d69cf1a3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "25.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-prettytable-0.7.2-25.fc34.noarch.rpm",
+        "checksum": "sha256:cc4401d1e292b28d771a2038081b929b342ffa3b60358aed91697fdbc668546a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pycparser",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pycparser-2.20-3.fc34.noarch.rpm",
+        "checksum": "sha256:32220dc513a6ebcd4994e7140ecb5859108baf44d12fe6b1f0c0459dbefc54e7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyserial",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "10.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pyserial-3.4-10.fc34.noarch.rpm",
+        "checksum": "sha256:70a90c6c682016e91fb4745eedbd23f28e150a38b01d18f85ce4e50fb4e0ca6c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "8.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pysocks-1.7.1-8.fc34.noarch.rpm",
+        "checksum": "sha256:4a74ae08a713e9b4e74ff27bfaf57374312370402f90e2796e66c504557ae189",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pyyaml-5.4.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:92e42b63fcc56dd21984abb722e8fa7ebbb58f6d54c529ac11871b4bbc63b290",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-requests-2.25.1-1.fc34.noarch.rpm",
+        "checksum": "sha256:6297d7eee103c679a0f1ea411568d3940af3fe8f38e19388a1544df70bda8b3c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.4.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-setools-4.4.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:e1f1b9c4b78fe9d84a87d7de67fdd8559fe2bea9969ca1632d137de635d7e898",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-six-1.15.0-5.fc34.noarch.rpm",
+        "checksum": "sha256:b5d5e7255c85c3aa9d63598ef140de35843ab2485adf1cb9a9130be80aa0297f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-slip",
+        "epoch": 0,
+        "version": "0.6.4",
+        "release": "22.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-slip-0.6.4-22.fc34.noarch.rpm",
+        "checksum": "sha256:4e45f4c24997b231cb6fb8d31e9d7e0aae40c1135337194d62ce98c197547dbf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-slip-dbus",
+        "epoch": 0,
+        "version": "0.6.4",
+        "release": "22.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-slip-dbus-0.6.4-22.fc34.noarch.rpm",
+        "checksum": "sha256:1c01e888717888901aef3fee5c02841a83f83b3d9d962bc3cd495a88a5e3ab5c",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/readline-8.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "29.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rootfiles-8.1-29.fc34.noarch.rpm",
+        "checksum": "sha256:164e1c0e3e8c89aeda4f272b3158932649a69b16aea058105117a64d3cdef517",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sed-4.8-7.fc34.aarch64.rpm",
+        "checksum": "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.7",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/setup-2.13.7-3.fc34.noarch.rpm",
+        "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.4",
+        "release": "4",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shim-aa64-15.4-4.aarch64.rpm",
+        "checksum": "sha256:23a539a271c92906ac0a12c7d877c7f4d0ad8e6b9bbd8642b5232f861b79ed22",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.34.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.5p2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-1.9.5p2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:40e231991444a589b17e0b5b338be8874d071e3d17e210aba6f6639620775f79",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.5p2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-python-plugin-1.9.5p2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:a86ec8f7284ee01574bb06bba726d8609e464f41d003215097e626c583f73ed0",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-0.3.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-lib-0.3.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/u/util-linux-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.10.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xfsprogs-5.10.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3228a36807658c7e4d881013aa26f877353388bf3bac6c948984f751c264a359",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-5.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-libs-5.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c",
+        "check_gpg": true
+      },
+      {
+        "name": "yajl",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "16.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/y/yajl-2.1.0-16.fc34.aarch64.rpm",
+        "checksum": "sha256:98370c7be5b5fc629505843db497c9d82d243234d31c65e2b3afd8538570e9ab",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "26.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/z/zlib-1.2.11-26.fc34.aarch64.rpm",
+        "checksum": "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.30.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.30.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4baf8ba6a5ed4609695f79a8bbc8324d7efa322a3573c8c5fa3942361eac0f1c",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.30.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.30.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f695ed244a1d9f3eb814947fb1da343d7d6fb3aaa2bf72965235e4b45a58a784",
+        "check_gpg": true
+      },
+      {
+        "name": "alsa-lib",
+        "epoch": 0,
+        "version": "1.2.6.1",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/alsa-lib-1.2.6.1-3.fc34.aarch64.rpm",
+        "checksum": "sha256:5e0a71bc53cae651289a962699fc17fd9f16a474398cb6b7dfe3d239876b6ed4",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-3.0.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:148aea26e381b33badde0ac2ae716a78f7b565f54f0b6970189a89713f335eaf",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-libs-3.0.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/c-ares-1.17.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:7c24e53e12891046bb6721e624cf9effd1946c0d076464427c2a86b29671318e",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm",
+        "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+        "check_gpg": true
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/chrony-4.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:61a9dbd9020e29012947978acf33a0c1150e6c3e078de372f1e38fb9c4ef529a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-8.32-30.fc34.aarch64.rpm",
+        "checksum": "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-common-8.32-30.fc34.aarch64.rpm",
+        "checksum": "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-2.9.6-27.fc34.aarch64.rpm",
+        "checksum": "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-dicts-2.9.6-27.fc34.aarch64.rpm",
+        "checksum": "sha256:2968703dd232a37620a0ae12146c9d1ec5220f62c40bfb0ecfc60b621d8e1eac",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.3.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/curl-7.76.1-12.fc34.aarch64.rpm",
+        "checksum": "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "11.b1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dhcp-client-4.4.2-11.b1.fc34.aarch64.rpm",
+        "checksum": "sha256:0ac62147585be2dae960ed37a3a0c3eb2f8a95d0fd0993991c8bf7238b1d5e27",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "11.b1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dhcp-common-4.4.2-11.b1.fc34.noarch.rpm",
+        "checksum": "sha256:11cd6fae157eb9e4800163633b57bcce21d59a1df4b86a99ba03707b6cee0cfc",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc34.noarch.rpm",
+        "checksum": "sha256:1feb6a045cb3e95e3c8e0112ecb4b8ffeb9986a503b52c5497fefce217846b90",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc34.aarch64.rpm",
+        "checksum": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc34.aarch64.rpm",
+        "checksum": "sha256:9aee2549d3ff9e5652dffaaa9b91ab7a243687cc2a85b8e45f4290d53d44702d",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/efi-filesystem-5-4.fc34.noarch.rpm",
+        "checksum": "sha256:8fbfbaf3b107b540428634c19c4cb05e7c46f9672cfbf14d1f44306ed3413a46",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc34.noarch.rpm",
+        "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-gpg-keys-34-2.noarch.rpm",
+        "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-34-39.noarch.rpm",
+        "checksum": "sha256:3e69e8412d5914ec01c5e82264833698e92a1b88a7c7b5ed9b1f0351fc91f5d2",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-common-34-39.noarch.rpm",
+        "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-34-39.noarch.rpm",
+        "checksum": "sha256:6d1c024b295c423746b44f120cf36ceb0fd898f8ce5a276813d7c78a3c8ece52",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-34-2.noarch.rpm",
+        "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-modular-34-2.noarch.rpm",
+        "checksum": "sha256:eb88e660b9fd02e695a90c0266831b79e513c2f65ba5d6353e82726af96e9752",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-5.39-7.fc34.aarch64.rpm",
+        "checksum": "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.aarch64.rpm",
+        "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/firewalld-0.9.4-1.fc34.noarch.rpm",
+        "checksum": "sha256:87fa60c9e5fd73e064450bb155b36501a1da34f06df257773a0ce7eb7e84e5a3",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/firewalld-filesystem-0.9.4-1.fc34.noarch.rpm",
+        "checksum": "sha256:1bbb7ec72916bb641b7c477a7bbd7b2ad57325f368846e34c26c592bc11a6d8e",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.68.4",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.aarch64.rpm",
+        "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-common-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-doc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-doc-2.33-20.fc34.noarch.rpm",
+        "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-langpack-en",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:059f825547fe257247656c29049ebc7bfa1d54a17479f3dcfeff37fbab7084bd",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/gnutls-3.7.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.68.0",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/gobject-introspection-1.68.0-4.fc34.aarch64.rpm",
+        "checksum": "sha256:0f2589fcd0d6387a2c13d7533b627b53e9d8f0b92ac497d95926646896ac1e6f",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm",
+        "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:71427f6f8f3f6370dccde81a76d566ff17144e7e375381ef13e04a661e63cba1",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013",
+        "check_gpg": true
+      },
+      {
+        "name": "hwdata",
+        "epoch": 0,
+        "version": "0.354",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/h/hwdata-0.354-1.fc34.noarch.rpm",
+        "checksum": "sha256:0e23d7345b89f14f69026da5aa9c730b601b78f8e2fb6c9ead7d5af4ecb1cc92",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/ipcalc-1.0.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:69de3dd68dc2b76e2a85c710a51e9c8acefe595d6ac5d9f19113c4062a5f0d92",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-legacy-libs-1.8.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-libs-1.8.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:ebd4a9473543a5ca50ec5f9de069fc0c240527516ae262cf3e28a5d914b99cb1",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-nft-1.8.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:fbe4ab6f2a2dee05ffb6d45519c29366bd50f61937a2792f5e831af1d1e257bb",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "100.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-100.fc34.aarch64.rpm",
+        "checksum": "sha256:55833f669ed1dbd32e79f494824c309b71bc373d2bf28eb5cdb663459dc6f7cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "100.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-100.fc34.aarch64.rpm",
+        "checksum": "sha256:0176b42c6b51fb3c829f168571527a3559b6a9c8cc5f847b70e3c40fb69f89e4",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "100.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-100.fc34.aarch64.rpm",
+        "checksum": "sha256:f3c940f33c6c8edb73b98527e0fff17aa211e823f06e3f732762d0c86cc0268c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-libs-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/krb5-libs-1.19.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/less-590-2.fc34.aarch64.rpm",
+        "checksum": "sha256:7cc0891a9e7c19757c03cba6c8155738d9db9f5774380c412106adf0eca44077",
+        "check_gpg": true
+      },
+      {
+        "name": "libX11",
+        "epoch": 0,
+        "version": "1.7.2",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libX11-1.7.2-3.fc34.aarch64.rpm",
+        "checksum": "sha256:3901de67d83f50b24768e660ac9633f8ebdf97ba3dcd22726927ff3e2c0ddb68",
+        "check_gpg": true
+      },
+      {
+        "name": "libX11-common",
+        "epoch": 0,
+        "version": "1.7.2",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libX11-common-1.7.2-3.fc34.noarch.rpm",
+        "checksum": "sha256:6ccc5b659a2b8328a7a80e63cf8b4b9e819aa8de1f64b7c6ab5e76b5f45586d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libXfixes",
+        "epoch": 0,
+        "version": "6.0.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libXfixes-6.0.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f55223761bb4510578ca39cc52f410ca52040d28ad3389e3dc67a0f04a71dfa5",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.aarch64.rpm",
+        "checksum": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "49.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm",
+        "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
+        "check_gpg": true
+      },
+      {
+        "name": "libdrm",
+        "epoch": 0,
+        "version": "2.4.109",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdrm-2.4.109-1.fc34.aarch64.rpm",
+        "checksum": "sha256:3e81f34c490661423c064fb9426cbacfc4a1f5c254aa40f98343d7cdc0f07603",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "38.20210714cvs.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libedit-3.1-38.20210714cvs.fc34.aarch64.rpm",
+        "checksum": "sha256:b6687e9977e337e5d029de0d42cb79d57bd44f2f642450440756ba1a0494a113",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdt",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libfdt-1.6.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:8f2ae60a71d008a9d67c151e088e9b420b07ccbaada55e0d06a66a3b8a1634b9",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcrypt-1.9.3-3.fc34.aarch64.rpm",
+        "checksum": "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "37.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libibverbs-37.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libidn2-2.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libldb-2.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:86cb1e5e80642b1575df57287c9549749603bf94b1ba652995b59ea45ac4272b",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.5.4",
+        "release": "2.rc3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libnfsidmap-2.5.4-2.rc3.fc34.aarch64.rpm",
+        "checksum": "sha256:330a36b1dabaf76daafeff3f7fd7a276880bf65d790ee84cb823a1958a4d99d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpcap-1.10.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm",
+        "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
+        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsepol-3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-0.9.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-config-0.9.6-1.fc34.noarch.rpm",
+        "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3b3bba1d61529a1dde47f234f34d0fdee07a38aa5958d87e30357ea04bbff142",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ac901ae730144d1e75b86d9991c1c6a9d6d0a44ce6e52b4d330df3a26d09e1ff",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3fdab509a59e0a765364d6f119c38c796a4420cc49b46595a37d98eb649d6c80",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:60ddc7b15e9742ff9995d1b336489b92721e21a45034d20f20d2fc800e419d1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:4123331b5d06f91ff31d147e4769806052f59b620e7677f69b0073eaf7beccb6",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "0.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtevent-0.11.0-0.fc34.aarch64.rpm",
+        "checksum": "sha256:a72bb74400b447af71600da141aebdc46da7776ef875abfdd635881f939891d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "0.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtirpc-1.3.2-0.fc34.aarch64.rpm",
+        "checksum": "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libuser-0.63-4.fc34.aarch64.rpm",
+        "checksum": "sha256:fd7dc918a1e3ad0114ecaa41d78c6652cc559271ad6653e5bba0bc780af35faa",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc34.aarch64.rpm",
+        "checksum": "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxkbcommon-1.3.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxml2-2.9.12-4.fc34.aarch64.rpm",
+        "checksum": "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc34.noarch.rpm",
+        "checksum": "sha256:8ab032e2a86f300d978e521ab030db1e7bb7eeccca205a5d2a4d68b51566f43f",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc34.noarch.rpm",
+        "checksum": "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mkpasswd-5.5.10-1.fc34.aarch64.rpm",
+        "checksum": "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mpfr-4.1.0-7.fc34.aarch64.rpm",
+        "checksum": "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/nettle-3.7.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "0.9.8",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/nftables-0.9.8-3.fc34.aarch64.rpm",
+        "checksum": "sha256:007f1604e1a0a51b226a758934efcce905cd5d285437068847c4995821513f1f",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.57",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openldap-2.4.57-6.fc34.aarch64.rpm",
+        "checksum": "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.6p1",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-8.6p1-5.fc34.aarch64.rpm",
+        "checksum": "sha256:5dcac7772d73ad1523f87cbeb1dc76dd62af4d2bb73dd06896a47d2bcf503e5e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.6p1",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.6p1-5.fc34.aarch64.rpm",
+        "checksum": "sha256:d5d622f60e97d43b095a98f2bb46982d91451e4e6018492da20944b294480af3",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.6p1",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-server-8.6p1-5.fc34.aarch64.rpm",
+        "checksum": "sha256:39160ef65b3519a70f14f992edc5967380ef86a6940896751db681781961903d",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssl-libs-1.1.1l-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pam-1.5.1-7.fc34.aarch64.rpm",
+        "checksum": "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "1.fc34.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/procps-ng-3.3.17-1.fc34.1.aarch64.rpm",
+        "checksum": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-setuptools-wheel-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.9.9-2.fc34.noarch.rpm",
+        "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-3.9.9-2.fc34.aarch64.rpm",
+        "checksum": "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-audit-3.0.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:139b9453b2038e52767d0102def782d58d558ca0603757eb0c97ddda28af1466",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-babel",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-babel-2.9.1-1.fc34.noarch.rpm",
+        "checksum": "sha256:59cc4d563ecb4c8b517f5dd7505f1cda297f950f32fc700344aa7789b69ca99c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dbus-1.2.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:00c29524aad123ec44056e60b9625e75ac428a6c751878a05fadbca7e956c249",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc34.noarch.rpm",
+        "checksum": "sha256:bab19da8b6f553325decae00748f88fc0924b918136f065ab8995e1ebf5bde5b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-firewall-0.9.4-1.fc34.noarch.rpm",
+        "checksum": "sha256:2aa0bf433e2f3c7d09613dd1f9b2853a8946bc26051ba9e747cd29518679958f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libs-3.9.9-2.fc34.aarch64.rpm",
+        "checksum": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "0.9.8",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-nftables-0.9.8-3.fc34.aarch64.rpm",
+        "checksum": "sha256:50f8013df88ebb6fbe7ef8a7720815196bced2e81e6e78d8932f53b990f73e1f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pip-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyrsistent",
+        "epoch": 0,
+        "version": "0.17.3",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.17.3-6.fc34.aarch64.rpm",
+        "checksum": "sha256:fc4104e014beee44b5003e72a32e45e689936a4ffdcf07e119b02be3ed4ab8d9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pytz",
+        "epoch": 0,
+        "version": "2021.3",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc34.noarch.rpm",
+        "checksum": "sha256:eecc86b828ad436a9f397d2f7acdf5705bfd36bcad3edd2da73f3acc94363411",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.25.10",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.25.10-5.fc34.noarch.rpm",
+        "checksum": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
+        "check_gpg": true
+      },
+      {
+        "name": "qemu-guest-agent",
+        "epoch": 2,
+        "version": "5.2.0",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-guest-agent-5.2.0-8.fc34.aarch64.rpm",
+        "checksum": "sha256:394ddf6f634c70dcd1ba5763af7be37145b5ac1749160e199f95b524767eef82",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.8.1",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.8.1-10.fc34.aarch64.rpm",
+        "checksum": "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99",
+        "check_gpg": true
+      },
+      {
+        "name": "spice-vdagent",
+        "epoch": 0,
+        "version": "0.21.0",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/spice-vdagent-0.21.0-4.fc34.aarch64.rpm",
+        "checksum": "sha256:94f598b1f39bd6e6a212c873d38b4e466b9c5dbea34c6fdbf0c58cf4d9ec4477",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-client-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:c814f83bcf3cfc590d84897c810a087354cfb0c961dd232af5031cfe8bd63a37",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-common-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:668a30c6f526e51705af9cb9d98fd11f279f5e86f7d905876ae9a86f486a8c36",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:7285fcc290a8af2cf845beb845e661cd4c06c2275417b15eb507824dedec7c69",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:0db1be9a78e5f329a519066a7b37379f6c73fe579154e0a6a26b2dcb4154ccd6",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-networkd-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:43b0b5d425a2041daeb6b41db2858abda1f92ecc38c6125f7de3b7502580a9f7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-pam-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-rpm-macros",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-rpm-macros-248.9-1.fc34.noarch.rpm",
+        "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
+        "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.3755",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.3755-1.fc34.noarch.rpm",
+        "checksum": "sha256:adcd36cb0e582f5fb2d0465cf88bb813ffac17d25d6ec8aa608b647d008bebc3",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.3755",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.3755-1.fc34.aarch64.rpm",
+        "checksum": "sha256:1af86c0a8c11e44958b022bf7dad5f48ad974fa8537cf41a12d5b0643444b1dc",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "26.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/which-2.21-26.fc34.aarch64.rpm",
+        "checksum": "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/whois-nls-5.5.10-1.fc34.noarch.rpm",
+        "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+        "check_gpg": true
+      },
+      {
+        "name": "xen-libs",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xen-libs-4.14.3-3.fc34.aarch64.rpm",
+        "checksum": "sha256:fdf6b777dd9639e3e37dca1910aa87b9fedf3ebe92b1911e41861805b0d361c6",
+        "check_gpg": true
+      },
+      {
+        "name": "xen-licenses",
+        "epoch": 0,
+        "version": "4.14.3",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xen-licenses-4.14.3-3.fc34.aarch64.rpm",
+        "checksum": "sha256:feeb03f8685db40f81d8eb63e292e5199e667a14c3104b7209557c1b9dd3d638",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
+        "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/y/yum-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:30bc3583e503e0f459e323b27551f7b9a8ab784de15437b5b29f447b31f8d9cd",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm",
+        "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
+        "check_gpg": true
+      }
+    ]
+  },
+  "image-info": {
+    "/etc/resolv.conf": [],
+    "boot-environment": {
+      "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+    },
+    "bootloader": "unknown",
+    "bootmenu": [
+      {
+        "grub_arg": "--unrestricted",
+        "grub_class": "fedora",
+        "grub_users": "$grub_users",
+        "initrd": "/boot/initramfs-5.15.13-100.fc34.aarch64.img",
+        "linux": "/boot/vmlinuz-5.15.13-100.fc34.aarch64",
+        "options": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8",
+        "title": "Fedora (5.15.13-100.fc34.aarch64) 34 (Thirty Four)",
+        "version": "5.15.13-100.fc34.aarch64"
+      }
+    ],
+    "chrony": {
+      "leapsectz": [
+        "right/UTC"
+      ],
+      "pool": [
+        "2.fedora.pool.ntp.org iburst"
+      ]
+    },
+    "cloud-init": {
+      "/etc/cloud": {
+        "cloud.cfg": {
+          "cloud_config_modules": [
+            "ssh-import-id",
+            "locale",
+            "set-passwords",
+            "spacewalk",
+            "yum-add-repo",
+            "ntp",
+            "timezone",
+            "disable-ec2-metadata",
+            "runcmd"
+          ],
+          "cloud_final_modules": [
+            "package-update-upgrade-install",
+            "puppet",
+            "chef",
+            "mcollective",
+            "salt-minion",
+            "reset_rmc",
+            "refresh_rmc_and_interface",
+            "rightscale_userdata",
+            "scripts-vendor",
+            "scripts-per-once",
+            "scripts-per-boot",
+            "scripts-per-instance",
+            "scripts-user",
+            "ssh-authkey-fingerprints",
+            "keys-to-console",
+            "phone-home",
+            "final-message",
+            "power-state-change"
+          ],
+          "cloud_init_modules": [
+            "migrator",
+            "seed_random",
+            "bootcmd",
+            "write-files",
+            "growpart",
+            "resizefs",
+            "disk_setup",
+            "mounts",
+            "set_hostname",
+            "update_hostname",
+            "update_etc_hosts",
+            "ca-certs",
+            "rsyslog",
+            "users-groups",
+            "ssh"
+          ],
+          "disable_root": true,
+          "mount_default_fields": [
+            null,
+            null,
+            "auto",
+            "defaults,nofail",
+            "0",
+            "2"
+          ],
+          "preserve_hostname": false,
+          "resize_rootfs_tmp": "/dev",
+          "ssh_pwauth": 0,
+          "system_info": {
+            "default_user": {
+              "gecos": "fedora Cloud User",
+              "groups": [
+                "wheel",
+                "adm",
+                "systemd-journal"
+              ],
+              "lock_passwd": true,
+              "name": "fedora",
+              "shell": "/bin/bash",
+              "sudo": [
+                "ALL=(ALL) NOPASSWD:ALL"
+              ]
+            },
+            "distro": "fedora",
+            "paths": {
+              "cloud_dir": "/var/lib/cloud/",
+              "templates_dir": "/etc/cloud/templates/"
+            },
+            "ssh_svcname": "sshd"
+          },
+          "users": [
+            "default"
+          ]
+        }
+      },
+      "/etc/cloud/cloud.cfg.d": {
+        "05_logging.cfg": {
+          "_log": [
+            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
+            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
+          ],
+          "log_cfgs": [
+            [
+              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
+            ]
+          ],
+          "output": {
+            "all": "| tee -a /var/log/cloud-init-output.log"
+          }
+        }
+      }
+    },
+    "default-target": "graphical.target",
+    "dracut": {
+      "/usr/lib/dracut/dracut.conf.d": {
+        "01-dist.conf": {
+          "dbus": "/usr/share/dbus-1",
+          "dbusconfdir": "/etc/dbus-1",
+          "dbusinterfaces": "/usr/share/dbus-1/interfaces",
+          "dbusinterfacesconfdir": "/etc/dbus-1/interfaces",
+          "dbusservices": "/usr/share/dbus-1/services",
+          "dbusservicesconfdir": "/etc/dbus-1/services",
+          "dbussession": "/usr/share/dbus-1/session.d",
+          "dbussessionconfdir": "/etc/dbus-1/session.d",
+          "dbussystem": "confdir/etc/dbus-1/system.d",
+          "dbussystemservices": "/usr/share/dbus-1/system-services",
+          "dbussystemservicesconfdir": "/etc/dbus-1/system-services",
+          "early_microcode": "yes",
+          "environment": "/usr/lib/environment.d",
+          "environmentconfdir": "/etc/environment.d",
+          "hostonly": "yes",
+          "hostonly_cmdline": "no",
+          "i18n_default_font": "eurlatgr",
+          "i18n_install_all": "yes",
+          "i18n_vars": "/etc/sysconfig/keyboard:KEYTABLE-KEYMAP /etc/sysconfig/i18n:SYSFONT-FONT,FONTACM-FONT_MAP,FONT_UNIMAP",
+          "install_optional_items": " vi /etc/virc ps grep cat rm ",
+          "prefix": "/",
+          "reproducible": "yes",
+          "stdloglvl": "3",
+          "sysctlconfdir": "/etc/sysctl.d",
+          "sysctld": "/usr/lib/sysctl.d",
+          "sysloglvl": "5",
+          "systemdcatalog": "/usr/lib/systemd/catalog",
+          "systemdntpunits": "/usr/lib/systemd/ntp-units.d",
+          "systemdntpunitsconfdir": "/etc/systemd/ntp-units.d",
+          "systemdportable": "/usr/lib/systemd/portable",
+          "systemdportableconfdir": "/etc/systemd/portable",
+          "systemdsystemconfdir": "/etc/systemd/system",
+          "systemdsystemunitdir": "/usr/lib/systemd/system",
+          "systemduser": "/usr/lib/systemd/user",
+          "systemduserconfdir": "/etc/systemd/user",
+          "systemdutilconfdir": "/etc/systemd",
+          "systemdutildir": "/usr/lib/systemd",
+          "sysusers": "/usr/lib/sysusers.d",
+          "sysusersconfdir": "/etc/sysusers.d",
+          "udevdir": "/usr/lib/udev"
+        },
+        "02-generic-image.conf": {
+          "hostonly": "no"
+        }
+      }
+    },
+    "firewall-enabled": [
+      "ssh",
+      "mdns",
+      "dhcpv6-client"
+    ],
+    "fstab": [
+      [
+        "UUID=46BB-8120",
+        "/boot/efi",
+        "vfat",
+        "umask=0077,shortname=winnt",
+        "0",
+        "2"
+      ],
+      [
+        "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+        "/",
+        "ext4",
+        "defaults",
+        "1",
+        "1"
+      ]
+    ],
+    "groups": [
+      "adm:x:4:",
+      "audio:x:63:",
+      "bin:x:1:",
+      "cdrom:x:11:",
+      "chrony:x:994:",
+      "daemon:x:2:",
+      "dbus:x:81:",
+      "dialout:x:18:",
+      "disk:x:6:",
+      "floppy:x:19:",
+      "ftp:x:50:",
+      "games:x:20:",
+      "input:x:104:",
+      "kmem:x:9:",
+      "kvm:x:36:",
+      "lock:x:54:",
+      "lp:x:7:",
+      "mail:x:12:",
+      "man:x:15:",
+      "mem:x:8:",
+      "nobody:x:65534:",
+      "redhat:x:1000:",
+      "render:x:105:",
+      "root:x:0:",
+      "sgx:x:106:",
+      "ssh_keys:x:996:",
+      "sshd:x:74:",
+      "sys:x:3:",
+      "systemd-coredump:x:999:",
+      "systemd-journal:x:190:",
+      "systemd-network:x:192:",
+      "systemd-oom:x:998:",
+      "systemd-resolve:x:193:",
+      "systemd-timesync:x:997:",
+      "tape:x:33:",
+      "tss:x:59:",
+      "tty:x:5:",
+      "unbound:x:995:",
+      "users:x:100:",
+      "utempter:x:35:",
+      "utmp:x:22:",
+      "video:x:39:",
+      "wheel:x:10:"
+    ],
+    "hostname": "localhost.localdomain",
+    "hosts": [
+      "127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4",
+      "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
+    ],
+    "image-format": {
+      "compat": "1.1",
+      "type": "qcow2"
+    },
+    "locale": {
+      "LANG": "en_US"
+    },
+    "machine-id": "",
+    "modprobe": {
+      "/usr/lib/modprobe.d": {
+        "dist-blacklist.conf": {
+          "blacklist": [
+            "chsc_sch"
+          ]
+        }
+      }
+    },
+    "os-release": {
+      "ANSI_COLOR": "0;38;2;60;110;180",
+      "BUG_REPORT_URL": "https://bugzilla.redhat.com/",
+      "CPE_NAME": "cpe:/o:fedoraproject:fedora:34",
+      "DOCUMENTATION_URL": "https://docs.fedoraproject.org/en-US/fedora/f34/system-administrators-guide/",
+      "HOME_URL": "https://fedoraproject.org/",
+      "ID": "fedora",
+      "LOGO": "fedora-logo-icon",
+      "NAME": "Fedora",
+      "PLATFORM_ID": "platform:f34",
+      "PRETTY_NAME": "Fedora 34 (Thirty Four)",
+      "PRIVACY_POLICY_URL": "https://fedoraproject.org/wiki/Legal:PrivacyPolicy",
+      "REDHAT_BUGZILLA_PRODUCT": "Fedora",
+      "REDHAT_BUGZILLA_PRODUCT_VERSION": "34",
+      "REDHAT_SUPPORT_PRODUCT": "Fedora",
+      "REDHAT_SUPPORT_PRODUCT_VERSION": "34",
+      "SUPPORT_URL": "https://fedoraproject.org/wiki/Communicating_and_getting_help",
+      "VERSION": "34 (Thirty Four)",
+      "VERSION_CODENAME": "",
+      "VERSION_ID": "34"
+    },
+    "packages": [
+      "NetworkManager-1.30.6-1.fc34.aarch64",
+      "NetworkManager-libnm-1.30.6-1.fc34.aarch64",
+      "acl-2.3.1-1.fc34.aarch64",
+      "alsa-lib-1.2.6.1-3.fc34.aarch64",
+      "alternatives-1.15-2.fc34.aarch64",
+      "audit-3.0.6-1.fc34.aarch64",
+      "audit-libs-3.0.6-1.fc34.aarch64",
+      "basesystem-11-11.fc34.noarch",
+      "bash-5.1.0-2.fc34.aarch64",
+      "bzip2-libs-1.0.8-6.fc34.aarch64",
+      "c-ares-1.17.2-1.fc34.aarch64",
+      "ca-certificates-2021.2.52-1.0.fc34.noarch",
+      "checkpolicy-3.2-1.fc34.aarch64",
+      "chrony-4.1-1.fc34.aarch64",
+      "cloud-init-20.4-2.fc34.noarch",
+      "coreutils-8.32-30.fc34.aarch64",
+      "coreutils-common-8.32-30.fc34.aarch64",
+      "cpio-2.13-10.fc34.aarch64",
+      "cracklib-2.9.6-27.fc34.aarch64",
+      "cracklib-dicts-2.9.6-27.fc34.aarch64",
+      "crypto-policies-20210213-1.git5c710c0.fc34.noarch",
+      "crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch",
+      "cryptsetup-libs-2.3.6-1.fc34.aarch64",
+      "curl-7.76.1-12.fc34.aarch64",
+      "cyrus-sasl-lib-2.1.27-8.fc34.aarch64",
+      "dbus-1.12.20-3.fc34.aarch64",
+      "dbus-broker-29-2.fc34.aarch64",
+      "dbus-common-1.12.20-3.fc34.noarch",
+      "dbus-libs-1.12.20-3.fc34.aarch64",
+      "dejavu-sans-fonts-2.37-16.fc34.noarch",
+      "deltarpm-3.6.2-8.fc34.aarch64",
+      "device-mapper-1.02.175-1.fc34.aarch64",
+      "device-mapper-libs-1.02.175-1.fc34.aarch64",
+      "dhcp-client-4.4.2-11.b1.fc34.aarch64",
+      "dhcp-common-4.4.2-11.b1.fc34.noarch",
+      "diffutils-3.7-8.fc34.aarch64",
+      "dnf-4.9.0-1.fc34.noarch",
+      "dnf-data-4.9.0-1.fc34.noarch",
+      "dnf-plugins-core-4.0.24-1.fc34.noarch",
+      "dracut-055-6.fc34.aarch64",
+      "dracut-config-generic-055-6.fc34.aarch64",
+      "e2fsprogs-1.45.6-5.fc34.aarch64",
+      "e2fsprogs-libs-1.45.6-5.fc34.aarch64",
+      "efi-filesystem-5-4.fc34.noarch",
+      "efibootmgr-16-10.fc34.aarch64",
+      "efivar-libs-37-15.fc34.aarch64",
+      "elfutils-debuginfod-client-0.186-1.fc34.aarch64",
+      "elfutils-default-yama-scope-0.186-1.fc34.noarch",
+      "elfutils-libelf-0.186-1.fc34.aarch64",
+      "elfutils-libs-0.186-1.fc34.aarch64",
+      "expat-2.4.1-1.fc34.aarch64",
+      "fedora-gpg-keys-34-2.noarch",
+      "fedora-release-34-39.noarch",
+      "fedora-release-common-34-39.noarch",
+      "fedora-release-identity-basic-34-39.noarch",
+      "fedora-repos-34-2.noarch",
+      "fedora-repos-modular-34-2.noarch",
+      "file-5.39-7.fc34.aarch64",
+      "file-libs-5.39-7.fc34.aarch64",
+      "filesystem-3.14-5.fc34.aarch64",
+      "findutils-4.8.0-2.fc34.aarch64",
+      "firewalld-0.9.4-1.fc34.noarch",
+      "firewalld-filesystem-0.9.4-1.fc34.noarch",
+      "fonts-filesystem-2.0.5-5.fc34.noarch",
+      "fuse-libs-2.9.9-11.fc34.aarch64",
+      "gawk-5.1.0-3.fc34.aarch64",
+      "gawk-all-langpacks-5.1.0-3.fc34.aarch64",
+      "gdbm-libs-1.19-2.fc34.aarch64",
+      "gettext-0.21-4.fc34.aarch64",
+      "gettext-libs-0.21-4.fc34.aarch64",
+      "glib2-2.68.4-1.fc34.aarch64",
+      "glibc-2.33-20.fc34.aarch64",
+      "glibc-common-2.33-20.fc34.aarch64",
+      "glibc-doc-2.33-20.fc34.noarch",
+      "glibc-langpack-en-2.33-20.fc34.aarch64",
+      "gmp-6.2.0-6.fc34.aarch64",
+      "gnupg2-2.2.27-4.fc34.aarch64",
+      "gnupg2-smime-2.2.27-4.fc34.aarch64",
+      "gnutls-3.7.2-1.fc34.aarch64",
+      "gobject-introspection-1.68.0-4.fc34.aarch64",
+      "gpg-pubkey-45719a39-5f2c0192",
+      "gpgme-1.15.1-2.fc34.aarch64",
+      "grep-3.6-2.fc34.aarch64",
+      "groff-base-1.22.4-7.fc34.aarch64",
+      "grub2-common-2.06-9.fc34.noarch",
+      "grub2-efi-aa64-2.06-9.fc34.aarch64",
+      "grub2-tools-2.06-9.fc34.aarch64",
+      "grub2-tools-minimal-2.06-9.fc34.aarch64",
+      "grubby-8.40-51.fc34.aarch64",
+      "gzip-1.10-4.fc34.aarch64",
+      "hostname-3.23-4.fc34.aarch64",
+      "hwdata-0.354-1.fc34.noarch",
+      "ima-evm-utils-1.3.2-2.fc34.aarch64",
+      "inih-49-3.fc34.aarch64",
+      "initscripts-10.09-1.fc34.aarch64",
+      "ipcalc-1.0.1-1.fc34.aarch64",
+      "iproute-5.10.0-2.fc34.aarch64",
+      "iproute-tc-5.10.0-2.fc34.aarch64",
+      "ipset-7.11-1.fc34.aarch64",
+      "ipset-libs-7.11-1.fc34.aarch64",
+      "iptables-legacy-libs-1.8.7-8.fc34.aarch64",
+      "iptables-libs-1.8.7-8.fc34.aarch64",
+      "iptables-nft-1.8.7-8.fc34.aarch64",
+      "iputils-20210202-2.fc34.aarch64",
+      "jansson-2.13.1-2.fc34.aarch64",
+      "json-c-0.14-8.fc34.aarch64",
+      "kbd-2.4.0-2.fc34.aarch64",
+      "kbd-misc-2.4.0-2.fc34.noarch",
+      "kernel-5.15.13-100.fc34.aarch64",
+      "kernel-core-5.15.13-100.fc34.aarch64",
+      "kernel-modules-5.15.13-100.fc34.aarch64",
+      "keyutils-libs-1.6.1-2.fc34.aarch64",
+      "kmod-29-2.fc34.aarch64",
+      "kmod-libs-29-2.fc34.aarch64",
+      "kpartx-0.8.5-4.fc34.aarch64",
+      "krb5-libs-1.19.2-2.fc34.aarch64",
+      "langpacks-core-en-3.0-14.fc34.noarch",
+      "langpacks-core-font-en-3.0-14.fc34.noarch",
+      "langpacks-en-3.0-14.fc34.noarch",
+      "less-590-2.fc34.aarch64",
+      "libX11-1.7.2-3.fc34.aarch64",
+      "libX11-common-1.7.2-3.fc34.noarch",
+      "libXau-1.0.9-6.fc34.aarch64",
+      "libXext-1.3.4-6.fc34.aarch64",
+      "libXfixes-6.0.0-1.fc34.aarch64",
+      "libXinerama-1.1.4-8.fc34.aarch64",
+      "libXrandr-1.5.2-6.fc34.aarch64",
+      "libXrender-0.9.10-14.fc34.aarch64",
+      "libacl-2.3.1-1.fc34.aarch64",
+      "libarchive-3.5.2-2.fc34.aarch64",
+      "libargon2-20171227-6.fc34.aarch64",
+      "libassuan-2.5.5-1.fc34.aarch64",
+      "libattr-2.5.1-1.fc34.aarch64",
+      "libbasicobjects-0.1.1-47.fc34.aarch64",
+      "libblkid-2.36.2-1.fc34.aarch64",
+      "libbrotli-1.0.9-4.fc34.aarch64",
+      "libcap-2.48-2.fc34.aarch64",
+      "libcap-ng-0.8.2-4.fc34.aarch64",
+      "libcbor-0.7.0-3.fc34.aarch64",
+      "libcollection-0.7.0-47.fc34.aarch64",
+      "libcom_err-1.45.6-5.fc34.aarch64",
+      "libcomps-0.1.18-1.fc34.aarch64",
+      "libcurl-7.76.1-12.fc34.aarch64",
+      "libdb-5.3.28-49.fc34.aarch64",
+      "libdhash-0.5.0-47.fc34.aarch64",
+      "libdnf-0.64.0-1.fc34.aarch64",
+      "libdrm-2.4.109-1.fc34.aarch64",
+      "libeconf-0.4.0-1.fc34.aarch64",
+      "libedit-3.1-38.20210714cvs.fc34.aarch64",
+      "libevent-2.1.12-3.fc34.aarch64",
+      "libfdisk-2.36.2-1.fc34.aarch64",
+      "libfdt-1.6.1-1.fc34.aarch64",
+      "libffi-3.1-28.fc34.aarch64",
+      "libfido2-1.6.0-2.fc34.aarch64",
+      "libgcc-11.2.1-1.fc34.aarch64",
+      "libgcrypt-1.9.3-3.fc34.aarch64",
+      "libgomp-11.2.1-1.fc34.aarch64",
+      "libgpg-error-1.42-1.fc34.aarch64",
+      "libibverbs-37.0-1.fc34.aarch64",
+      "libidn2-2.3.2-1.fc34.aarch64",
+      "libini_config-1.3.1-47.fc34.aarch64",
+      "libkcapi-1.2.1-1.fc34.aarch64",
+      "libkcapi-hmaccalc-1.2.1-1.fc34.aarch64",
+      "libksba-1.5.0-2.fc34.aarch64",
+      "libldb-2.3.2-1.fc34.aarch64",
+      "libmaxminddb-1.5.2-1.fc34.aarch64",
+      "libmnl-1.0.4-13.fc34.aarch64",
+      "libmodulemd-2.13.0-2.fc34.aarch64",
+      "libmount-2.36.2-1.fc34.aarch64",
+      "libndp-1.7-7.fc34.aarch64",
+      "libnetfilter_conntrack-1.0.8-2.fc34.aarch64",
+      "libnfnetlink-1.0.1-19.fc34.aarch64",
+      "libnfsidmap-2.5.4-2.rc3.fc34.aarch64",
+      "libnftnl-1.1.9-2.fc34.aarch64",
+      "libnghttp2-1.43.0-2.fc34.aarch64",
+      "libnl3-3.5.0-6.fc34.aarch64",
+      "libnsl2-1.3.0-2.fc34.aarch64",
+      "libpath_utils-0.2.1-47.fc34.aarch64",
+      "libpcap-1.10.1-1.fc34.aarch64",
+      "libpciaccess-0.16-4.fc34.aarch64",
+      "libpipeline-1.5.3-2.fc34.aarch64",
+      "libpsl-0.21.1-3.fc34.aarch64",
+      "libpwquality-1.4.4-6.fc34.aarch64",
+      "libref_array-0.1.5-47.fc34.aarch64",
+      "librepo-1.14.2-1.fc34.aarch64",
+      "libreport-filesystem-2.15.2-2.fc34.noarch",
+      "libseccomp-2.5.3-1.fc34.aarch64",
+      "libsecret-0.20.4-2.fc34.aarch64",
+      "libselinux-3.2-1.fc34.aarch64",
+      "libselinux-utils-3.2-1.fc34.aarch64",
+      "libsemanage-3.2-1.fc34.aarch64",
+      "libsepol-3.2-2.fc34.aarch64",
+      "libsigsegv-2.13-2.fc34.aarch64",
+      "libsmartcols-2.36.2-1.fc34.aarch64",
+      "libsolv-0.7.17-3.fc34.aarch64",
+      "libss-1.45.6-5.fc34.aarch64",
+      "libssh-0.9.6-1.fc34.aarch64",
+      "libssh-config-0.9.6-1.fc34.noarch",
+      "libsss_autofs-2.5.2-2.fc34.aarch64",
+      "libsss_certmap-2.5.2-2.fc34.aarch64",
+      "libsss_idmap-2.5.2-2.fc34.aarch64",
+      "libsss_nss_idmap-2.5.2-2.fc34.aarch64",
+      "libsss_sudo-2.5.2-2.fc34.aarch64",
+      "libstdc++-11.2.1-1.fc34.aarch64",
+      "libtalloc-2.3.2-2.fc34.aarch64",
+      "libtasn1-4.16.0-4.fc34.aarch64",
+      "libtdb-1.4.3-6.fc34.aarch64",
+      "libtevent-0.11.0-0.fc34.aarch64",
+      "libtextstyle-0.21-4.fc34.aarch64",
+      "libtirpc-1.3.2-0.fc34.aarch64",
+      "libunistring-0.9.10-10.fc34.aarch64",
+      "liburing-0.7-4.fc34.aarch64",
+      "libusbx-1.0.24-2.fc34.aarch64",
+      "libuser-0.63-4.fc34.aarch64",
+      "libutempter-1.2.1-4.fc34.aarch64",
+      "libuuid-2.36.2-1.fc34.aarch64",
+      "libverto-0.3.2-1.fc34.aarch64",
+      "libxcb-1.13.1-7.fc34.aarch64",
+      "libxcrypt-4.4.27-1.fc34.aarch64",
+      "libxkbcommon-1.3.0-1.fc34.aarch64",
+      "libxml2-2.9.12-4.fc34.aarch64",
+      "libyaml-0.2.5-5.fc34.aarch64",
+      "libzstd-1.5.0-1.fc34.aarch64",
+      "linux-atm-libs-2.5.1-28.fc34.aarch64",
+      "linux-firmware-20211216-127.fc34.noarch",
+      "linux-firmware-whence-20211216-127.fc34.noarch",
+      "lmdb-libs-0.9.29-1.fc34.aarch64",
+      "lua-libs-5.4.3-1.fc34.aarch64",
+      "lz4-libs-1.9.3-2.fc34.aarch64",
+      "man-db-2.9.3-3.fc34.aarch64",
+      "memstrack-0.2.2-1.fc34.aarch64",
+      "mkpasswd-5.5.10-1.fc34.aarch64",
+      "mokutil-0.4.0-4.fc34.aarch64",
+      "mpfr-4.1.0-7.fc34.aarch64",
+      "ncurses-6.2-4.20200222.fc34.aarch64",
+      "ncurses-base-6.2-4.20200222.fc34.noarch",
+      "ncurses-libs-6.2-4.20200222.fc34.aarch64",
+      "net-tools-2.0-0.59.20160912git.fc34.aarch64",
+      "nettle-3.7.3-1.fc34.aarch64",
+      "nftables-0.9.8-3.fc34.aarch64",
+      "npth-1.6-6.fc34.aarch64",
+      "openldap-2.4.57-6.fc34.aarch64",
+      "openssh-8.6p1-5.fc34.aarch64",
+      "openssh-clients-8.6p1-5.fc34.aarch64",
+      "openssh-server-8.6p1-5.fc34.aarch64",
+      "openssl-libs-1.1.1l-2.fc34.aarch64",
+      "openssl-pkcs11-0.4.11-2.fc34.aarch64",
+      "os-prober-1.77-7.fc34.aarch64",
+      "p11-kit-0.23.22-3.fc34.aarch64",
+      "p11-kit-trust-0.23.22-3.fc34.aarch64",
+      "pam-1.5.1-7.fc34.aarch64",
+      "parted-3.4-2.fc34.aarch64",
+      "passwd-0.80-10.fc34.aarch64",
+      "pcre-8.44-3.fc34.1.aarch64",
+      "pcre2-10.36-4.fc34.aarch64",
+      "pcre2-syntax-10.36-4.fc34.noarch",
+      "pigz-2.5-1.fc34.aarch64",
+      "pinentry-1.2.0-1.fc34.aarch64",
+      "plymouth-0.9.5-2.20210331git1ea1020.fc34.aarch64",
+      "plymouth-core-libs-0.9.5-2.20210331git1ea1020.fc34.aarch64",
+      "plymouth-scripts-0.9.5-2.20210331git1ea1020.fc34.aarch64",
+      "policycoreutils-3.2-1.fc34.aarch64",
+      "popt-1.18-4.fc34.aarch64",
+      "procps-ng-3.3.17-1.fc34.1.aarch64",
+      "protobuf-c-1.3.3-7.fc34.aarch64",
+      "psmisc-23.4-1.fc34.aarch64",
+      "publicsuffix-list-dafsa-20190417-5.fc34.noarch",
+      "python-pip-wheel-21.0.1-4.fc34.noarch",
+      "python-setuptools-wheel-53.0.0-2.fc34.noarch",
+      "python-unversioned-command-3.9.9-2.fc34.noarch",
+      "python3-3.9.9-2.fc34.aarch64",
+      "python3-attrs-20.3.0-2.fc34.noarch",
+      "python3-audit-3.0.6-1.fc34.aarch64",
+      "python3-babel-2.9.1-1.fc34.noarch",
+      "python3-cffi-1.14.5-1.fc34.aarch64",
+      "python3-chardet-4.0.0-1.fc34.noarch",
+      "python3-configobj-5.0.6-23.fc34.noarch",
+      "python3-cryptography-3.4.6-1.fc34.aarch64",
+      "python3-dateutil-2.8.1-3.fc34.noarch",
+      "python3-dbus-1.2.18-1.fc34.aarch64",
+      "python3-decorator-4.4.2-4.fc34.noarch",
+      "python3-distro-1.5.0-5.fc34.noarch",
+      "python3-dnf-4.9.0-1.fc34.noarch",
+      "python3-dnf-plugins-core-4.0.24-1.fc34.noarch",
+      "python3-firewall-0.9.4-1.fc34.noarch",
+      "python3-gobject-base-3.40.1-1.fc34.aarch64",
+      "python3-gpg-1.15.1-2.fc34.aarch64",
+      "python3-hawkey-0.64.0-1.fc34.aarch64",
+      "python3-idna-2.10-3.fc34.noarch",
+      "python3-jinja2-2.11.3-1.fc34.noarch",
+      "python3-jsonpatch-1.21-14.fc34.noarch",
+      "python3-jsonpointer-2.0-2.fc34.noarch",
+      "python3-jsonschema-3.2.0-9.fc34.noarch",
+      "python3-jwt+crypto-1.7.1-11.fc34.noarch",
+      "python3-jwt-1.7.1-11.fc34.noarch",
+      "python3-libcomps-0.1.18-1.fc34.aarch64",
+      "python3-libdnf-0.64.0-1.fc34.aarch64",
+      "python3-libs-3.9.9-2.fc34.aarch64",
+      "python3-libselinux-3.2-1.fc34.aarch64",
+      "python3-libsemanage-3.2-1.fc34.aarch64",
+      "python3-markupsafe-1.1.1-10.fc34.aarch64",
+      "python3-nftables-0.9.8-3.fc34.aarch64",
+      "python3-oauthlib+signedtoken-3.0.2-9.fc34.noarch",
+      "python3-oauthlib-3.0.2-9.fc34.noarch",
+      "python3-pip-21.0.1-4.fc34.noarch",
+      "python3-ply-3.11-11.fc34.noarch",
+      "python3-policycoreutils-3.2-1.fc34.noarch",
+      "python3-prettytable-0.7.2-25.fc34.noarch",
+      "python3-pycparser-2.20-3.fc34.noarch",
+      "python3-pyrsistent-0.17.3-6.fc34.aarch64",
+      "python3-pyserial-3.4-10.fc34.noarch",
+      "python3-pysocks-1.7.1-8.fc34.noarch",
+      "python3-pytz-2021.3-1.fc34.noarch",
+      "python3-pyyaml-5.4.1-2.fc34.aarch64",
+      "python3-requests-2.25.1-1.fc34.noarch",
+      "python3-rpm-4.16.1.3-1.fc34.aarch64",
+      "python3-setools-4.4.0-1.fc34.aarch64",
+      "python3-setuptools-53.0.0-2.fc34.noarch",
+      "python3-six-1.15.0-5.fc34.noarch",
+      "python3-slip-0.6.4-22.fc34.noarch",
+      "python3-slip-dbus-0.6.4-22.fc34.noarch",
+      "python3-unbound-1.13.2-1.fc34.aarch64",
+      "python3-urllib3-1.25.10-5.fc34.noarch",
+      "qemu-guest-agent-5.2.0-8.fc34.aarch64",
+      "qrencode-libs-4.1.1-1.fc34.aarch64",
+      "readline-8.1-2.fc34.aarch64",
+      "rootfiles-8.1-29.fc34.noarch",
+      "rpm-4.16.1.3-1.fc34.aarch64",
+      "rpm-build-libs-4.16.1.3-1.fc34.aarch64",
+      "rpm-libs-4.16.1.3-1.fc34.aarch64",
+      "rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64",
+      "rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64",
+      "rpm-sign-libs-4.16.1.3-1.fc34.aarch64",
+      "sed-4.8-7.fc34.aarch64",
+      "selinux-policy-34.23-1.fc34.noarch",
+      "selinux-policy-targeted-34.23-1.fc34.noarch",
+      "setup-2.13.7-3.fc34.noarch",
+      "shadow-utils-4.8.1-10.fc34.aarch64",
+      "shared-mime-info-2.1-2.fc34.aarch64",
+      "shim-aa64-15.4-4.aarch64",
+      "spice-vdagent-0.21.0-4.fc34.aarch64",
+      "sqlite-libs-3.34.1-2.fc34.aarch64",
+      "sssd-client-2.5.2-2.fc34.aarch64",
+      "sssd-common-2.5.2-2.fc34.aarch64",
+      "sssd-kcm-2.5.2-2.fc34.aarch64",
+      "sssd-nfs-idmap-2.5.2-2.fc34.aarch64",
+      "sudo-1.9.5p2-1.fc34.aarch64",
+      "sudo-python-plugin-1.9.5p2-1.fc34.aarch64",
+      "systemd-248.9-1.fc34.aarch64",
+      "systemd-libs-248.9-1.fc34.aarch64",
+      "systemd-networkd-248.9-1.fc34.aarch64",
+      "systemd-oomd-defaults-248.9-1.fc34.aarch64",
+      "systemd-pam-248.9-1.fc34.aarch64",
+      "systemd-rpm-macros-248.9-1.fc34.noarch",
+      "systemd-udev-248.9-1.fc34.aarch64",
+      "tpm2-tss-3.1.0-1.fc34.aarch64",
+      "trousers-0.3.15-2.fc34.aarch64",
+      "trousers-lib-0.3.15-2.fc34.aarch64",
+      "tzdata-2021e-1.fc34.noarch",
+      "unbound-libs-1.13.2-1.fc34.aarch64",
+      "util-linux-2.36.2-1.fc34.aarch64",
+      "vim-data-8.2.3755-1.fc34.noarch",
+      "vim-minimal-8.2.3755-1.fc34.aarch64",
+      "which-2.21-26.fc34.aarch64",
+      "whois-nls-5.5.10-1.fc34.noarch",
+      "xen-libs-4.14.3-3.fc34.aarch64",
+      "xen-licenses-4.14.3-3.fc34.aarch64",
+      "xfsprogs-5.10.0-2.fc34.aarch64",
+      "xkeyboard-config-2.33-1.fc34.noarch",
+      "xz-5.2.5-5.fc34.aarch64",
+      "xz-libs-5.2.5-5.fc34.aarch64",
+      "yajl-2.1.0-16.fc34.aarch64",
+      "yum-4.9.0-1.fc34.noarch",
+      "zchunk-libs-1.1.15-1.fc34.aarch64",
+      "zlib-1.2.11-26.fc34.aarch64"
+    ],
+    "partition-table": "gpt",
+    "partition-table-id": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
+    "partitions": [
+      {
+        "bootable": false,
+        "fstype": "vfat",
+        "label": "EFI-SYSTEM",
+        "partuuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
+        "size": 498073600,
+        "start": 1048576,
+        "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+        "uuid": "46BB-8120"
+      },
+      {
+        "bootable": false,
+        "fstype": "ext4",
+        "label": null,
+        "partuuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
+        "size": 1647296000,
+        "start": 500170752,
+        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+        "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+      }
+    ],
+    "passwd": [
+      "adm:x:3:4:adm:/var/adm:/sbin/nologin",
+      "bin:x:1:1:bin:/bin:/sbin/nologin",
+      "chrony:x:995:994::/var/lib/chrony:/sbin/nologin",
+      "daemon:x:2:2:daemon:/sbin:/sbin/nologin",
+      "dbus:x:81:81:System message bus:/:/sbin/nologin",
+      "ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin",
+      "games:x:12:100:games:/usr/games:/sbin/nologin",
+      "halt:x:7:0:halt:/sbin:/sbin/halt",
+      "lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin",
+      "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
+      "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
+      "operator:x:11:0:operator:/root:/sbin/nologin",
+      "redhat:x:1000:1000::/home/redhat:/bin/bash",
+      "root:x:0:0:root:/root:/bin/bash",
+      "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
+      "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
+      "sync:x:5:0:sync:/sbin:/bin/sync",
+      "systemd-coredump:x:999:999:systemd Core Dumper:/:/sbin/nologin",
+      "systemd-network:x:192:192:systemd Network Management:/:/sbin/nologin",
+      "systemd-oom:x:998:998:systemd Userspace OOM Killer:/:/sbin/nologin",
+      "systemd-resolve:x:193:193:systemd Resolver:/:/sbin/nologin",
+      "systemd-timesync:x:997:997:systemd Time Synchronization:/:/sbin/nologin",
+      "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
+      "unbound:x:996:995:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
+    ],
+    "rpm-verify": {
+      "changed": {
+        "/boot/efi/EFI": ".M.......",
+        "/boot/efi/EFI/fedora/grubaa64.efi": ".......T.",
+        "/etc/machine-id": ".M.......",
+        "/etc/udev/hwdb.bin": ".M.......",
+        "/proc": ".M.......",
+        "/sys": ".M.......",
+        "/var/log/lastlog": ".M....G.."
+      },
+      "missing": []
+    },
+    "selinux": {
+      "context-mismatch": [
+        {
+          "actual": "system_u:object_r:unlabeled_t:s0",
+          "expected": "system_u:object_r:lost_found_t:s0",
+          "filename": "/lost+found"
+        }
+      ],
+      "policy": {
+        "SELINUX": "enforcing",
+        "SELINUXTYPE": "targeted"
+      }
+    },
+    "services-disabled": [
+      "arp-ethers.service",
+      "chrony-wait.service",
+      "console-getty.service",
+      "debug-shell.service",
+      "exit.target",
+      "halt.target",
+      "kexec.target",
+      "loadmodules.service",
+      "man-db-restart-cache-update.service",
+      "nftables.service",
+      "nis-domainname.service",
+      "poweroff.target",
+      "proc-sys-fs-binfmt_misc.mount",
+      "rdisc.service",
+      "remote-cryptsetup.target",
+      "remote-veritysetup.target",
+      "runlevel0.target",
+      "selinux-check-proper-disable.service",
+      "serial-getty@.service",
+      "sshd-keygen@.service",
+      "sshd.socket",
+      "sssd-autofs.socket",
+      "sssd-nss.socket",
+      "sssd-pac.socket",
+      "sssd-pam-priv.socket",
+      "sssd-pam.socket",
+      "sssd-ssh.socket",
+      "sssd-sudo.socket",
+      "systemd-boot-check-no-failures.service",
+      "systemd-network-generator.service",
+      "systemd-networkd-wait-online.service",
+      "systemd-networkd.service",
+      "systemd-networkd.socket",
+      "systemd-pstore.service",
+      "systemd-sysext.service",
+      "systemd-time-wait-sync.service",
+      "systemd-timesyncd.service",
+      "tcsd.service"
+    ],
+    "services-enabled": [
+      "NetworkManager-dispatcher.service",
+      "NetworkManager-wait-online.service",
+      "NetworkManager.service",
+      "auditd.service",
+      "autovt@.service",
+      "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
+      "ctrl-alt-del.target",
+      "dbus-broker.service",
+      "dbus-org.fedoraproject.FirewallD1.service",
+      "dbus-org.freedesktop.home1.service",
+      "dbus-org.freedesktop.nm-dispatcher.service",
+      "dbus-org.freedesktop.oom1.service",
+      "dbus-org.freedesktop.resolve1.service",
+      "dbus.service",
+      "dbus.socket",
+      "dnf-makecache.timer",
+      "firewalld.service",
+      "fstrim.timer",
+      "getty@.service",
+      "import-state.service",
+      "qemu-guest-agent.service",
+      "reboot.target",
+      "remote-fs.target",
+      "rpmdb-rebuild.service",
+      "runlevel6.target",
+      "selinux-autorelabel-mark.service",
+      "sshd.service",
+      "sssd-kcm.socket",
+      "sssd.service",
+      "systemd-homed-activate.service",
+      "systemd-homed.service",
+      "systemd-oomd.service",
+      "systemd-resolved.service",
+      "systemd-userdbd.socket",
+      "unbound-anchor.timer"
+    ],
+    "sudoers": {
+      "/etc/sudoers": [
+        "Defaults   !visiblepw",
+        "Defaults    always_set_home",
+        "Defaults    match_group_by_gid",
+        "Defaults    always_query_group_plugin",
+        "Defaults    env_reset",
+        "Defaults    env_keep =  \"COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS\"",
+        "Defaults    env_keep += \"MAIL QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE\"",
+        "Defaults    env_keep += \"LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES\"",
+        "Defaults    env_keep += \"LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE\"",
+        "Defaults    env_keep += \"LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY\"",
+        "Defaults    secure_path = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+        "root\tALL=(ALL) \tALL",
+        "%wheel\tALL=(ALL)\tALL"
+      ]
+    },
+    "sysctl.d": {
+      "/usr/lib/sysctl.d": {
+        "10-default-yama-scope.conf": [
+          "kernel.yama.ptrace_scope = 0"
+        ],
+        "50-coredump.conf": [
+          "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h",
+          "kernel.core_pipe_limit=16",
+          "fs.suid_dumpable=2"
+        ],
+        "50-default.conf": [
+          "kernel.sysrq = 16",
+          "kernel.core_uses_pid = 1",
+          "net.ipv4.conf.default.rp_filter = 2",
+          "net.ipv4.conf.*.rp_filter = 2",
+          "-net.ipv4.conf.all.rp_filter",
+          "net.ipv4.conf.default.accept_source_route = 0",
+          "net.ipv4.conf.*.accept_source_route = 0",
+          "-net.ipv4.conf.all.accept_source_route",
+          "net.ipv4.conf.default.promote_secondaries = 1",
+          "net.ipv4.conf.*.promote_secondaries = 1",
+          "-net.ipv4.conf.all.promote_secondaries",
+          "-net.ipv4.ping_group_range = 0 2147483647",
+          "-net.core.default_qdisc = fq_codel",
+          "fs.protected_hardlinks = 1",
+          "fs.protected_symlinks = 1",
+          "fs.protected_regular = 1",
+          "fs.protected_fifos = 1"
+        ],
+        "50-libkcapi-optmem_max.conf": [
+          "net.core.optmem_max = 81920"
+        ],
+        "50-pid-max.conf": [
+          "kernel.pid_max = 4194304"
+        ]
+      }
+    },
+    "systemd-service-dropins": {
+      "/usr/lib/systemd/system": {
+        "systemd-hostnamed.service.d": {
+          "Service": {
+            "PrivateDevices": "no"
+          }
+        },
+        "systemd-logind.service.d": {
+          "Service": {
+            "Environment": "SYSTEMD_REBOOT_TO_BOOT_LOADER_MENU=true"
+          }
+        },
+        "systemd-udev-trigger.service.d": {
+          "Unit": {
+            "RefuseManualStop": "true"
+          }
+        },
+        "user@.service.d": {
+          "Service": {
+            "ManagedOOMMemoryPressure": "kill",
+            "ManagedOOMMemoryPressureLimit": "50%"
+          }
+        }
+      }
+    },
+    "timezone": "UTC",
+    "tmpfiles.d": {
+      "/usr/lib/tmpfiles.d": {
+        "cloud-init.conf": [
+          "d /run/cloud-init 0700 root root - -"
+        ],
+        "cryptsetup.conf": [
+          "d /run/cryptsetup 0700 root root -"
+        ],
+        "dnf.conf": [
+          "R /var/tmp/dnf*/locks/*",
+          "r /var/cache/dnf/download_lock.pid",
+          "r /var/cache/dnf/metadata_lock.pid",
+          "r /var/lib/dnf/rpmdb_lock.pid",
+          "r /var/log/log_lock.pid"
+        ],
+        "etc.conf": [
+          "L /etc/os-release - - - - ../usr/lib/os-release",
+          "L+ /etc/mtab - - - - ../proc/self/mounts",
+          "L! /etc/resolv.conf - - - - ../run/systemd/resolve/stub-resolv.conf",
+          "C! /etc/nsswitch.conf - - - -",
+          "C! /etc/pam.d - - - -",
+          "C! /etc/issue - - - -"
+        ],
+        "home.conf": [
+          "Q /home 0755 - - -",
+          "q /srv 0755 - - -"
+        ],
+        "journal-nocow.conf": [
+          "h /var/log/journal - - - - +C",
+          "h /var/log/journal/%m - - - - +C",
+          "h /var/log/journal/remote - - - - +C"
+        ],
+        "legacy.conf": [
+          "d /run/lock 0755 root root -",
+          "L /var/lock - - - - ../run/lock",
+          "d /run/lock/subsys 0755 root root -",
+          "r! /forcefsck",
+          "r! /fastboot",
+          "r! /forcequotacheck"
+        ],
+        "libselinux.conf": [
+          "d /run/setrans 0755 root root"
+        ],
+        "man-db.conf": [
+          "d /var/cache/man 0755 root root 1w"
+        ],
+        "pam.conf": [
+          "d /run/console 0755 root root -",
+          "d /run/faillock 0755 root root -",
+          "d /run/sepermit 0755 root root -",
+          "d /run/motd.d 0755 root root -",
+          "f /var/log/tallylog 0600 root root -"
+        ],
+        "portables.conf": [
+          "Q /var/lib/portables 0700"
+        ],
+        "selinux-policy.conf": [
+          "z /sys/devices/system/cpu/online - - -",
+          "Z /sys/class/net - - -",
+          "z /sys/kernel/uevent_helper - - -",
+          "w /sys/fs/selinux/checkreqprot - - - - 0"
+        ],
+        "setup.conf": [
+          "f /run/motd 0644 root root -",
+          "d /run/motd.d 0755 root root -"
+        ],
+        "spice-vdagentd.conf": [
+          "d /run/spice-vdagentd 0755 root root -"
+        ],
+        "static-nodes-permissions.conf": [
+          "z /dev/snd/seq      0660 - audio -",
+          "z /dev/snd/timer    0660 - audio -",
+          "z /dev/loop-control 0660 - disk  -",
+          "z /dev/net/tun      0666 - -     -",
+          "z /dev/fuse         0666 - -     -",
+          "z /dev/kvm          0666 - kvm -",
+          "z /dev/vhost-net    0666 - kvm -",
+          "z /dev/vhost-vsock  0666 - kvm -"
+        ],
+        "sudo.conf": [
+          "d /run/sudo 0711 root root",
+          "D /run/sudo/ts 0700 root root"
+        ],
+        "systemd-nologin.conf": [
+          "F! /run/nologin 0644 - - - \"System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8).\""
+        ],
+        "systemd-pstore.conf": [
+          "d /var/lib/systemd/pstore 0755 root root 14d"
+        ],
+        "systemd-tmp.conf": [
+          "x /tmp/systemd-private-%b-*",
+          "X /tmp/systemd-private-%b-*/tmp",
+          "x /var/tmp/systemd-private-%b-*",
+          "X /var/tmp/systemd-private-%b-*/tmp",
+          "R! /tmp/systemd-private-*",
+          "R! /var/tmp/systemd-private-*",
+          "x  /var/lib/systemd/coredump/.#core*.%b*",
+          "r! /var/lib/systemd/coredump/.#*"
+        ],
+        "systemd.conf": [
+          "d /run/user 0755 root root -",
+          "F! /run/utmp 0664 root utmp -",
+          "d /run/systemd/ask-password 0755 root root -",
+          "d /run/systemd/seats 0755 root root -",
+          "d /run/systemd/sessions 0755 root root -",
+          "d /run/systemd/users 0755 root root -",
+          "d /run/systemd/machines 0755 root root -",
+          "d /run/systemd/shutdown 0755 root root -",
+          "d /run/systemd/netif 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/links 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/leases 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/lldp 0755 systemd-network systemd-network -",
+          "d /run/log 0755 root root -",
+          "z /run/log/journal 2755 root systemd-journal - -",
+          "Z /run/log/journal/%m ~2750 root systemd-journal - -",
+          "a+ /run/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m/*.journal* - - - - group:adm:r--,group:wheel:r--",
+          "z /var/log/journal 2755 root systemd-journal - -",
+          "z /var/log/journal/%m 2755 root systemd-journal - -",
+          "z /var/log/journal/%m/system.journal 0640 root systemd-journal - -",
+          "a+ /var/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m/system.journal - - - - group:adm:r--,group:wheel:r--",
+          "d /var/lib/systemd 0755 root root -",
+          "d /var/lib/systemd/coredump 0755 root root 3d",
+          "d /var/lib/private 0700 root root -",
+          "d /var/log/private 0700 root root -",
+          "d /var/cache/private 0700 root root -"
+        ],
+        "tmp.conf": [
+          "q /tmp 1777 root root 10d",
+          "q /var/tmp 1777 root root 30d"
+        ],
+        "tpm2-tss-fapi.conf": [
+          "d       /var/lib/tpm2-tss/system/keystore   2775 tss  tss   -           -",
+          "a+      /var/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx",
+          "d       /run/tpm2-tss/eventlog                2775 tss  tss   -           -",
+          "a+      /run/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx"
+        ],
+        "var.conf": [
+          "q /var 0755 - - -",
+          "L /var/run - - - - ../run",
+          "d /var/log 0755 - - -",
+          "f /var/log/wtmp 0664 root utmp -",
+          "f /var/log/btmp 0660 root utmp -",
+          "f /var/log/lastlog 0664 root utmp -",
+          "d /var/cache 0755 - - -",
+          "d /var/lib 0755 - - -",
+          "d /var/spool 0755 - - -"
+        ],
+        "x11.conf": [
+          "D! /tmp/.X11-unix 1777 root root 10d",
+          "D! /tmp/.ICE-unix 1777 root root 10d",
+          "D! /tmp/.XIM-unix 1777 root root 10d",
+          "D! /tmp/.font-unix 1777 root root 10d",
+          "D! /tmp/.Test-unix 1777 root root 10d",
+          "r! /tmp/.X[0-9]*-lock"
+        ]
+      }
+    }
+  }
+}

--- a/test/data/manifests/fedora_34-aarch64-qcow2-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-qcow2-boot.json
@@ -1,0 +1,10188 @@
+{
+  "compose-request": {
+    "distro": "fedora-34",
+    "arch": "aarch64",
+    "image-type": "qcow2",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-modular-20210512/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-modular-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      }
+    ],
+    "filename": "disk.qcow2",
+    "blueprint": {
+      "name": "qcow2-boot-test",
+      "description": "Image for boot test",
+      "packages": [],
+      "modules": [],
+      "groups": [],
+      "customizations": {
+        "user": [
+          {
+            "name": "redhat",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+          }
+        ]
+      }
+    }
+  },
+  "manifest": {
+    "sources": {
+      "org.osbuild.files": {
+        "urls": {
+          "sha256:00c29524aad123ec44056e60b9625e75ac428a6c751878a05fadbca7e956c249": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dbus-1.2.18-1.fc34.aarch64.rpm"
+          },
+          "sha256:0176b42c6b51fb3c829f168571527a3559b6a9c8cc5f847b70e3c40fb69f89e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-100.fc34.aarch64.rpm"
+          },
+          "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-legacy-libs-1.8.7-8.fc34.aarch64.rpm"
+          },
+          "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-9.fc34.aarch64.rpm"
+          },
+          "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc34.aarch64.rpm"
+          },
+          "sha256:059f825547fe257247656c29049ebc7bfa1d54a17479f3dcfeff37fbab7084bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.33-20.fc34.aarch64.rpm"
+          },
+          "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libibverbs-37.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc34.aarch64.rpm"
+          },
+          "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.aarch64.rpm"
+          },
+          "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm"
+          },
+          "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pip-21.0.1-4.fc34.noarch.rpm"
+          },
+          "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cyrus-sasl-lib-2.1.27-8.fc34.aarch64.rpm"
+          },
+          "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxml2-2.9.12-4.fc34.aarch64.rpm"
+          },
+          "sha256:0ac62147585be2dae960ed37a3a0c3eb2f8a95d0fd0993991c8bf7238b1d5e27": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dhcp-client-4.4.2-11.b1.fc34.aarch64.rpm"
+          },
+          "sha256:0db1be9a78e5f329a519066a7b37379f6c73fe579154e0a6a26b2dcb4154ccd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-common-2.33-20.fc34.aarch64.rpm"
+          },
+          "sha256:0f9ebdf7f08a506a8d1d6c4b4788dd7ca3dbb832509072b66def4da5b86d7862": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/efibootmgr-16-10.fc34.aarch64.rpm"
+          },
+          "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm"
+          },
+          "sha256:1014763656c1578ae96b38fd3e87c4d07b548cb8423688cc928d0f9762d43a44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfido2-1.6.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libblkid-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:11a0c09b716f8071f0484278bec326fb82e93d987376c8b38188d1febcd5381d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libndp-1.7-7.fc34.aarch64.rpm"
+          },
+          "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:11cd6fae157eb9e4800163633b57bcce21d59a1df4b86a99ba03707b6cee0cfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dhcp-common-4.4.2-11.b1.fc34.noarch.rpm"
+          },
+          "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libuuid-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm"
+          },
+          "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-ng-0.8.2-4.fc34.aarch64.rpm"
+          },
+          "sha256:12b7666d61e7bd8b3b5b1a7c57539964531802287e592e33449e039799ea2071": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbasicobjects-0.1.1-47.fc34.aarch64.rpm"
+          },
+          "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/which-2.21-26.fc34.aarch64.rpm"
+          },
+          "sha256:131adc47f044c9f600f5295ded0f5431cda57fa7276100c3ec81c9d1ce3fa6f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jwt-1.7.1-11.fc34.noarch.rpm"
+          },
+          "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:139b9453b2038e52767d0102def782d58d558ca0603757eb0c97ddda28af1466": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-audit-3.0.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:148aea26e381b33badde0ac2ae716a78f7b565f54f0b6970189a89713f335eaf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-3.0.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:164e1c0e3e8c89aeda4f272b3158932649a69b16aea058105117a64d3cdef517": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rootfiles-8.1-29.fc34.noarch.rpm"
+          },
+          "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm"
+          },
+          "sha256:1877af369228dd661ae1adfc43bbb8d53d3464d59ead0f5bcf6c2be88f8e8685": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-0.21.2-1.fc34.noarch.rpm"
+          },
+          "sha256:1af86c0a8c11e44958b022bf7dad5f48ad974fa8537cf41a12d5b0643444b1dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.3755-1.fc34.aarch64.rpm"
+          },
+          "sha256:1b1af6b54050ec223c3289b107a9695a686c9d46d17a80ec9cd5d0201ec5d544": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonpointer-2.0-2.fc34.noarch.rpm"
+          },
+          "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.aarch64.rpm"
+          },
+          "sha256:1feb6a045cb3e95e3c8e0112ecb4b8ffeb9986a503b52c5497fefce217846b90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc34.noarch.rpm"
+          },
+          "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.aarch64.rpm"
+          },
+          "sha256:2027da420b35a0b70ae5045d2fd79cdccb820f03e5ff4018a2205d3d413ff1af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtdb-1.4.3-6.fc34.aarch64.rpm"
+          },
+          "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm"
+          },
+          "sha256:23a539a271c92906ac0a12c7d877c7f4d0ad8e6b9bbd8642b5232f861b79ed22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shim-aa64-15.4-4.aarch64.rpm"
+          },
+          "sha256:23e3ed871799a9209915359f71660babf451b0b44902e3ed488b7b22aff37718": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-ply-3.11-11.fc34.noarch.rpm"
+          },
+          "sha256:2414cb7345bc193f7ff7983c020c8b0e706aab013ee30af5d457d35c4de4a698": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jinja2-2.11.3-1.fc34.noarch.rpm"
+          },
+          "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/whois-nls-5.5.10-1.fc34.noarch.rpm"
+          },
+          "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpsl-0.21.1-3.fc34.aarch64.rpm"
+          },
+          "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm"
+          },
+          "sha256:27920113489e3260e58d4a033d31401c6ae22ded72895c6b8c0e43ebf89a62df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/parted-3.4-2.fc34.aarch64.rpm"
+          },
+          "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/nettle-3.7.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-all-langpacks-5.1.0-3.fc34.aarch64.rpm"
+          },
+          "sha256:2968703dd232a37620a0ae12146c9d1ec5220f62c40bfb0ecfc60b621d8e1eac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-dicts-2.9.6-27.fc34.aarch64.rpm"
+          },
+          "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-34.23-1.fc34.noarch.rpm"
+          },
+          "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-8.32-30.fc34.aarch64.rpm"
+          },
+          "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxkbcommon-1.3.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:30bc3583e503e0f459e323b27551f7b9a8ab784de15437b5b29f447b31f8d9cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/y/yum-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.aarch64.rpm"
+          },
+          "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:32220dc513a6ebcd4994e7140ecb5859108baf44d12fe6b1f0c0459dbefc54e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pycparser-2.20-3.fc34.noarch.rpm"
+          },
+          "sha256:3228a36807658c7e4d881013aa26f877353388bf3bac6c948984f751c264a359": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xfsprogs-5.10.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:330a36b1dabaf76daafeff3f7fd7a276880bf65d790ee84cb823a1958a4d99d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libnfsidmap-2.5.4-2.rc3.fc34.aarch64.rpm"
+          },
+          "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-6.2-4.20200222.fc34.aarch64.rpm"
+          },
+          "sha256:33b878000610ca3ba875b72f2a454e4fac9471f80579824304ca81e6f3e3f79d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/checkpolicy-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-20210213-1.git5c710c0.fc34.noarch.rpm"
+          },
+          "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm"
+          },
+          "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-setuptools-wheel-53.0.0-2.fc34.noarch.rpm"
+          },
+          "sha256:37cda2c179e4311a1aeeb0ea8d07d3eacc8ea8bf97d122ec22cd596c61b8e770": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/groff-base-1.22.4-7.fc34.aarch64.rpm"
+          },
+          "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.aarch64.rpm"
+          },
+          "sha256:39160ef65b3519a70f14f992edc5967380ef86a6940896751db681781961903d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-server-8.6p1-5.fc34.aarch64.rpm"
+          },
+          "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sed-4.8-7.fc34.aarch64.rpm"
+          },
+          "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.aarch64.rpm"
+          },
+          "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grep-3.6-2.fc34.aarch64.rpm"
+          },
+          "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.0.1-4.fc34.noarch.rpm"
+          },
+          "sha256:3b3bba1d61529a1dde47f234f34d0fdee07a38aa5958d87e30357ea04bbff142": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.aarch64.rpm"
+          },
+          "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/keyutils-libs-1.6.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-0.21-4.fc34.aarch64.rpm"
+          },
+          "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/setup-2.13.7-3.fc34.noarch.rpm"
+          },
+          "sha256:3e69e8412d5914ec01c5e82264833698e92a1b88a7c7b5ed9b1f0351fc91f5d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-34-39.noarch.rpm"
+          },
+          "sha256:3f7bde703045c2651fbd4142131ea1e303a565269388a08e2312af0eb83307a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-issuegen-0.21.2-1.fc34.noarch.rpm"
+          },
+          "sha256:3fb05067cbd7fcf3283f2ab306c2dae668d818d3a69422e729c2ef62974810a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fonts-filesystem-2.0.5-5.fc34.noarch.rpm"
+          },
+          "sha256:3fdab509a59e0a765364d6f119c38c796a4420cc49b46595a37d98eb649d6c80": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm"
+          },
+          "sha256:40e231991444a589b17e0b5b338be8874d071e3d17e210aba6f6639620775f79": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-1.9.5p2-1.fc34.aarch64.rpm"
+          },
+          "sha256:4123331b5d06f91ff31d147e4769806052f59b620e7677f69b0073eaf7beccb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:424f73b97c7d7541d35685108bdcddb03100cd0f3d6e0fd9def576462ca65b59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-profile-0.21.2-1.fc34.noarch.rpm"
+          },
+          "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.aarch64.rpm"
+          },
+          "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.9.9-2.fc34.noarch.rpm"
+          },
+          "sha256:43b0b5d425a2041daeb6b41db2858abda1f92ecc38c6125f7de3b7502580a9f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:45d38ed1d2247e17e3e8faf7d6755216c5ef4422736129f55b712f160532d8f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libini_config-1.3.1-47.fc34.aarch64.rpm"
+          },
+          "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm"
+          },
+          "sha256:47c92a952b162b7bafbe49a7e409a7a81825adc77b3e139651913d52d8aa84fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/h/hostname-3.23-4.fc34.aarch64.rpm"
+          },
+          "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsemanage-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnl3-3.5.0-6.fc34.aarch64.rpm"
+          },
+          "sha256:4a74ae08a713e9b4e74ff27bfaf57374312370402f90e2796e66c504557ae189": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pysocks-1.7.1-8.fc34.noarch.rpm"
+          },
+          "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:4b65dc9856b0d0ce555dd9bce88dcfb680ba689a2c6b88ae9f84b016553d96af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iputils-20210202-2.fc34.aarch64.rpm"
+          },
+          "sha256:4baf8ba6a5ed4609695f79a8bbc8324d7efa322a3573c8c5fa3942361eac0f1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.30.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-1.12.20-3.fc34.aarch64.rpm"
+          },
+          "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-2.9.6-27.fc34.aarch64.rpm"
+          },
+          "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/curl-7.76.1-12.fc34.aarch64.rpm"
+          },
+          "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-common-1.12.20-3.fc34.noarch.rpm"
+          },
+          "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gdbm-libs-1.19-2.fc34.aarch64.rpm"
+          },
+          "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/gnutls-3.7.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:55833f669ed1dbd32e79f494824c309b71bc373d2bf28eb5cdb663459dc6f7cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-100.fc34.aarch64.rpm"
+          },
+          "sha256:56634e58fc7499d719a3f431dd188e8f2655ebfa402e94ce105794a47debf45b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtalloc-2.3.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.aarch64.rpm"
+          },
+          "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc34.aarch64.rpm"
+          },
+          "sha256:59cc4d563ecb4c8b517f5dd7505f1cda297f950f32fc700344aa7789b69ca99c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-babel-2.9.1-1.fc34.noarch.rpm"
+          },
+          "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:5d2c28837f0573ae2647b8fbba85f7c502f9c3da0a3eab1c9ba121de4a1a6cee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-dateutil-2.8.1-3.fc34.noarch.rpm"
+          },
+          "sha256:5dcac7772d73ad1523f87cbeb1dc76dd62af4d2bb73dd06896a47d2bcf503e5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-8.6p1-5.fc34.aarch64.rpm"
+          },
+          "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm"
+          },
+          "sha256:6046f881a5c0822c30bd037aec040c65594b6328b1c0d72b6681fe1575eac765": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcbor-0.7.0-3.fc34.aarch64.rpm"
+          },
+          "sha256:60ddc7b15e9742ff9995d1b336489b92721e21a45034d20f20d2fc800e419d1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/popt-1.18-4.fc34.aarch64.rpm"
+          },
+          "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:61a9dbd9020e29012947978acf33a0c1150e6c3e078de372f1e38fb9c4ef529a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/chrony-4.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:61ba1ecff8f8578cbd3445df596d001067bb0281745191ac168fcc6079d8e1cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/man-db-2.9.3-3.fc34.aarch64.rpm"
+          },
+          "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-3.9.9-2.fc34.aarch64.rpm"
+          },
+          "sha256:6297d7eee103c679a0f1ea411568d3940af3fe8f38e19388a1544df70bda8b3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-requests-2.25.1-1.fc34.noarch.rpm"
+          },
+          "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpcap-1.10.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-0.23.22-3.fc34.aarch64.rpm"
+          },
+          "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbrotli-1.0.9-4.fc34.aarch64.rpm"
+          },
+          "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-libs-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm"
+          },
+          "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtirpc-1.3.2-0.fc34.aarch64.rpm"
+          },
+          "sha256:668a30c6f526e51705af9cb9d98fd11f279f5e86f7d905876ae9a86f486a8c36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-common-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm"
+          },
+          "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm"
+          },
+          "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-34.23-1.fc34.noarch.rpm"
+          },
+          "sha256:686e015d81c1be2e6b88c7e8a50d45109d7273143a034caa9c935ecd014e1c62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libref_array-0.1.5-47.fc34.aarch64.rpm"
+          },
+          "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-trust-0.23.22-3.fc34.aarch64.rpm"
+          },
+          "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/procps-ng-3.3.17-1.fc34.1.aarch64.rpm"
+          },
+          "sha256:69de3dd68dc2b76e2a85c710a51e9c8acefe595d6ac5d9f19113c4062a5f0d92": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/ipcalc-1.0.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:6a864bec34b7d39de3e6ae1e39ec07fa3a2d21837a9a2d7151228d7f0ac38e73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/passwd-0.80-10.fc34.aarch64.rpm"
+          },
+          "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-34-2.noarch.rpm"
+          },
+          "sha256:6d1b95e06ec98f6d65c64e18fec693d379b98128a3e94b4dec8929321354c549": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cloud-utils-growpart-0.31-8.fc34.noarch.rpm"
+          },
+          "sha256:6d1c024b295c423746b44f120cf36ceb0fd898f8ce5a276813d7c78a3c8ece52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-34-39.noarch.rpm"
+          },
+          "sha256:6d3301f6e99d9728698822e81fc2d170694cc367b7e7fea5c7a019f7b1a6073b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/inih-49-3.fc34.aarch64.rpm"
+          },
+          "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm"
+          },
+          "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fuse-libs-2.9.9-11.fc34.aarch64.rpm"
+          },
+          "sha256:70a90c6c682016e91fb4745eedbd23f28e150a38b01d18f85ce4e50fb4e0ca6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pyserial-3.4-10.fc34.noarch.rpm"
+          },
+          "sha256:71427f6f8f3f6370dccde81a76d566ff17144e7e375381ef13e04a661e63cba1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-9.fc34.aarch64.rpm"
+          },
+          "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtextstyle-0.21-4.fc34.aarch64.rpm"
+          },
+          "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-config-0.9.6-1.fc34.noarch.rpm"
+          },
+          "sha256:7285fcc290a8af2cf845beb845e661cd4c06c2275417b15eb507824dedec7c69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnghttp2-1.43.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtasn1-4.16.0-4.fc34.aarch64.rpm"
+          },
+          "sha256:7721bc647c521d96e07e665f7da306326d3bd1499d610c58552317815aaf3c45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lmdb-libs-0.9.29-1.fc34.aarch64.rpm"
+          },
+          "sha256:79834af7f95c0d1e5dcf85b794819bd854197a52d2966594abdb3c3de0fcceb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dejavu-sans-fonts-2.37-16.fc34.noarch.rpm"
+          },
+          "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:79864051052858a1c95538888ca61a43b509b6eae4ae269ae6ea7bf8b076a2b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmnl-1.0.4-13.fc34.aarch64.rpm"
+          },
+          "sha256:7c24e53e12891046bb6721e624cf9effd1946c0d076464427c2a86b29671318e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/c-ares-1.17.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:7cc0891a9e7c19757c03cba6c8155738d9db9f5774380c412106adf0eca44077": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/less-590-2.fc34.aarch64.rpm"
+          },
+          "sha256:7d00ccbb224617a00f58053afd88e7a49062446f1306ba39c72b78d20aeee1ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-cffi-1.14.5-1.fc34.aarch64.rpm"
+          },
+          "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/z/zlib-1.2.11-26.fc34.aarch64.rpm"
+          },
+          "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/filesystem-3.14-5.fc34.aarch64.rpm"
+          },
+          "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm"
+          },
+          "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-common-34-39.noarch.rpm"
+          },
+          "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch.rpm"
+          },
+          "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/findutils-4.8.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bzip2-libs-1.0.8-6.fc34.aarch64.rpm"
+          },
+          "sha256:820fee96d610178c7c7b8ce2b115bd02063d2f6dfcae5da4bf5d411de0b575f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-attrs-20.3.0-2.fc34.noarch.rpm"
+          },
+          "sha256:82b51ca6bec551d74a6d8c43194b0fd4e8bfdf19d1d68b58c1787723edd88bd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-en-3.0-14.fc34.noarch.rpm"
+          },
+          "sha256:82cbc5e0339e832d2fc0160541c30f3dee59b3d28d83907ae7b55e22d5092c51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-core-font-en-3.0-14.fc34.noarch.rpm"
+          },
+          "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-common-8.32-30.fc34.aarch64.rpm"
+          },
+          "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-29-2.fc34.aarch64.rpm"
+          },
+          "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:86cb1e5e80642b1575df57287c9549749603bf94b1ba652995b59ea45ac4272b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libldb-2.3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-libs-1.02.175-1.fc34.aarch64.rpm"
+          },
+          "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pam-1.5.1-7.fc34.aarch64.rpm"
+          },
+          "sha256:87749765dbe5ce8f098279170c39bb8a89abbf3f8430c2a6dbfb973117e11dfa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-libsemanage-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libidn2-2.3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.aarch64.rpm"
+          },
+          "sha256:8ab032e2a86f300d978e521ab030db1e7bb7eeccca205a5d2a4d68b51566f43f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc34.noarch.rpm"
+          },
+          "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openldap-2.4.57-6.fc34.aarch64.rpm"
+          },
+          "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libs-3.9.9-2.fc34.aarch64.rpm"
+          },
+          "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre-8.44-3.fc34.1.aarch64.rpm"
+          },
+          "sha256:8fbfbaf3b107b540428634c19c4cb05e7c46f9672cfbf14d1f44306ed3413a46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/efi-filesystem-5-4.fc34.noarch.rpm"
+          },
+          "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm"
+          },
+          "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc34.aarch64.rpm"
+          },
+          "sha256:92e42b63fcc56dd21984abb722e8fa7ebbb58f6d54c529ac11871b4bbc63b290": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pyyaml-5.4.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gmp-6.2.0-6.fc34.aarch64.rpm"
+          },
+          "sha256:96c7a26b707d4038a50b4ab0fd8d79ba3997466bed543f13c10d30e7ec256b5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/net-tools-2.0-0.59.20160912git.fc34.aarch64.rpm"
+          },
+          "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm"
+          },
+          "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/basesystem-11-11.fc34.noarch.rpm"
+          },
+          "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-5.2.5-5.fc34.aarch64.rpm"
+          },
+          "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/openssl-pkcs11-0.4.11-2.fc34.aarch64.rpm"
+          },
+          "sha256:9aee2549d3ff9e5652dffaaa9b91ab7a243687cc2a85b8e45f4290d53d44702d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc34.aarch64.rpm"
+          },
+          "sha256:9cc240ac305a862146e85d8dcc4ad981f5233a58b6901ecfac691d0b39966b49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jwt+crypto-1.7.1-11.fc34.noarch.rpm"
+          },
+          "sha256:9ce3f0c0904ac22ab5769babebf43e7dcdb488b0ef999b2e9e88a5b5eb424e51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-chardet-4.0.0-1.fc34.noarch.rpm"
+          },
+          "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm"
+          },
+          "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsepol-3.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-libs-0.21-4.fc34.aarch64.rpm"
+          },
+          "sha256:9f2f2a20f285a2ac306ce72475beecf967cf92308b426aafca68215a6c3c12ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/jansson-2.13.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-misc-2.4.0-2.fc34.noarch.rpm"
+          },
+          "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.aarch64.rpm"
+          },
+          "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm"
+          },
+          "sha256:a0f1b653f889bb95e6edec2c525dfc71e280076b29394cf9c06ffa81ecd8b9fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/efivar-libs-37-15.fc34.aarch64.rpm"
+          },
+          "sha256:a1a996e8da4733b14c449b69e34484fe4f2b88c0f2963145bf0402cf04baf30e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpath_utils-0.2.1-47.fc34.aarch64.rpm"
+          },
+          "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc34.noarch.rpm"
+          },
+          "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-gpg-keys-34-2.noarch.rpm"
+          },
+          "sha256:a60e3e035883de829c5778417d316ffc47a0b4a304953e3fdc44def8f2f172ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/linux-atm-libs-2.5.1-28.fc34.aarch64.rpm"
+          },
+          "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:a72bb74400b447af71600da141aebdc46da7776ef875abfdd635881f939891d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtevent-0.11.0-0.fc34.aarch64.rpm"
+          },
+          "sha256:a86ec8f7284ee01574bb06bba726d8609e464f41d003215097e626c583f73ed0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-python-plugin-1.9.5p2-1.fc34.aarch64.rpm"
+          },
+          "sha256:a9828dc2c4215e6bcb9aa14370d854f24637b0510e4b1a63709135049314e2b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rsync-3.2.3-5.fc34.aarch64.rpm"
+          },
+          "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-2.33-20.fc34.aarch64.rpm"
+          },
+          "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssl-libs-1.1.1l-2.fc34.aarch64.rpm"
+          },
+          "sha256:ac901ae730144d1e75b86d9991c1c6a9d6d0a44ce6e52b4d330df3a26d09e1ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/u/util-linux-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnsl2-1.3.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm"
+          },
+          "sha256:adb1b49ec7038eec956edd77d0ad2a72179b4f37c14548e3c9637d8a75c276a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.33-20.fc34.aarch64.rpm"
+          },
+          "sha256:adcd36cb0e582f5fb2d0465cf88bb813ffac17d25d6ec8aa608b647d008bebc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.3755-1.fc34.noarch.rpm"
+          },
+          "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-networkd-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/policycoreutils-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm"
+          },
+          "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libgpg-error-1.42-1.fc34.aarch64.rpm"
+          },
+          "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/os-prober-1.77-7.fc34.aarch64.rpm"
+          },
+          "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-pam-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-libs-5.2.5-5.fc34.aarch64.rpm"
+          },
+          "sha256:b30db4e3d9605e7263387ff91f91508667693d28e8b8835a2b7fcefd64f24388": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-oauthlib+signedtoken-3.0.2-9.fc34.noarch.rpm"
+          },
+          "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm"
+          },
+          "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-lib-0.3.15-2.fc34.aarch64.rpm"
+          },
+          "sha256:b5d5e7255c85c3aa9d63598ef140de35843ab2485adf1cb9a9130be80aa0297f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-six-1.15.0-5.fc34.noarch.rpm"
+          },
+          "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:b6687e9977e337e5d029de0d42cb79d57bd44f2f642450440756ba1a0494a113": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libedit-3.1-38.20210714cvs.fc34.aarch64.rpm"
+          },
+          "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libattr-2.5.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.aarch64.rpm"
+          },
+          "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cpio-2.13-10.fc34.aarch64.rpm"
+          },
+          "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-1.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm"
+          },
+          "sha256:bab19da8b6f553325decae00748f88fc0924b918136f065ab8995e1ebf5bde5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc34.noarch.rpm"
+          },
+          "sha256:bb078ccf6e7372cf22e55901c005517daff0b8cffa14fa3dec5e9804b4f65897": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmaxminddb-1.5.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm"
+          },
+          "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm"
+          },
+          "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mkpasswd-5.5.10-1.fc34.aarch64.rpm"
+          },
+          "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-syntax-10.36-4.fc34.noarch.rpm"
+          },
+          "sha256:bfd008fce37b2ec17dc4142c38a6e808c2e0031eed802a0253fca812989845d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iproute-tc-5.10.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:c04a67670d45f576c5a8b23fe64d5ce31b04ddf4792cbf78448fd4c96899f9c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnfnetlink-1.0.1-19.fc34.aarch64.rpm"
+          },
+          "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-rpm-macros-248.9-1.fc34.noarch.rpm"
+          },
+          "sha256:c20caffb4d2a500416dab0e8418a24ae5e25c02c831ae02ee10f97a0dcc80374": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-core-en-3.0-14.fc34.noarch.rpm"
+          },
+          "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm"
+          },
+          "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc34.aarch64.rpm"
+          },
+          "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-2.48-2.fc34.aarch64.rpm"
+          },
+          "sha256:c814f83bcf3cfc590d84897c810a087354cfb0c961dd232af5031cfe8bd63a37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-client-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-10.36-4.fc34.aarch64.rpm"
+          },
+          "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm"
+          },
+          "sha256:ca8f4843c8b23ce16b957143550d8dc83ae630cd64587fa2dd127e4ecbe9bb23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnetfilter_conntrack-1.0.8-2.fc34.aarch64.rpm"
+          },
+          "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.aarch64.rpm"
+          },
+          "sha256:cc4401d1e292b28d771a2038081b929b342ffa3b60358aed91697fdbc668546a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-prettytable-0.7.2-25.fc34.noarch.rpm"
+          },
+          "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.aarch64.rpm"
+          },
+          "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcrypt-1.9.3-3.fc34.aarch64.rpm"
+          },
+          "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-0.9.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc34.noarch.rpm"
+          },
+          "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsigsegv-2.13-2.fc34.aarch64.rpm"
+          },
+          "sha256:cf18d61c8f526fe86cd24073dfdce942b6a463ea909ed5a59a5cc4378d9101a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcollection-0.7.0-47.fc34.aarch64.rpm"
+          },
+          "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/memstrack-0.2.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pigz-2.5-1.fc34.aarch64.rpm"
+          },
+          "sha256:d1c8a2302e64fc856aff6a05a78140986e89eddd8f110deb9ba78d44aebcd411": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/psmisc-23.4-1.fc34.aarch64.rpm"
+          },
+          "sha256:d2bac91a1969f555ea2641b161bb23fa0aaaffaba3284d9973ad696594b73f18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-motdgen-0.21.2-1.fc34.noarch.rpm"
+          },
+          "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-libs-29-2.fc34.aarch64.rpm"
+          },
+          "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bash-5.1.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:d54b628e6d0b7813ec0b4cc0beb1b8f3f8510ffbaff8ae1d9c4b9993095e4edf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-cloud-34-39.noarch.rpm"
+          },
+          "sha256:d5d622f60e97d43b095a98f2bb46982d91451e4e6018492da20944b294480af3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.6p1-5.fc34.aarch64.rpm"
+          },
+          "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.3.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:d6810c97f24d93cd54a61bb288ada8591a94e4083b5165e0719915bceb637504": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonschema-3.2.0-9.fc34.noarch.rpm"
+          },
+          "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/readline-8.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mpfr-4.1.0-7.fc34.aarch64.rpm"
+          },
+          "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-libs-3.0.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-9.fc34.aarch64.rpm"
+          },
+          "sha256:dbf3fb9e356236575a06e4fdcd532331f418236aa4ff4e024260c24be2b9a7cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-libselinux-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/json-c-0.14-8.fc34.aarch64.rpm"
+          },
+          "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/alternatives-1.15-2.fc34.aarch64.rpm"
+          },
+          "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/acl-2.3.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:e035a5041c721ea40e47cbbc19eb1b91c520183f85137ee1dd3ed3b42a47c180": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-cloud-34-39.noarch.rpm"
+          },
+          "sha256:e0dffa204780c20c16357a51b992351aa1cf9f9cdda6182939ecd0cd7ab2c2bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonpatch-1.21-14.fc34.noarch.rpm"
+          },
+          "sha256:e1e89027213f00ae1014bbb1253058ed8d5d476e7246921f03736ea129d2a162": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iproute-5.10.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:e1f1b9c4b78fe9d84a87d7de67fdd8559fe2bea9969ca1632d137de635d7e898": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-setools-4.4.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-0.3.15-2.fc34.aarch64.rpm"
+          },
+          "sha256:e530795e5c9bc27de609fcbbacdc43c226026fee95e47a1f783f1c03ba5d48ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-distro-1.5.0-5.fc34.noarch.rpm"
+          },
+          "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libutempter-1.2.1-4.fc34.aarch64.rpm"
+          },
+          "sha256:e76f1401d9e119eae4cc461c8b68e9eae075d4b69f61870cb5c19ba7d69cf1a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-policycoreutils-3.2-1.fc34.noarch.rpm"
+          },
+          "sha256:e7d1d0b85ac49d8b0c9dd3fce4613e6229ac8720cfb74c80a496b9f0beaa7a22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cloud-init-20.4-2.fc34.noarch.rpm"
+          },
+          "sha256:e9814c1b1a22b8cbd39413dc4f0eab452ef7380ce01f05ecab0e41e2d00ba3c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libdhash-0.5.0-47.fc34.aarch64.rpm"
+          },
+          "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm"
+          },
+          "sha256:ea8067f2310d30b31f7b1f13825b2a5a5e679c114fefd072267b6c369a365a63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-cryptography-3.4.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:eab8d30db6004f8c21247689cac52f143e1bde1da817db9761420cf3cf855c38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/initscripts-10.09-1.fc34.aarch64.rpm"
+          },
+          "sha256:eb88e660b9fd02e695a90c0266831b79e513c2f65ba5d6353e82726af96e9752": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-modular-34-2.noarch.rpm"
+          },
+          "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/krb5-libs-1.19.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:ebd4a9473543a5ca50ec5f9de069fc0c240527516ae262cf3e28a5d914b99cb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-libs-1.8.7-8.fc34.aarch64.rpm"
+          },
+          "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-1.02.175-1.fc34.aarch64.rpm"
+          },
+          "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:ee147f5a7017de1c77abfbb79dd32eb97c923fc7c1b74c32bda6020b9025938c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpipeline-1.5.3-2.fc34.aarch64.rpm"
+          },
+          "sha256:eecc86b828ad436a9f397d2f7acdf5705bfd36bcad3edd2da73f3acc94363411": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc34.noarch.rpm"
+          },
+          "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-5.39-7.fc34.aarch64.rpm"
+          },
+          "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm"
+          },
+          "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grubby-8.40-51.fc34.aarch64.rpm"
+          },
+          "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.25.10-5.fc34.noarch.rpm"
+          },
+          "sha256:f3c940f33c6c8edb73b98527e0fff17aa211e823f06e3f732762d0c86cc0268c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-100.fc34.aarch64.rpm"
+          },
+          "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-doc-2.33-20.fc34.noarch.rpm"
+          },
+          "sha256:f68c93c0461c149bb17282dededf421cbc1fbfa5ac133b59bd362526f59e0d57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-idna-2.10-3.fc34.noarch.rpm"
+          },
+          "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:f695ed244a1d9f3eb814947fb1da343d7d6fb3aaa2bf72965235e4b45a58a784": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.30.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm"
+          },
+          "sha256:f7c7dc1d8e5cf4776a1fde155871a2bb1fdd0676f897a43334cfbb60eb69e52a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/mokutil-0.4.0-4.fc34.aarch64.rpm"
+          },
+          "sha256:f7f8832ccaedd7ddad064956309478b9bf366f0576517356ee68481e196236cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-configobj-5.0.6-23.fc34.noarch.rpm"
+          },
+          "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm"
+          },
+          "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:f9b2e7232d0b2d33bf52993c31b43b31520601f52f44fe792acd6dee4d84afc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-oauthlib-3.0.2-9.fc34.noarch.rpm"
+          },
+          "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfdisk-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:fbf45cda87a05418a72f4bf3877da5ebcabbe68d393bc5bec007a8b01ef6bafe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-markupsafe-1.1.1-10.fc34.aarch64.rpm"
+          },
+          "sha256:fc4104e014beee44b5003e72a32e45e689936a4ffdcf07e119b02be3ed4ab8d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.17.3-6.fc34.aarch64.rpm"
+          },
+          "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lz4-libs-1.9.3-2.fc34.aarch64.rpm"
+          },
+          "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.8.1-10.fc34.aarch64.rpm"
+          },
+          "sha256:fd7dc918a1e3ad0114ecaa41d78c6652cc559271ad6653e5bba0bc780af35faa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libuser-0.63-4.fc34.aarch64.rpm"
+          },
+          "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.aarch64.rpm"
+          }
+        }
+      }
+    },
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.rpm",
+              "options": {
+                "gpgkeys": [
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n"
+                ],
+                "packages": [
+                  {
+                    "checksum": "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3e69e8412d5914ec01c5e82264833698e92a1b88a7c7b5ed9b1f0351fc91f5d2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6d1c024b295c423746b44f120cf36ceb0fd898f8ce5a276813d7c78a3c8ece52",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:adb1b49ec7038eec956edd77d0ad2a72179b4f37c14548e3c9637d8a75c276a1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
+                    "check_gpg": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "org.osbuild.selinux",
+              "options": {
+                "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+                "labels": {
+                  "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+                }
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.fedora33"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8"
+          }
+        },
+        {
+          "name": "org.osbuild.rpm",
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "packages": [
+              {
+                "checksum": "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:33b878000610ca3ba875b72f2a454e4fac9471f80579824304ca81e6f3e3f79d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e7d1d0b85ac49d8b0c9dd3fce4613e6229ac8720cfb74c80a496b9f0beaa7a22",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6d1b95e06ec98f6d65c64e18fec693d379b98128a3e94b4dec8929321354c549",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1877af369228dd661ae1adfc43bbb8d53d3464d59ead0f5bcf6c2be88f8e8685",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3f7bde703045c2651fbd4142131ea1e303a565269388a08e2312af0eb83307a4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d2bac91a1969f555ea2641b161bb23fa0aaaffaba3284d9973ad696594b73f18",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:424f73b97c7d7541d35685108bdcddb03100cd0f3d6e0fd9def576462ca65b59",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:79834af7f95c0d1e5dcf85b794819bd854197a52d2966594abdb3c3de0fcceb6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0f9ebdf7f08a506a8d1d6c4b4788dd7ca3dbb832509072b66def4da5b86d7862",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a0f1b653f889bb95e6edec2c525dfc71e280076b29394cf9c06ffa81ecd8b9fa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3fb05067cbd7fcf3283f2ab306c2dae668d818d3a69422e729c2ef62974810a5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:37cda2c179e4311a1aeeb0ea8d07d3eacc8ea8bf97d122ec22cd596c61b8e770",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:47c92a952b162b7bafbe49a7e409a7a81825adc77b3e139651913d52d8aa84fb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6d3301f6e99d9728698822e81fc2d170694cc367b7e7fea5c7a019f7b1a6073b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eab8d30db6004f8c21247689cac52f143e1bde1da817db9761420cf3cf855c38",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e1e89027213f00ae1014bbb1253058ed8d5d476e7246921f03736ea129d2a162",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bfd008fce37b2ec17dc4142c38a6e808c2e0031eed802a0253fca812989845d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4b65dc9856b0d0ce555dd9bce88dcfb680ba689a2c6b88ae9f84b016553d96af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9f2f2a20f285a2ac306ce72475beecf967cf92308b426aafca68215a6c3c12ca",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c20caffb4d2a500416dab0e8418a24ae5e25c02c831ae02ee10f97a0dcc80374",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:82cbc5e0339e832d2fc0160541c30f3dee59b3d28d83907ae7b55e22d5092c51",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:82b51ca6bec551d74a6d8c43194b0fd4e8bfdf19d1d68b58c1787723edd88bd0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:12b7666d61e7bd8b3b5b1a7c57539964531802287e592e33449e039799ea2071",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6046f881a5c0822c30bd037aec040c65594b6328b1c0d72b6681fe1575eac765",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cf18d61c8f526fe86cd24073dfdce942b6a463ea909ed5a59a5cc4378d9101a1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e9814c1b1a22b8cbd39413dc4f0eab452ef7380ce01f05ecab0e41e2d00ba3c0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1014763656c1578ae96b38fd3e87c4d07b548cb8423688cc928d0f9762d43a44",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:45d38ed1d2247e17e3e8faf7d6755216c5ef4422736129f55b712f160532d8f2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bb078ccf6e7372cf22e55901c005517daff0b8cffa14fa3dec5e9804b4f65897",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:79864051052858a1c95538888ca61a43b509b6eae4ae269ae6ea7bf8b076a2b8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11a0c09b716f8071f0484278bec326fb82e93d987376c8b38188d1febcd5381d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ca8f4843c8b23ce16b957143550d8dc83ae630cd64587fa2dd127e4ecbe9bb23",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c04a67670d45f576c5a8b23fe64d5ce31b04ddf4792cbf78448fd4c96899f9c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a1a996e8da4733b14c449b69e34484fe4f2b88c0f2963145bf0402cf04baf30e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ee147f5a7017de1c77abfbb79dd32eb97c923fc7c1b74c32bda6020b9025938c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:686e015d81c1be2e6b88c7e8a50d45109d7273143a034caa9c935ecd014e1c62",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:56634e58fc7499d719a3f431dd188e8f2655ebfa402e94ce105794a47debf45b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2027da420b35a0b70ae5045d2fd79cdccb820f03e5ff4018a2205d3d413ff1af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a60e3e035883de829c5778417d316ffc47a0b4a304953e3fdc44def8f2f172ab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7721bc647c521d96e07e665f7da306326d3bd1499d610c58552317815aaf3c45",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61ba1ecff8f8578cbd3445df596d001067bb0281745191ac168fcc6079d8e1cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f7c7dc1d8e5cf4776a1fde155871a2bb1fdd0676f897a43334cfbb60eb69e52a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:96c7a26b707d4038a50b4ab0fd8d79ba3997466bed543f13c10d30e7ec256b5e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:27920113489e3260e58d4a033d31401c6ae22ded72895c6b8c0e43ebf89a62df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6a864bec34b7d39de3e6ae1e39ec07fa3a2d21837a9a2d7151228d7f0ac38e73",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d1c8a2302e64fc856aff6a05a78140986e89eddd8f110deb9ba78d44aebcd411",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:820fee96d610178c7c7b8ce2b115bd02063d2f6dfcae5da4bf5d411de0b575f7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7d00ccbb224617a00f58053afd88e7a49062446f1306ba39c72b78d20aeee1ef",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9ce3f0c0904ac22ab5769babebf43e7dcdb488b0ef999b2e9e88a5b5eb424e51",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f7f8832ccaedd7ddad064956309478b9bf366f0576517356ee68481e196236cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ea8067f2310d30b31f7b1f13825b2a5a5e679c114fefd072267b6c369a365a63",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d2c28837f0573ae2647b8fbba85f7c502f9c3da0a3eab1c9ba121de4a1a6cee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e530795e5c9bc27de609fcbbacdc43c226026fee95e47a1f783f1c03ba5d48ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f68c93c0461c149bb17282dededf421cbc1fbfa5ac133b59bd362526f59e0d57",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2414cb7345bc193f7ff7983c020c8b0e706aab013ee30af5d457d35c4de4a698",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e0dffa204780c20c16357a51b992351aa1cf9f9cdda6182939ecd0cd7ab2c2bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1b1af6b54050ec223c3289b107a9695a686c9d46d17a80ec9cd5d0201ec5d544",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d6810c97f24d93cd54a61bb288ada8591a94e4083b5165e0719915bceb637504",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9cc240ac305a862146e85d8dcc4ad981f5233a58b6901ecfac691d0b39966b49",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:131adc47f044c9f600f5295ded0f5431cda57fa7276100c3ec81c9d1ce3fa6f7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dbf3fb9e356236575a06e4fdcd532331f418236aa4ff4e024260c24be2b9a7cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:87749765dbe5ce8f098279170c39bb8a89abbf3f8430c2a6dbfb973117e11dfa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fbf45cda87a05418a72f4bf3877da5ebcabbe68d393bc5bec007a8b01ef6bafe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b30db4e3d9605e7263387ff91f91508667693d28e8b8835a2b7fcefd64f24388",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f9b2e7232d0b2d33bf52993c31b43b31520601f52f44fe792acd6dee4d84afc8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:23e3ed871799a9209915359f71660babf451b0b44902e3ed488b7b22aff37718",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e76f1401d9e119eae4cc461c8b68e9eae075d4b69f61870cb5c19ba7d69cf1a3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cc4401d1e292b28d771a2038081b929b342ffa3b60358aed91697fdbc668546a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:32220dc513a6ebcd4994e7140ecb5859108baf44d12fe6b1f0c0459dbefc54e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:70a90c6c682016e91fb4745eedbd23f28e150a38b01d18f85ce4e50fb4e0ca6c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4a74ae08a713e9b4e74ff27bfaf57374312370402f90e2796e66c504557ae189",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:92e42b63fcc56dd21984abb722e8fa7ebbb58f6d54c529ac11871b4bbc63b290",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6297d7eee103c679a0f1ea411568d3940af3fe8f38e19388a1544df70bda8b3c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e1f1b9c4b78fe9d84a87d7de67fdd8559fe2bea9969ca1632d137de635d7e898",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5d5e7255c85c3aa9d63598ef140de35843ab2485adf1cb9a9130be80aa0297f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:164e1c0e3e8c89aeda4f272b3158932649a69b16aea058105117a64d3cdef517",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a9828dc2c4215e6bcb9aa14370d854f24637b0510e4b1a63709135049314e2b3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:23a539a271c92906ac0a12c7d877c7f4d0ad8e6b9bbd8642b5232f861b79ed22",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:40e231991444a589b17e0b5b338be8874d071e3d17e210aba6f6639620775f79",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a86ec8f7284ee01574bb06bba726d8609e464f41d003215097e626c583f73ed0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3228a36807658c7e4d881013aa26f877353388bf3bac6c948984f751c264a359",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4baf8ba6a5ed4609695f79a8bbc8324d7efa322a3573c8c5fa3942361eac0f1c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f695ed244a1d9f3eb814947fb1da343d7d6fb3aaa2bf72965235e4b45a58a784",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:148aea26e381b33badde0ac2ae716a78f7b565f54f0b6970189a89713f335eaf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7c24e53e12891046bb6721e624cf9effd1946c0d076464427c2a86b29671318e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61a9dbd9020e29012947978acf33a0c1150e6c3e078de372f1e38fb9c4ef529a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2968703dd232a37620a0ae12146c9d1ec5220f62c40bfb0ecfc60b621d8e1eac",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0ac62147585be2dae960ed37a3a0c3eb2f8a95d0fd0993991c8bf7238b1d5e27",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11cd6fae157eb9e4800163633b57bcce21d59a1df4b86a99ba03707b6cee0cfc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1feb6a045cb3e95e3c8e0112ecb4b8ffeb9986a503b52c5497fefce217846b90",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9aee2549d3ff9e5652dffaaa9b91ab7a243687cc2a85b8e45f4290d53d44702d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8fbfbaf3b107b540428634c19c4cb05e7c46f9672cfbf14d1f44306ed3413a46",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d54b628e6d0b7813ec0b4cc0beb1b8f3f8510ffbaff8ae1d9c4b9993095e4edf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e035a5041c721ea40e47cbbc19eb1b91c520183f85137ee1dd3ed3b42a47c180",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eb88e660b9fd02e695a90c0266831b79e513c2f65ba5d6353e82726af96e9752",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:059f825547fe257247656c29049ebc7bfa1d54a17479f3dcfeff37fbab7084bd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:71427f6f8f3f6370dccde81a76d566ff17144e7e375381ef13e04a661e63cba1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:69de3dd68dc2b76e2a85c710a51e9c8acefe595d6ac5d9f19113c4062a5f0d92",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ebd4a9473543a5ca50ec5f9de069fc0c240527516ae262cf3e28a5d914b99cb1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:55833f669ed1dbd32e79f494824c309b71bc373d2bf28eb5cdb663459dc6f7cd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0176b42c6b51fb3c829f168571527a3559b6a9c8cc5f847b70e3c40fb69f89e4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3c940f33c6c8edb73b98527e0fff17aa211e823f06e3f732762d0c86cc0268c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7cc0891a9e7c19757c03cba6c8155738d9db9f5774380c412106adf0eca44077",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b6687e9977e337e5d029de0d42cb79d57bd44f2f642450440756ba1a0494a113",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:86cb1e5e80642b1575df57287c9549749603bf94b1ba652995b59ea45ac4272b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:330a36b1dabaf76daafeff3f7fd7a276880bf65d790ee84cb823a1958a4d99d7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b3bba1d61529a1dde47f234f34d0fdee07a38aa5958d87e30357ea04bbff142",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac901ae730144d1e75b86d9991c1c6a9d6d0a44ce6e52b4d330df3a26d09e1ff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3fdab509a59e0a765364d6f119c38c796a4420cc49b46595a37d98eb649d6c80",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:60ddc7b15e9742ff9995d1b336489b92721e21a45034d20f20d2fc800e419d1c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4123331b5d06f91ff31d147e4769806052f59b620e7677f69b0073eaf7beccb6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a72bb74400b447af71600da141aebdc46da7776ef875abfdd635881f939891d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fd7dc918a1e3ad0114ecaa41d78c6652cc559271ad6653e5bba0bc780af35faa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8ab032e2a86f300d978e521ab030db1e7bb7eeccca205a5d2a4d68b51566f43f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5dcac7772d73ad1523f87cbeb1dc76dd62af4d2bb73dd06896a47d2bcf503e5e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d5d622f60e97d43b095a98f2bb46982d91451e4e6018492da20944b294480af3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:39160ef65b3519a70f14f992edc5967380ef86a6940896751db681781961903d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:139b9453b2038e52767d0102def782d58d558ca0603757eb0c97ddda28af1466",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59cc4d563ecb4c8b517f5dd7505f1cda297f950f32fc700344aa7789b69ca99c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:00c29524aad123ec44056e60b9625e75ac428a6c751878a05fadbca7e956c249",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bab19da8b6f553325decae00748f88fc0924b918136f065ab8995e1ebf5bde5b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fc4104e014beee44b5003e72a32e45e689936a4ffdcf07e119b02be3ed4ab8d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eecc86b828ad436a9f397d2f7acdf5705bfd36bcad3edd2da73f3acc94363411",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c814f83bcf3cfc590d84897c810a087354cfb0c961dd232af5031cfe8bd63a37",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:668a30c6f526e51705af9cb9d98fd11f279f5e86f7d905876ae9a86f486a8c36",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7285fcc290a8af2cf845beb845e661cd4c06c2275417b15eb507824dedec7c69",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0db1be9a78e5f329a519066a7b37379f6c73fe579154e0a6a26b2dcb4154ccd6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:43b0b5d425a2041daeb6b41db2858abda1f92ecc38c6125f7de3b7502580a9f7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:adcd36cb0e582f5fb2d0465cf88bb813ffac17d25d6ec8aa608b647d008bebc3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1af86c0a8c11e44958b022bf7dad5f48ad974fa8537cf41a12d5b0643444b1dc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30bc3583e503e0f459e323b27551f7b9a8ab784de15437b5b29f447b31f8d9cd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
+                "check_gpg": true
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.hostname",
+          "options": {
+            "hostname": "localhost.localdomain"
+          }
+        },
+        {
+          "name": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "redhat": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              },
+              {
+                "uuid": "46BB-8120",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "umask=0077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "uefi": {
+              "vendor": "fedora"
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
+        "options": {
+          "format": "qcow2",
+          "filename": "disk.qcow2",
+          "size": 2147483648,
+          "ptuuid": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
+          "pttype": "gpt",
+          "partitions": [
+            {
+              "start": 2048,
+              "size": 972800,
+              "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+              "uuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
+              "filesystem": {
+                "type": "vfat",
+                "uuid": "46BB-8120",
+                "label": "EFI-SYSTEM",
+                "mountpoint": "/boot/efi"
+              }
+            },
+            {
+              "start": 976896,
+              "uuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build-packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/acl-2.3.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/alternatives-1.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/basesystem-11-11.fc34.noarch.rpm",
+        "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bash-5.1.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bzip2-libs-1.0.8-6.fc34.aarch64.rpm",
+        "checksum": "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cpio-2.13-10.fc34.aarch64.rpm",
+        "checksum": "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cyrus-sasl-lib-2.1.27-8.fc34.aarch64.rpm",
+        "checksum": "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-1.12.20-3.fc34.aarch64.rpm",
+        "checksum": "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-common-1.12.20-3.fc34.noarch.rpm",
+        "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm",
+        "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm",
+        "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-1.02.175-1.fc34.aarch64.rpm",
+        "checksum": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-libs-1.02.175-1.fc34.aarch64.rpm",
+        "checksum": "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/filesystem-3.14-5.fc34.aarch64.rpm",
+        "checksum": "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/findutils-4.8.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "11.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fuse-libs-2.9.9-11.fc34.aarch64.rpm",
+        "checksum": "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-all-langpacks-5.1.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.19",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gdbm-libs-1.19-2.fc34.aarch64.rpm",
+        "checksum": "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-libs-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gmp-6.2.0-6.fc34.aarch64.rpm",
+        "checksum": "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm",
+        "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grep-3.6-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "51.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grubby-8.40-51.fc34.aarch64.rpm",
+        "checksum": "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm",
+        "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.14",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/json-c-0.14-8.fc34.aarch64.rpm",
+        "checksum": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-misc-2.4.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/keyutils-libs-1.6.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.5",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "11.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.aarch64.rpm",
+        "checksum": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.aarch64.rpm",
+        "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libattr-2.5.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libblkid-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbrotli-1.0.9-4.fc34.aarch64.rpm",
+        "checksum": "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-2.48-2.fc34.aarch64.rpm",
+        "checksum": "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-ng-0.8.2-4.fc34.aarch64.rpm",
+        "checksum": "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm",
+        "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfdisk-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "28.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.aarch64.rpm",
+        "checksum": "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.42",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libgpg-error-1.42-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-1.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.43.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnghttp2-1.43.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnl3-3.5.0-6.fc34.aarch64.rpm",
+        "checksum": "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnsl2-1.3.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpsl-0.21.1-3.fc34.aarch64.rpm",
+        "checksum": "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm",
+        "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsemanage-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsigsegv-2.13-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.17",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm",
+        "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtasn1-4.16.0-4.fc34.aarch64.rpm",
+        "checksum": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
+        "check_gpg": true
+      },
+      {
+        "name": "libtextstyle",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtextstyle-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.aarch64.rpm",
+        "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
+        "check_gpg": true
+      },
+      {
+        "name": "liburing",
+        "epoch": 0,
+        "version": "0.7",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm",
+        "checksum": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
+        "check_gpg": true
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libutempter-1.2.1-4.fc34.aarch64.rpm",
+        "checksum": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libuuid-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lz4-libs-1.9.3-2.fc34.aarch64.rpm",
+        "checksum": "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/memstrack-0.2.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-6.2-4.20200222.fc34.aarch64.rpm",
+        "checksum": "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm",
+        "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm",
+        "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm",
+        "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/openssl-pkcs11-0.4.11-2.fc34.aarch64.rpm",
+        "checksum": "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/os-prober-1.77-7.fc34.aarch64.rpm",
+        "checksum": "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-0.23.22-3.fc34.aarch64.rpm",
+        "checksum": "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-trust-0.23.22-3.fc34.aarch64.rpm",
+        "checksum": "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.44",
+        "release": "3.fc34.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre-8.44-3.fc34.1.aarch64.rpm",
+        "checksum": "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-10.36-4.fc34.aarch64.rpm",
+        "checksum": "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-syntax-10.36-4.fc34.noarch.rpm",
+        "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pigz-2.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/policycoreutils-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/popt-1.18-4.fc34.aarch64.rpm",
+        "checksum": "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm",
+        "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20190417",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
+        "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/readline-8.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sed-4.8-7.fc34.aarch64.rpm",
+        "checksum": "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.7",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/setup-2.13.7-3.fc34.noarch.rpm",
+        "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.34.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm",
+        "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-0.3.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-lib-0.3.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/u/util-linux-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-5.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-libs-5.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "26.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/z/zlib-1.2.11-26.fc34.aarch64.rpm",
+        "checksum": "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-libs-3.0.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm",
+        "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-8.32-30.fc34.aarch64.rpm",
+        "checksum": "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-common-8.32-30.fc34.aarch64.rpm",
+        "checksum": "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-2.9.6-27.fc34.aarch64.rpm",
+        "checksum": "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.3.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/curl-7.76.1-12.fc34.aarch64.rpm",
+        "checksum": "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc34.aarch64.rpm",
+        "checksum": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc34.noarch.rpm",
+        "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-gpg-keys-34-2.noarch.rpm",
+        "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-34-39.noarch.rpm",
+        "checksum": "sha256:3e69e8412d5914ec01c5e82264833698e92a1b88a7c7b5ed9b1f0351fc91f5d2",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-common-34-39.noarch.rpm",
+        "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-34-39.noarch.rpm",
+        "checksum": "sha256:6d1c024b295c423746b44f120cf36ceb0fd898f8ce5a276813d7c78a3c8ece52",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-34-2.noarch.rpm",
+        "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-5.39-7.fc34.aarch64.rpm",
+        "checksum": "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.aarch64.rpm",
+        "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.68.4",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.aarch64.rpm",
+        "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-common-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-doc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-doc-2.33-20.fc34.noarch.rpm",
+        "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:adb1b49ec7038eec956edd77d0ad2a72179b4f37c14548e3c9637d8a75c276a1",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/gnutls-3.7.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm",
+        "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-legacy-libs-1.8.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-libs-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/krb5-libs-1.19.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.aarch64.rpm",
+        "checksum": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "49.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm",
+        "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcrypt-1.9.3-3.fc34.aarch64.rpm",
+        "checksum": "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "37.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libibverbs-37.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libidn2-2.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpcap-1.10.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm",
+        "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
+        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsepol-3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-0.9.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-config-0.9.6-1.fc34.noarch.rpm",
+        "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "0.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtirpc-1.3.2-0.fc34.aarch64.rpm",
+        "checksum": "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc34.aarch64.rpm",
+        "checksum": "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxkbcommon-1.3.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxml2-2.9.12-4.fc34.aarch64.rpm",
+        "checksum": "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mkpasswd-5.5.10-1.fc34.aarch64.rpm",
+        "checksum": "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mpfr-4.1.0-7.fc34.aarch64.rpm",
+        "checksum": "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/nettle-3.7.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.57",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openldap-2.4.57-6.fc34.aarch64.rpm",
+        "checksum": "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssl-libs-1.1.1l-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pam-1.5.1-7.fc34.aarch64.rpm",
+        "checksum": "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "1.fc34.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/procps-ng-3.3.17-1.fc34.1.aarch64.rpm",
+        "checksum": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-setuptools-wheel-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.9.9-2.fc34.noarch.rpm",
+        "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-3.9.9-2.fc34.aarch64.rpm",
+        "checksum": "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libs-3.9.9-2.fc34.aarch64.rpm",
+        "checksum": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pip-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
+        "check_gpg": true
+      },
+      {
+        "name": "qemu-img",
+        "epoch": 2,
+        "version": "5.2.0",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm",
+        "checksum": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.8.1",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.8.1-10.fc34.aarch64.rpm",
+        "checksum": "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-networkd-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-pam-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-rpm-macros",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-rpm-macros-248.9-1.fc34.noarch.rpm",
+        "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
+        "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "26.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/which-2.21-26.fc34.aarch64.rpm",
+        "checksum": "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/whois-nls-5.5.10-1.fc34.noarch.rpm",
+        "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
+        "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm",
+        "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
+        "check_gpg": true
+      }
+    ],
+    "packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/acl-2.3.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/alternatives-1.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/basesystem-11-11.fc34.noarch.rpm",
+        "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bash-5.1.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bzip2-libs-1.0.8-6.fc34.aarch64.rpm",
+        "checksum": "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4",
+        "check_gpg": true
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/checkpolicy-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:33b878000610ca3ba875b72f2a454e4fac9471f80579824304ca81e6f3e3f79d",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "20.4",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cloud-init-20.4-2.fc34.noarch.rpm",
+        "checksum": "sha256:e7d1d0b85ac49d8b0c9dd3fce4613e6229ac8720cfb74c80a496b9f0beaa7a22",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-utils-growpart",
+        "epoch": 0,
+        "version": "0.31",
+        "release": "8.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cloud-utils-growpart-0.31-8.fc34.noarch.rpm",
+        "checksum": "sha256:6d1b95e06ec98f6d65c64e18fec693d379b98128a3e94b4dec8929321354c549",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-0.21.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:1877af369228dd661ae1adfc43bbb8d53d3464d59ead0f5bcf6c2be88f8e8685",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-issuegen",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-issuegen-0.21.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:3f7bde703045c2651fbd4142131ea1e303a565269388a08e2312af0eb83307a4",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-motdgen",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-motdgen-0.21.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:d2bac91a1969f555ea2641b161bb23fa0aaaffaba3284d9973ad696594b73f18",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-profile",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-profile-0.21.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:424f73b97c7d7541d35685108bdcddb03100cd0f3d6e0fd9def576462ca65b59",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cpio-2.13-10.fc34.aarch64.rpm",
+        "checksum": "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cyrus-sasl-lib-2.1.27-8.fc34.aarch64.rpm",
+        "checksum": "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-1.12.20-3.fc34.aarch64.rpm",
+        "checksum": "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-common-1.12.20-3.fc34.noarch.rpm",
+        "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm",
+        "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
+        "check_gpg": true
+      },
+      {
+        "name": "dejavu-sans-fonts",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "16.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dejavu-sans-fonts-2.37-16.fc34.noarch.rpm",
+        "checksum": "sha256:79834af7f95c0d1e5dcf85b794819bd854197a52d2966594abdb3c3de0fcceb6",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm",
+        "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-1.02.175-1.fc34.aarch64.rpm",
+        "checksum": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-libs-1.02.175-1.fc34.aarch64.rpm",
+        "checksum": "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/efibootmgr-16-10.fc34.aarch64.rpm",
+        "checksum": "sha256:0f9ebdf7f08a506a8d1d6c4b4788dd7ca3dbb832509072b66def4da5b86d7862",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "37",
+        "release": "15.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/efivar-libs-37-15.fc34.aarch64.rpm",
+        "checksum": "sha256:a0f1b653f889bb95e6edec2c525dfc71e280076b29394cf9c06ffa81ecd8b9fa",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/filesystem-3.14-5.fc34.aarch64.rpm",
+        "checksum": "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/findutils-4.8.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501",
+        "check_gpg": true
+      },
+      {
+        "name": "fonts-filesystem",
+        "epoch": 1,
+        "version": "2.0.5",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fonts-filesystem-2.0.5-5.fc34.noarch.rpm",
+        "checksum": "sha256:3fb05067cbd7fcf3283f2ab306c2dae668d818d3a69422e729c2ef62974810a5",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "11.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fuse-libs-2.9.9-11.fc34.aarch64.rpm",
+        "checksum": "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-all-langpacks-5.1.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.19",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gdbm-libs-1.19-2.fc34.aarch64.rpm",
+        "checksum": "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-libs-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gmp-6.2.0-6.fc34.aarch64.rpm",
+        "checksum": "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm",
+        "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grep-3.6-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/groff-base-1.22.4-7.fc34.aarch64.rpm",
+        "checksum": "sha256:37cda2c179e4311a1aeeb0ea8d07d3eacc8ea8bf97d122ec22cd596c61b8e770",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "51.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grubby-8.40-51.fc34.aarch64.rpm",
+        "checksum": "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm",
+        "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/h/hostname-3.23-4.fc34.aarch64.rpm",
+        "checksum": "sha256:47c92a952b162b7bafbe49a7e409a7a81825adc77b3e139651913d52d8aa84fb",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "49",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/inih-49-3.fc34.aarch64.rpm",
+        "checksum": "sha256:6d3301f6e99d9728698822e81fc2d170694cc367b7e7fea5c7a019f7b1a6073b",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.09",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/initscripts-10.09-1.fc34.aarch64.rpm",
+        "checksum": "sha256:eab8d30db6004f8c21247689cac52f143e1bde1da817db9761420cf3cf855c38",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.10.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iproute-5.10.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e1e89027213f00ae1014bbb1253058ed8d5d476e7246921f03736ea129d2a162",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute-tc",
+        "epoch": 0,
+        "version": "5.10.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iproute-tc-5.10.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:bfd008fce37b2ec17dc4142c38a6e808c2e0031eed802a0253fca812989845d1",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20210202",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iputils-20210202-2.fc34.aarch64.rpm",
+        "checksum": "sha256:4b65dc9856b0d0ce555dd9bce88dcfb680ba689a2c6b88ae9f84b016553d96af",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/jansson-2.13.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:9f2f2a20f285a2ac306ce72475beecf967cf92308b426aafca68215a6c3c12ca",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.14",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/json-c-0.14-8.fc34.aarch64.rpm",
+        "checksum": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-misc-2.4.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/keyutils-libs-1.6.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.5",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-core-en-3.0-14.fc34.noarch.rpm",
+        "checksum": "sha256:c20caffb4d2a500416dab0e8418a24ae5e25c02c831ae02ee10f97a0dcc80374",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-font-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-core-font-en-3.0-14.fc34.noarch.rpm",
+        "checksum": "sha256:82cbc5e0339e832d2fc0160541c30f3dee59b3d28d83907ae7b55e22d5092c51",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-en-3.0-14.fc34.noarch.rpm",
+        "checksum": "sha256:82b51ca6bec551d74a6d8c43194b0fd4e8bfdf19d1d68b58c1787723edd88bd0",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.aarch64.rpm",
+        "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libattr-2.5.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbasicobjects-0.1.1-47.fc34.aarch64.rpm",
+        "checksum": "sha256:12b7666d61e7bd8b3b5b1a7c57539964531802287e592e33449e039799ea2071",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libblkid-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbrotli-1.0.9-4.fc34.aarch64.rpm",
+        "checksum": "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-2.48-2.fc34.aarch64.rpm",
+        "checksum": "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-ng-0.8.2-4.fc34.aarch64.rpm",
+        "checksum": "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcbor-0.7.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:6046f881a5c0822c30bd037aec040c65594b6328b1c0d72b6681fe1575eac765",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcollection-0.7.0-47.fc34.aarch64.rpm",
+        "checksum": "sha256:cf18d61c8f526fe86cd24073dfdce942b6a463ea909ed5a59a5cc4378d9101a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libdhash-0.5.0-47.fc34.aarch64.rpm",
+        "checksum": "sha256:e9814c1b1a22b8cbd39413dc4f0eab452ef7380ce01f05ecab0e41e2d00ba3c0",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm",
+        "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfdisk-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "28.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.aarch64.rpm",
+        "checksum": "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfido2-1.6.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:1014763656c1578ae96b38fd3e87c4d07b548cb8423688cc928d0f9762d43a44",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.42",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libgpg-error-1.42-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libini_config-1.3.1-47.fc34.aarch64.rpm",
+        "checksum": "sha256:45d38ed1d2247e17e3e8faf7d6755216c5ef4422736129f55b712f160532d8f2",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-1.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmaxminddb-1.5.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bb078ccf6e7372cf22e55901c005517daff0b8cffa14fa3dec5e9804b4f65897",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "13.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmnl-1.0.4-13.fc34.aarch64.rpm",
+        "checksum": "sha256:79864051052858a1c95538888ca61a43b509b6eae4ae269ae6ea7bf8b076a2b8",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.7",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libndp-1.7-7.fc34.aarch64.rpm",
+        "checksum": "sha256:11a0c09b716f8071f0484278bec326fb82e93d987376c8b38188d1febcd5381d",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnetfilter_conntrack-1.0.8-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ca8f4843c8b23ce16b957143550d8dc83ae630cd64587fa2dd127e4ecbe9bb23",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "19.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnfnetlink-1.0.1-19.fc34.aarch64.rpm",
+        "checksum": "sha256:c04a67670d45f576c5a8b23fe64d5ce31b04ddf4792cbf78448fd4c96899f9c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.43.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnghttp2-1.43.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnl3-3.5.0-6.fc34.aarch64.rpm",
+        "checksum": "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnsl2-1.3.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpath_utils-0.2.1-47.fc34.aarch64.rpm",
+        "checksum": "sha256:a1a996e8da4733b14c449b69e34484fe4f2b88c0f2963145bf0402cf04baf30e",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpipeline-1.5.3-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ee147f5a7017de1c77abfbb79dd32eb97c923fc7c1b74c32bda6020b9025938c",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpsl-0.21.1-3.fc34.aarch64.rpm",
+        "checksum": "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libref_array-0.1.5-47.fc34.aarch64.rpm",
+        "checksum": "sha256:686e015d81c1be2e6b88c7e8a50d45109d7273143a034caa9c935ecd014e1c62",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm",
+        "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsemanage-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsigsegv-2.13-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.17",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm",
+        "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtalloc-2.3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:56634e58fc7499d719a3f431dd188e8f2655ebfa402e94ce105794a47debf45b",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtasn1-4.16.0-4.fc34.aarch64.rpm",
+        "checksum": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.3",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtdb-1.4.3-6.fc34.aarch64.rpm",
+        "checksum": "sha256:2027da420b35a0b70ae5045d2fd79cdccb820f03e5ff4018a2205d3d413ff1af",
+        "check_gpg": true
+      },
+      {
+        "name": "libtextstyle",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtextstyle-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.aarch64.rpm",
+        "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
+        "check_gpg": true
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libutempter-1.2.1-4.fc34.aarch64.rpm",
+        "checksum": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libuuid-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-atm-libs",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "28.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/linux-atm-libs-2.5.1-28.fc34.aarch64.rpm",
+        "checksum": "sha256:a60e3e035883de829c5778417d316ffc47a0b4a304953e3fdc44def8f2f172ab",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lmdb-libs-0.9.29-1.fc34.aarch64.rpm",
+        "checksum": "sha256:7721bc647c521d96e07e665f7da306326d3bd1499d610c58552317815aaf3c45",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lz4-libs-1.9.3-2.fc34.aarch64.rpm",
+        "checksum": "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.9.3",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/man-db-2.9.3-3.fc34.aarch64.rpm",
+        "checksum": "sha256:61ba1ecff8f8578cbd3445df596d001067bb0281745191ac168fcc6079d8e1cf",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/memstrack-0.2.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.4.0",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/mokutil-0.4.0-4.fc34.aarch64.rpm",
+        "checksum": "sha256:f7c7dc1d8e5cf4776a1fde155871a2bb1fdd0676f897a43334cfbb60eb69e52a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-6.2-4.20200222.fc34.aarch64.rpm",
+        "checksum": "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm",
+        "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm",
+        "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
+        "check_gpg": true
+      },
+      {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.59.20160912git.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/net-tools-2.0-0.59.20160912git.fc34.aarch64.rpm",
+        "checksum": "sha256:96c7a26b707d4038a50b4ab0fd8d79ba3997466bed543f13c10d30e7ec256b5e",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm",
+        "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/openssl-pkcs11-0.4.11-2.fc34.aarch64.rpm",
+        "checksum": "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/os-prober-1.77-7.fc34.aarch64.rpm",
+        "checksum": "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-0.23.22-3.fc34.aarch64.rpm",
+        "checksum": "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-trust-0.23.22-3.fc34.aarch64.rpm",
+        "checksum": "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/parted-3.4-2.fc34.aarch64.rpm",
+        "checksum": "sha256:27920113489e3260e58d4a033d31401c6ae22ded72895c6b8c0e43ebf89a62df",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/passwd-0.80-10.fc34.aarch64.rpm",
+        "checksum": "sha256:6a864bec34b7d39de3e6ae1e39ec07fa3a2d21837a9a2d7151228d7f0ac38e73",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.44",
+        "release": "3.fc34.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre-8.44-3.fc34.1.aarch64.rpm",
+        "checksum": "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-10.36-4.fc34.aarch64.rpm",
+        "checksum": "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-syntax-10.36-4.fc34.noarch.rpm",
+        "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pigz-2.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/policycoreutils-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/popt-1.18-4.fc34.aarch64.rpm",
+        "checksum": "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm",
+        "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/psmisc-23.4-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d1c8a2302e64fc856aff6a05a78140986e89eddd8f110deb9ba78d44aebcd411",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20190417",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
+        "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-attrs",
+        "epoch": 0,
+        "version": "20.3.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-attrs-20.3.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:820fee96d610178c7c7b8ce2b115bd02063d2f6dfcae5da4bf5d411de0b575f7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cffi",
+        "epoch": 0,
+        "version": "1.14.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-cffi-1.14.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:7d00ccbb224617a00f58053afd88e7a49062446f1306ba39c72b78d20aeee1ef",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-chardet-4.0.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:9ce3f0c0904ac22ab5769babebf43e7dcdb488b0ef999b2e9e88a5b5eb424e51",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-configobj",
+        "epoch": 0,
+        "version": "5.0.6",
+        "release": "23.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-configobj-5.0.6-23.fc34.noarch.rpm",
+        "checksum": "sha256:f7f8832ccaedd7ddad064956309478b9bf366f0576517356ee68481e196236cf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cryptography",
+        "epoch": 0,
+        "version": "3.4.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-cryptography-3.4.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:ea8067f2310d30b31f7b1f13825b2a5a5e679c114fefd072267b6c369a365a63",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-dateutil-2.8.1-3.fc34.noarch.rpm",
+        "checksum": "sha256:5d2c28837f0573ae2647b8fbba85f7c502f9c3da0a3eab1c9ba121de4a1a6cee",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-distro-1.5.0-5.fc34.noarch.rpm",
+        "checksum": "sha256:e530795e5c9bc27de609fcbbacdc43c226026fee95e47a1f783f1c03ba5d48ae",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-idna-2.10-3.fc34.noarch.rpm",
+        "checksum": "sha256:f68c93c0461c149bb17282dededf421cbc1fbfa5ac133b59bd362526f59e0d57",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jinja2",
+        "epoch": 0,
+        "version": "2.11.3",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jinja2-2.11.3-1.fc34.noarch.rpm",
+        "checksum": "sha256:2414cb7345bc193f7ff7983c020c8b0e706aab013ee30af5d457d35c4de4a698",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpatch",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonpatch-1.21-14.fc34.noarch.rpm",
+        "checksum": "sha256:e0dffa204780c20c16357a51b992351aa1cf9f9cdda6182939ecd0cd7ab2c2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpointer",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonpointer-2.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:1b1af6b54050ec223c3289b107a9695a686c9d46d17a80ec9cd5d0201ec5d544",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonschema",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonschema-3.2.0-9.fc34.noarch.rpm",
+        "checksum": "sha256:d6810c97f24d93cd54a61bb288ada8591a94e4083b5165e0719915bceb637504",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt+crypto",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jwt+crypto-1.7.1-11.fc34.noarch.rpm",
+        "checksum": "sha256:9cc240ac305a862146e85d8dcc4ad981f5233a58b6901ecfac691d0b39966b49",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jwt-1.7.1-11.fc34.noarch.rpm",
+        "checksum": "sha256:131adc47f044c9f600f5295ded0f5431cda57fa7276100c3ec81c9d1ce3fa6f7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libselinux",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-libselinux-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:dbf3fb9e356236575a06e4fdcd532331f418236aa4ff4e024260c24be2b9a7cf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-libsemanage-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:87749765dbe5ce8f098279170c39bb8a89abbf3f8430c2a6dbfb973117e11dfa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-markupsafe-1.1.1-10.fc34.aarch64.rpm",
+        "checksum": "sha256:fbf45cda87a05418a72f4bf3877da5ebcabbe68d393bc5bec007a8b01ef6bafe",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib+signedtoken",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-oauthlib+signedtoken-3.0.2-9.fc34.noarch.rpm",
+        "checksum": "sha256:b30db4e3d9605e7263387ff91f91508667693d28e8b8835a2b7fcefd64f24388",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-oauthlib-3.0.2-9.fc34.noarch.rpm",
+        "checksum": "sha256:f9b2e7232d0b2d33bf52993c31b43b31520601f52f44fe792acd6dee4d84afc8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ply",
+        "epoch": 0,
+        "version": "3.11",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-ply-3.11-11.fc34.noarch.rpm",
+        "checksum": "sha256:23e3ed871799a9209915359f71660babf451b0b44902e3ed488b7b22aff37718",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-policycoreutils-3.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:e76f1401d9e119eae4cc461c8b68e9eae075d4b69f61870cb5c19ba7d69cf1a3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "25.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-prettytable-0.7.2-25.fc34.noarch.rpm",
+        "checksum": "sha256:cc4401d1e292b28d771a2038081b929b342ffa3b60358aed91697fdbc668546a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pycparser",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pycparser-2.20-3.fc34.noarch.rpm",
+        "checksum": "sha256:32220dc513a6ebcd4994e7140ecb5859108baf44d12fe6b1f0c0459dbefc54e7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyserial",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "10.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pyserial-3.4-10.fc34.noarch.rpm",
+        "checksum": "sha256:70a90c6c682016e91fb4745eedbd23f28e150a38b01d18f85ce4e50fb4e0ca6c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "8.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pysocks-1.7.1-8.fc34.noarch.rpm",
+        "checksum": "sha256:4a74ae08a713e9b4e74ff27bfaf57374312370402f90e2796e66c504557ae189",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pyyaml-5.4.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:92e42b63fcc56dd21984abb722e8fa7ebbb58f6d54c529ac11871b4bbc63b290",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-requests-2.25.1-1.fc34.noarch.rpm",
+        "checksum": "sha256:6297d7eee103c679a0f1ea411568d3940af3fe8f38e19388a1544df70bda8b3c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.4.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-setools-4.4.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:e1f1b9c4b78fe9d84a87d7de67fdd8559fe2bea9969ca1632d137de635d7e898",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-six-1.15.0-5.fc34.noarch.rpm",
+        "checksum": "sha256:b5d5e7255c85c3aa9d63598ef140de35843ab2485adf1cb9a9130be80aa0297f",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/readline-8.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "29.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rootfiles-8.1-29.fc34.noarch.rpm",
+        "checksum": "sha256:164e1c0e3e8c89aeda4f272b3158932649a69b16aea058105117a64d3cdef517",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
+        "check_gpg": true
+      },
+      {
+        "name": "rsync",
+        "epoch": 0,
+        "version": "3.2.3",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rsync-3.2.3-5.fc34.aarch64.rpm",
+        "checksum": "sha256:a9828dc2c4215e6bcb9aa14370d854f24637b0510e4b1a63709135049314e2b3",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sed-4.8-7.fc34.aarch64.rpm",
+        "checksum": "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.7",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/setup-2.13.7-3.fc34.noarch.rpm",
+        "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.4",
+        "release": "4",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shim-aa64-15.4-4.aarch64.rpm",
+        "checksum": "sha256:23a539a271c92906ac0a12c7d877c7f4d0ad8e6b9bbd8642b5232f861b79ed22",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.34.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.5p2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-1.9.5p2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:40e231991444a589b17e0b5b338be8874d071e3d17e210aba6f6639620775f79",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.5p2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-python-plugin-1.9.5p2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:a86ec8f7284ee01574bb06bba726d8609e464f41d003215097e626c583f73ed0",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm",
+        "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-0.3.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-lib-0.3.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/u/util-linux-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.10.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xfsprogs-5.10.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3228a36807658c7e4d881013aa26f877353388bf3bac6c948984f751c264a359",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-5.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-libs-5.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "26.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/z/zlib-1.2.11-26.fc34.aarch64.rpm",
+        "checksum": "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.30.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.30.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4baf8ba6a5ed4609695f79a8bbc8324d7efa322a3573c8c5fa3942361eac0f1c",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.30.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.30.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f695ed244a1d9f3eb814947fb1da343d7d6fb3aaa2bf72965235e4b45a58a784",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-3.0.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:148aea26e381b33badde0ac2ae716a78f7b565f54f0b6970189a89713f335eaf",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-libs-3.0.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/c-ares-1.17.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:7c24e53e12891046bb6721e624cf9effd1946c0d076464427c2a86b29671318e",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm",
+        "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+        "check_gpg": true
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/chrony-4.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:61a9dbd9020e29012947978acf33a0c1150e6c3e078de372f1e38fb9c4ef529a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-8.32-30.fc34.aarch64.rpm",
+        "checksum": "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-common-8.32-30.fc34.aarch64.rpm",
+        "checksum": "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-2.9.6-27.fc34.aarch64.rpm",
+        "checksum": "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-dicts-2.9.6-27.fc34.aarch64.rpm",
+        "checksum": "sha256:2968703dd232a37620a0ae12146c9d1ec5220f62c40bfb0ecfc60b621d8e1eac",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.3.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/curl-7.76.1-12.fc34.aarch64.rpm",
+        "checksum": "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "11.b1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dhcp-client-4.4.2-11.b1.fc34.aarch64.rpm",
+        "checksum": "sha256:0ac62147585be2dae960ed37a3a0c3eb2f8a95d0fd0993991c8bf7238b1d5e27",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "11.b1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dhcp-common-4.4.2-11.b1.fc34.noarch.rpm",
+        "checksum": "sha256:11cd6fae157eb9e4800163633b57bcce21d59a1df4b86a99ba03707b6cee0cfc",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc34.noarch.rpm",
+        "checksum": "sha256:1feb6a045cb3e95e3c8e0112ecb4b8ffeb9986a503b52c5497fefce217846b90",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc34.aarch64.rpm",
+        "checksum": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc34.aarch64.rpm",
+        "checksum": "sha256:9aee2549d3ff9e5652dffaaa9b91ab7a243687cc2a85b8e45f4290d53d44702d",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/efi-filesystem-5-4.fc34.noarch.rpm",
+        "checksum": "sha256:8fbfbaf3b107b540428634c19c4cb05e7c46f9672cfbf14d1f44306ed3413a46",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc34.noarch.rpm",
+        "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-gpg-keys-34-2.noarch.rpm",
+        "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-cloud",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-cloud-34-39.noarch.rpm",
+        "checksum": "sha256:d54b628e6d0b7813ec0b4cc0beb1b8f3f8510ffbaff8ae1d9c4b9993095e4edf",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-common-34-39.noarch.rpm",
+        "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-cloud",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-cloud-34-39.noarch.rpm",
+        "checksum": "sha256:e035a5041c721ea40e47cbbc19eb1b91c520183f85137ee1dd3ed3b42a47c180",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-34-2.noarch.rpm",
+        "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-modular-34-2.noarch.rpm",
+        "checksum": "sha256:eb88e660b9fd02e695a90c0266831b79e513c2f65ba5d6353e82726af96e9752",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-5.39-7.fc34.aarch64.rpm",
+        "checksum": "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.aarch64.rpm",
+        "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.68.4",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.aarch64.rpm",
+        "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-common-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-doc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-doc-2.33-20.fc34.noarch.rpm",
+        "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-langpack-en",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:059f825547fe257247656c29049ebc7bfa1d54a17479f3dcfeff37fbab7084bd",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/gnutls-3.7.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm",
+        "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:71427f6f8f3f6370dccde81a76d566ff17144e7e375381ef13e04a661e63cba1",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/ipcalc-1.0.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:69de3dd68dc2b76e2a85c710a51e9c8acefe595d6ac5d9f19113c4062a5f0d92",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-legacy-libs-1.8.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-libs-1.8.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:ebd4a9473543a5ca50ec5f9de069fc0c240527516ae262cf3e28a5d914b99cb1",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "100.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-100.fc34.aarch64.rpm",
+        "checksum": "sha256:55833f669ed1dbd32e79f494824c309b71bc373d2bf28eb5cdb663459dc6f7cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "100.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-100.fc34.aarch64.rpm",
+        "checksum": "sha256:0176b42c6b51fb3c829f168571527a3559b6a9c8cc5f847b70e3c40fb69f89e4",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "100.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-100.fc34.aarch64.rpm",
+        "checksum": "sha256:f3c940f33c6c8edb73b98527e0fff17aa211e823f06e3f732762d0c86cc0268c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-libs-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/krb5-libs-1.19.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/less-590-2.fc34.aarch64.rpm",
+        "checksum": "sha256:7cc0891a9e7c19757c03cba6c8155738d9db9f5774380c412106adf0eca44077",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.aarch64.rpm",
+        "checksum": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "49.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm",
+        "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "38.20210714cvs.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libedit-3.1-38.20210714cvs.fc34.aarch64.rpm",
+        "checksum": "sha256:b6687e9977e337e5d029de0d42cb79d57bd44f2f642450440756ba1a0494a113",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcrypt-1.9.3-3.fc34.aarch64.rpm",
+        "checksum": "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "37.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libibverbs-37.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libidn2-2.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libldb-2.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:86cb1e5e80642b1575df57287c9549749603bf94b1ba652995b59ea45ac4272b",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.5.4",
+        "release": "2.rc3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libnfsidmap-2.5.4-2.rc3.fc34.aarch64.rpm",
+        "checksum": "sha256:330a36b1dabaf76daafeff3f7fd7a276880bf65d790ee84cb823a1958a4d99d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpcap-1.10.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm",
+        "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
+        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsepol-3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-0.9.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-config-0.9.6-1.fc34.noarch.rpm",
+        "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3b3bba1d61529a1dde47f234f34d0fdee07a38aa5958d87e30357ea04bbff142",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ac901ae730144d1e75b86d9991c1c6a9d6d0a44ce6e52b4d330df3a26d09e1ff",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3fdab509a59e0a765364d6f119c38c796a4420cc49b46595a37d98eb649d6c80",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:60ddc7b15e9742ff9995d1b336489b92721e21a45034d20f20d2fc800e419d1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:4123331b5d06f91ff31d147e4769806052f59b620e7677f69b0073eaf7beccb6",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "0.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtevent-0.11.0-0.fc34.aarch64.rpm",
+        "checksum": "sha256:a72bb74400b447af71600da141aebdc46da7776ef875abfdd635881f939891d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "0.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtirpc-1.3.2-0.fc34.aarch64.rpm",
+        "checksum": "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libuser-0.63-4.fc34.aarch64.rpm",
+        "checksum": "sha256:fd7dc918a1e3ad0114ecaa41d78c6652cc559271ad6653e5bba0bc780af35faa",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc34.aarch64.rpm",
+        "checksum": "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxkbcommon-1.3.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxml2-2.9.12-4.fc34.aarch64.rpm",
+        "checksum": "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc34.noarch.rpm",
+        "checksum": "sha256:8ab032e2a86f300d978e521ab030db1e7bb7eeccca205a5d2a4d68b51566f43f",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc34.noarch.rpm",
+        "checksum": "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mkpasswd-5.5.10-1.fc34.aarch64.rpm",
+        "checksum": "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mpfr-4.1.0-7.fc34.aarch64.rpm",
+        "checksum": "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/nettle-3.7.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.57",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openldap-2.4.57-6.fc34.aarch64.rpm",
+        "checksum": "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.6p1",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-8.6p1-5.fc34.aarch64.rpm",
+        "checksum": "sha256:5dcac7772d73ad1523f87cbeb1dc76dd62af4d2bb73dd06896a47d2bcf503e5e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.6p1",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.6p1-5.fc34.aarch64.rpm",
+        "checksum": "sha256:d5d622f60e97d43b095a98f2bb46982d91451e4e6018492da20944b294480af3",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.6p1",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-server-8.6p1-5.fc34.aarch64.rpm",
+        "checksum": "sha256:39160ef65b3519a70f14f992edc5967380ef86a6940896751db681781961903d",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssl-libs-1.1.1l-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pam-1.5.1-7.fc34.aarch64.rpm",
+        "checksum": "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "1.fc34.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/procps-ng-3.3.17-1.fc34.1.aarch64.rpm",
+        "checksum": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-setuptools-wheel-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.9.9-2.fc34.noarch.rpm",
+        "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-3.9.9-2.fc34.aarch64.rpm",
+        "checksum": "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-audit-3.0.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:139b9453b2038e52767d0102def782d58d558ca0603757eb0c97ddda28af1466",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-babel",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-babel-2.9.1-1.fc34.noarch.rpm",
+        "checksum": "sha256:59cc4d563ecb4c8b517f5dd7505f1cda297f950f32fc700344aa7789b69ca99c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dbus-1.2.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:00c29524aad123ec44056e60b9625e75ac428a6c751878a05fadbca7e956c249",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc34.noarch.rpm",
+        "checksum": "sha256:bab19da8b6f553325decae00748f88fc0924b918136f065ab8995e1ebf5bde5b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libs-3.9.9-2.fc34.aarch64.rpm",
+        "checksum": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pip-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyrsistent",
+        "epoch": 0,
+        "version": "0.17.3",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.17.3-6.fc34.aarch64.rpm",
+        "checksum": "sha256:fc4104e014beee44b5003e72a32e45e689936a4ffdcf07e119b02be3ed4ab8d9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pytz",
+        "epoch": 0,
+        "version": "2021.3",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc34.noarch.rpm",
+        "checksum": "sha256:eecc86b828ad436a9f397d2f7acdf5705bfd36bcad3edd2da73f3acc94363411",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.25.10",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.25.10-5.fc34.noarch.rpm",
+        "checksum": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.8.1",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.8.1-10.fc34.aarch64.rpm",
+        "checksum": "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-client-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:c814f83bcf3cfc590d84897c810a087354cfb0c961dd232af5031cfe8bd63a37",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-common-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:668a30c6f526e51705af9cb9d98fd11f279f5e86f7d905876ae9a86f486a8c36",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:7285fcc290a8af2cf845beb845e661cd4c06c2275417b15eb507824dedec7c69",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:0db1be9a78e5f329a519066a7b37379f6c73fe579154e0a6a26b2dcb4154ccd6",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-networkd-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:43b0b5d425a2041daeb6b41db2858abda1f92ecc38c6125f7de3b7502580a9f7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-pam-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-rpm-macros",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-rpm-macros-248.9-1.fc34.noarch.rpm",
+        "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
+        "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.3755",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.3755-1.fc34.noarch.rpm",
+        "checksum": "sha256:adcd36cb0e582f5fb2d0465cf88bb813ffac17d25d6ec8aa608b647d008bebc3",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.3755",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.3755-1.fc34.aarch64.rpm",
+        "checksum": "sha256:1af86c0a8c11e44958b022bf7dad5f48ad974fa8537cf41a12d5b0643444b1dc",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "26.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/which-2.21-26.fc34.aarch64.rpm",
+        "checksum": "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/whois-nls-5.5.10-1.fc34.noarch.rpm",
+        "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
+        "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/y/yum-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:30bc3583e503e0f459e323b27551f7b9a8ab784de15437b5b29f447b31f8d9cd",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm",
+        "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
+        "check_gpg": true
+      }
+    ]
+  },
+  "image-info": {
+    "/etc/resolv.conf": [],
+    "boot-environment": {
+      "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+    },
+    "bootloader": "unknown",
+    "bootmenu": [
+      {
+        "grub_arg": "--unrestricted",
+        "grub_class": "fedora",
+        "grub_users": "$grub_users",
+        "initrd": "/boot/initramfs-5.15.13-100.fc34.aarch64.img",
+        "linux": "/boot/vmlinuz-5.15.13-100.fc34.aarch64",
+        "options": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8",
+        "title": "Fedora (5.15.13-100.fc34.aarch64) 34 (Cloud Edition)",
+        "version": "5.15.13-100.fc34.aarch64"
+      }
+    ],
+    "chrony": {
+      "leapsectz": [
+        "right/UTC"
+      ],
+      "pool": [
+        "2.fedora.pool.ntp.org iburst"
+      ]
+    },
+    "cloud-init": {
+      "/etc/cloud": {
+        "cloud.cfg": {
+          "cloud_config_modules": [
+            "ssh-import-id",
+            "locale",
+            "set-passwords",
+            "spacewalk",
+            "yum-add-repo",
+            "ntp",
+            "timezone",
+            "disable-ec2-metadata",
+            "runcmd"
+          ],
+          "cloud_final_modules": [
+            "package-update-upgrade-install",
+            "puppet",
+            "chef",
+            "mcollective",
+            "salt-minion",
+            "reset_rmc",
+            "refresh_rmc_and_interface",
+            "rightscale_userdata",
+            "scripts-vendor",
+            "scripts-per-once",
+            "scripts-per-boot",
+            "scripts-per-instance",
+            "scripts-user",
+            "ssh-authkey-fingerprints",
+            "keys-to-console",
+            "phone-home",
+            "final-message",
+            "power-state-change"
+          ],
+          "cloud_init_modules": [
+            "migrator",
+            "seed_random",
+            "bootcmd",
+            "write-files",
+            "growpart",
+            "resizefs",
+            "disk_setup",
+            "mounts",
+            "set_hostname",
+            "update_hostname",
+            "update_etc_hosts",
+            "ca-certs",
+            "rsyslog",
+            "users-groups",
+            "ssh"
+          ],
+          "disable_root": true,
+          "mount_default_fields": [
+            null,
+            null,
+            "auto",
+            "defaults,nofail",
+            "0",
+            "2"
+          ],
+          "preserve_hostname": false,
+          "resize_rootfs_tmp": "/dev",
+          "ssh_pwauth": 0,
+          "system_info": {
+            "default_user": {
+              "gecos": "fedora Cloud User",
+              "groups": [
+                "wheel",
+                "adm",
+                "systemd-journal"
+              ],
+              "lock_passwd": true,
+              "name": "fedora",
+              "shell": "/bin/bash",
+              "sudo": [
+                "ALL=(ALL) NOPASSWD:ALL"
+              ]
+            },
+            "distro": "fedora",
+            "paths": {
+              "cloud_dir": "/var/lib/cloud/",
+              "templates_dir": "/etc/cloud/templates/"
+            },
+            "ssh_svcname": "sshd"
+          },
+          "users": [
+            "default"
+          ]
+        }
+      },
+      "/etc/cloud/cloud.cfg.d": {
+        "05_logging.cfg": {
+          "_log": [
+            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
+            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
+          ],
+          "log_cfgs": [
+            [
+              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
+            ]
+          ],
+          "output": {
+            "all": "| tee -a /var/log/cloud-init-output.log"
+          }
+        }
+      }
+    },
+    "default-target": "graphical.target",
+    "dracut": {
+      "/usr/lib/dracut/dracut.conf.d": {
+        "01-dist.conf": {
+          "dbus": "/usr/share/dbus-1",
+          "dbusconfdir": "/etc/dbus-1",
+          "dbusinterfaces": "/usr/share/dbus-1/interfaces",
+          "dbusinterfacesconfdir": "/etc/dbus-1/interfaces",
+          "dbusservices": "/usr/share/dbus-1/services",
+          "dbusservicesconfdir": "/etc/dbus-1/services",
+          "dbussession": "/usr/share/dbus-1/session.d",
+          "dbussessionconfdir": "/etc/dbus-1/session.d",
+          "dbussystem": "confdir/etc/dbus-1/system.d",
+          "dbussystemservices": "/usr/share/dbus-1/system-services",
+          "dbussystemservicesconfdir": "/etc/dbus-1/system-services",
+          "early_microcode": "yes",
+          "environment": "/usr/lib/environment.d",
+          "environmentconfdir": "/etc/environment.d",
+          "hostonly": "yes",
+          "hostonly_cmdline": "no",
+          "i18n_default_font": "eurlatgr",
+          "i18n_install_all": "yes",
+          "i18n_vars": "/etc/sysconfig/keyboard:KEYTABLE-KEYMAP /etc/sysconfig/i18n:SYSFONT-FONT,FONTACM-FONT_MAP,FONT_UNIMAP",
+          "install_optional_items": " vi /etc/virc ps grep cat rm ",
+          "prefix": "/",
+          "reproducible": "yes",
+          "stdloglvl": "3",
+          "sysctlconfdir": "/etc/sysctl.d",
+          "sysctld": "/usr/lib/sysctl.d",
+          "sysloglvl": "5",
+          "systemdcatalog": "/usr/lib/systemd/catalog",
+          "systemdntpunits": "/usr/lib/systemd/ntp-units.d",
+          "systemdntpunitsconfdir": "/etc/systemd/ntp-units.d",
+          "systemdportable": "/usr/lib/systemd/portable",
+          "systemdportableconfdir": "/etc/systemd/portable",
+          "systemdsystemconfdir": "/etc/systemd/system",
+          "systemdsystemunitdir": "/usr/lib/systemd/system",
+          "systemduser": "/usr/lib/systemd/user",
+          "systemduserconfdir": "/etc/systemd/user",
+          "systemdutilconfdir": "/etc/systemd",
+          "systemdutildir": "/usr/lib/systemd",
+          "sysusers": "/usr/lib/sysusers.d",
+          "sysusersconfdir": "/etc/sysusers.d",
+          "udevdir": "/usr/lib/udev"
+        },
+        "02-generic-image.conf": {
+          "hostonly": "no"
+        }
+      }
+    },
+    "fstab": [
+      [
+        "UUID=46BB-8120",
+        "/boot/efi",
+        "vfat",
+        "umask=0077,shortname=winnt",
+        "0",
+        "2"
+      ],
+      [
+        "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+        "/",
+        "ext4",
+        "defaults",
+        "1",
+        "1"
+      ]
+    ],
+    "groups": [
+      "adm:x:4:",
+      "audio:x:63:",
+      "bin:x:1:",
+      "cdrom:x:11:",
+      "chrony:x:994:",
+      "daemon:x:2:",
+      "dbus:x:81:",
+      "dialout:x:18:",
+      "disk:x:6:",
+      "floppy:x:19:",
+      "ftp:x:50:",
+      "games:x:20:",
+      "input:x:104:",
+      "kmem:x:9:",
+      "kvm:x:36:",
+      "lock:x:54:",
+      "lp:x:7:",
+      "mail:x:12:",
+      "man:x:15:",
+      "mem:x:8:",
+      "nobody:x:65534:",
+      "redhat:x:1000:",
+      "render:x:105:",
+      "root:x:0:",
+      "sgx:x:106:",
+      "ssh_keys:x:996:",
+      "sshd:x:74:",
+      "sys:x:3:",
+      "systemd-coredump:x:999:",
+      "systemd-journal:x:190:",
+      "systemd-network:x:192:",
+      "systemd-oom:x:998:",
+      "systemd-resolve:x:193:",
+      "systemd-timesync:x:997:",
+      "tape:x:33:",
+      "tss:x:59:",
+      "tty:x:5:",
+      "unbound:x:995:",
+      "users:x:100:",
+      "utempter:x:35:",
+      "utmp:x:22:",
+      "video:x:39:",
+      "wheel:x:10:"
+    ],
+    "hostname": "localhost.localdomain",
+    "hosts": [
+      "127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4",
+      "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
+    ],
+    "image-format": {
+      "compat": "1.1",
+      "type": "qcow2"
+    },
+    "locale": {
+      "LANG": "en_US"
+    },
+    "machine-id": "",
+    "os-release": {
+      "ANSI_COLOR": "0;38;2;60;110;180",
+      "BUG_REPORT_URL": "https://bugzilla.redhat.com/",
+      "CPE_NAME": "cpe:/o:fedoraproject:fedora:34",
+      "DOCUMENTATION_URL": "https://docs.fedoraproject.org/en-US/fedora/f34/system-administrators-guide/",
+      "HOME_URL": "https://fedoraproject.org/",
+      "ID": "fedora",
+      "LOGO": "fedora-logo-icon",
+      "NAME": "Fedora",
+      "PLATFORM_ID": "platform:f34",
+      "PRETTY_NAME": "Fedora 34 (Cloud Edition)",
+      "PRIVACY_POLICY_URL": "https://fedoraproject.org/wiki/Legal:PrivacyPolicy",
+      "REDHAT_BUGZILLA_PRODUCT": "Fedora",
+      "REDHAT_BUGZILLA_PRODUCT_VERSION": "34",
+      "REDHAT_SUPPORT_PRODUCT": "Fedora",
+      "REDHAT_SUPPORT_PRODUCT_VERSION": "34",
+      "SUPPORT_URL": "https://fedoraproject.org/wiki/Communicating_and_getting_help",
+      "VARIANT": "Cloud Edition",
+      "VARIANT_ID": "cloud",
+      "VERSION": "34 (Cloud Edition)",
+      "VERSION_CODENAME": "",
+      "VERSION_ID": "34"
+    },
+    "packages": [
+      "NetworkManager-1.30.6-1.fc34.aarch64",
+      "NetworkManager-libnm-1.30.6-1.fc34.aarch64",
+      "acl-2.3.1-1.fc34.aarch64",
+      "alternatives-1.15-2.fc34.aarch64",
+      "audit-3.0.6-1.fc34.aarch64",
+      "audit-libs-3.0.6-1.fc34.aarch64",
+      "basesystem-11-11.fc34.noarch",
+      "bash-5.1.0-2.fc34.aarch64",
+      "bzip2-libs-1.0.8-6.fc34.aarch64",
+      "c-ares-1.17.2-1.fc34.aarch64",
+      "ca-certificates-2021.2.52-1.0.fc34.noarch",
+      "checkpolicy-3.2-1.fc34.aarch64",
+      "chrony-4.1-1.fc34.aarch64",
+      "cloud-init-20.4-2.fc34.noarch",
+      "cloud-utils-growpart-0.31-8.fc34.noarch",
+      "console-login-helper-messages-0.21.2-1.fc34.noarch",
+      "console-login-helper-messages-issuegen-0.21.2-1.fc34.noarch",
+      "console-login-helper-messages-motdgen-0.21.2-1.fc34.noarch",
+      "console-login-helper-messages-profile-0.21.2-1.fc34.noarch",
+      "coreutils-8.32-30.fc34.aarch64",
+      "coreutils-common-8.32-30.fc34.aarch64",
+      "cpio-2.13-10.fc34.aarch64",
+      "cracklib-2.9.6-27.fc34.aarch64",
+      "cracklib-dicts-2.9.6-27.fc34.aarch64",
+      "crypto-policies-20210213-1.git5c710c0.fc34.noarch",
+      "crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch",
+      "cryptsetup-libs-2.3.6-1.fc34.aarch64",
+      "curl-7.76.1-12.fc34.aarch64",
+      "cyrus-sasl-lib-2.1.27-8.fc34.aarch64",
+      "dbus-1.12.20-3.fc34.aarch64",
+      "dbus-broker-29-2.fc34.aarch64",
+      "dbus-common-1.12.20-3.fc34.noarch",
+      "dbus-libs-1.12.20-3.fc34.aarch64",
+      "dejavu-sans-fonts-2.37-16.fc34.noarch",
+      "deltarpm-3.6.2-8.fc34.aarch64",
+      "device-mapper-1.02.175-1.fc34.aarch64",
+      "device-mapper-libs-1.02.175-1.fc34.aarch64",
+      "dhcp-client-4.4.2-11.b1.fc34.aarch64",
+      "dhcp-common-4.4.2-11.b1.fc34.noarch",
+      "diffutils-3.7-8.fc34.aarch64",
+      "dnf-4.9.0-1.fc34.noarch",
+      "dnf-data-4.9.0-1.fc34.noarch",
+      "dnf-plugins-core-4.0.24-1.fc34.noarch",
+      "dracut-055-6.fc34.aarch64",
+      "dracut-config-generic-055-6.fc34.aarch64",
+      "e2fsprogs-1.45.6-5.fc34.aarch64",
+      "e2fsprogs-libs-1.45.6-5.fc34.aarch64",
+      "efi-filesystem-5-4.fc34.noarch",
+      "efibootmgr-16-10.fc34.aarch64",
+      "efivar-libs-37-15.fc34.aarch64",
+      "elfutils-debuginfod-client-0.186-1.fc34.aarch64",
+      "elfutils-default-yama-scope-0.186-1.fc34.noarch",
+      "elfutils-libelf-0.186-1.fc34.aarch64",
+      "elfutils-libs-0.186-1.fc34.aarch64",
+      "expat-2.4.1-1.fc34.aarch64",
+      "fedora-gpg-keys-34-2.noarch",
+      "fedora-release-cloud-34-39.noarch",
+      "fedora-release-common-34-39.noarch",
+      "fedora-release-identity-cloud-34-39.noarch",
+      "fedora-repos-34-2.noarch",
+      "fedora-repos-modular-34-2.noarch",
+      "file-5.39-7.fc34.aarch64",
+      "file-libs-5.39-7.fc34.aarch64",
+      "filesystem-3.14-5.fc34.aarch64",
+      "findutils-4.8.0-2.fc34.aarch64",
+      "fonts-filesystem-2.0.5-5.fc34.noarch",
+      "fuse-libs-2.9.9-11.fc34.aarch64",
+      "gawk-5.1.0-3.fc34.aarch64",
+      "gawk-all-langpacks-5.1.0-3.fc34.aarch64",
+      "gdbm-libs-1.19-2.fc34.aarch64",
+      "gettext-0.21-4.fc34.aarch64",
+      "gettext-libs-0.21-4.fc34.aarch64",
+      "glib2-2.68.4-1.fc34.aarch64",
+      "glibc-2.33-20.fc34.aarch64",
+      "glibc-common-2.33-20.fc34.aarch64",
+      "glibc-doc-2.33-20.fc34.noarch",
+      "glibc-langpack-en-2.33-20.fc34.aarch64",
+      "gmp-6.2.0-6.fc34.aarch64",
+      "gnupg2-2.2.27-4.fc34.aarch64",
+      "gnupg2-smime-2.2.27-4.fc34.aarch64",
+      "gnutls-3.7.2-1.fc34.aarch64",
+      "gpg-pubkey-45719a39-5f2c0192",
+      "gpgme-1.15.1-2.fc34.aarch64",
+      "grep-3.6-2.fc34.aarch64",
+      "groff-base-1.22.4-7.fc34.aarch64",
+      "grub2-common-2.06-9.fc34.noarch",
+      "grub2-efi-aa64-2.06-9.fc34.aarch64",
+      "grub2-tools-2.06-9.fc34.aarch64",
+      "grub2-tools-minimal-2.06-9.fc34.aarch64",
+      "grubby-8.40-51.fc34.aarch64",
+      "gzip-1.10-4.fc34.aarch64",
+      "hostname-3.23-4.fc34.aarch64",
+      "ima-evm-utils-1.3.2-2.fc34.aarch64",
+      "inih-49-3.fc34.aarch64",
+      "initscripts-10.09-1.fc34.aarch64",
+      "ipcalc-1.0.1-1.fc34.aarch64",
+      "iproute-5.10.0-2.fc34.aarch64",
+      "iproute-tc-5.10.0-2.fc34.aarch64",
+      "iptables-legacy-libs-1.8.7-8.fc34.aarch64",
+      "iptables-libs-1.8.7-8.fc34.aarch64",
+      "iputils-20210202-2.fc34.aarch64",
+      "jansson-2.13.1-2.fc34.aarch64",
+      "json-c-0.14-8.fc34.aarch64",
+      "kbd-2.4.0-2.fc34.aarch64",
+      "kbd-misc-2.4.0-2.fc34.noarch",
+      "kernel-5.15.13-100.fc34.aarch64",
+      "kernel-core-5.15.13-100.fc34.aarch64",
+      "kernel-modules-5.15.13-100.fc34.aarch64",
+      "keyutils-libs-1.6.1-2.fc34.aarch64",
+      "kmod-29-2.fc34.aarch64",
+      "kmod-libs-29-2.fc34.aarch64",
+      "kpartx-0.8.5-4.fc34.aarch64",
+      "krb5-libs-1.19.2-2.fc34.aarch64",
+      "langpacks-core-en-3.0-14.fc34.noarch",
+      "langpacks-core-font-en-3.0-14.fc34.noarch",
+      "langpacks-en-3.0-14.fc34.noarch",
+      "less-590-2.fc34.aarch64",
+      "libacl-2.3.1-1.fc34.aarch64",
+      "libarchive-3.5.2-2.fc34.aarch64",
+      "libargon2-20171227-6.fc34.aarch64",
+      "libassuan-2.5.5-1.fc34.aarch64",
+      "libattr-2.5.1-1.fc34.aarch64",
+      "libbasicobjects-0.1.1-47.fc34.aarch64",
+      "libblkid-2.36.2-1.fc34.aarch64",
+      "libbrotli-1.0.9-4.fc34.aarch64",
+      "libcap-2.48-2.fc34.aarch64",
+      "libcap-ng-0.8.2-4.fc34.aarch64",
+      "libcbor-0.7.0-3.fc34.aarch64",
+      "libcollection-0.7.0-47.fc34.aarch64",
+      "libcom_err-1.45.6-5.fc34.aarch64",
+      "libcomps-0.1.18-1.fc34.aarch64",
+      "libcurl-7.76.1-12.fc34.aarch64",
+      "libdb-5.3.28-49.fc34.aarch64",
+      "libdhash-0.5.0-47.fc34.aarch64",
+      "libdnf-0.64.0-1.fc34.aarch64",
+      "libeconf-0.4.0-1.fc34.aarch64",
+      "libedit-3.1-38.20210714cvs.fc34.aarch64",
+      "libevent-2.1.12-3.fc34.aarch64",
+      "libfdisk-2.36.2-1.fc34.aarch64",
+      "libffi-3.1-28.fc34.aarch64",
+      "libfido2-1.6.0-2.fc34.aarch64",
+      "libgcc-11.2.1-1.fc34.aarch64",
+      "libgcrypt-1.9.3-3.fc34.aarch64",
+      "libgomp-11.2.1-1.fc34.aarch64",
+      "libgpg-error-1.42-1.fc34.aarch64",
+      "libibverbs-37.0-1.fc34.aarch64",
+      "libidn2-2.3.2-1.fc34.aarch64",
+      "libini_config-1.3.1-47.fc34.aarch64",
+      "libkcapi-1.2.1-1.fc34.aarch64",
+      "libkcapi-hmaccalc-1.2.1-1.fc34.aarch64",
+      "libksba-1.5.0-2.fc34.aarch64",
+      "libldb-2.3.2-1.fc34.aarch64",
+      "libmaxminddb-1.5.2-1.fc34.aarch64",
+      "libmnl-1.0.4-13.fc34.aarch64",
+      "libmodulemd-2.13.0-2.fc34.aarch64",
+      "libmount-2.36.2-1.fc34.aarch64",
+      "libndp-1.7-7.fc34.aarch64",
+      "libnetfilter_conntrack-1.0.8-2.fc34.aarch64",
+      "libnfnetlink-1.0.1-19.fc34.aarch64",
+      "libnfsidmap-2.5.4-2.rc3.fc34.aarch64",
+      "libnghttp2-1.43.0-2.fc34.aarch64",
+      "libnl3-3.5.0-6.fc34.aarch64",
+      "libnsl2-1.3.0-2.fc34.aarch64",
+      "libpath_utils-0.2.1-47.fc34.aarch64",
+      "libpcap-1.10.1-1.fc34.aarch64",
+      "libpipeline-1.5.3-2.fc34.aarch64",
+      "libpsl-0.21.1-3.fc34.aarch64",
+      "libpwquality-1.4.4-6.fc34.aarch64",
+      "libref_array-0.1.5-47.fc34.aarch64",
+      "librepo-1.14.2-1.fc34.aarch64",
+      "libreport-filesystem-2.15.2-2.fc34.noarch",
+      "libseccomp-2.5.3-1.fc34.aarch64",
+      "libsecret-0.20.4-2.fc34.aarch64",
+      "libselinux-3.2-1.fc34.aarch64",
+      "libselinux-utils-3.2-1.fc34.aarch64",
+      "libsemanage-3.2-1.fc34.aarch64",
+      "libsepol-3.2-2.fc34.aarch64",
+      "libsigsegv-2.13-2.fc34.aarch64",
+      "libsmartcols-2.36.2-1.fc34.aarch64",
+      "libsolv-0.7.17-3.fc34.aarch64",
+      "libss-1.45.6-5.fc34.aarch64",
+      "libssh-0.9.6-1.fc34.aarch64",
+      "libssh-config-0.9.6-1.fc34.noarch",
+      "libsss_autofs-2.5.2-2.fc34.aarch64",
+      "libsss_certmap-2.5.2-2.fc34.aarch64",
+      "libsss_idmap-2.5.2-2.fc34.aarch64",
+      "libsss_nss_idmap-2.5.2-2.fc34.aarch64",
+      "libsss_sudo-2.5.2-2.fc34.aarch64",
+      "libstdc++-11.2.1-1.fc34.aarch64",
+      "libtalloc-2.3.2-2.fc34.aarch64",
+      "libtasn1-4.16.0-4.fc34.aarch64",
+      "libtdb-1.4.3-6.fc34.aarch64",
+      "libtevent-0.11.0-0.fc34.aarch64",
+      "libtextstyle-0.21-4.fc34.aarch64",
+      "libtirpc-1.3.2-0.fc34.aarch64",
+      "libunistring-0.9.10-10.fc34.aarch64",
+      "libusbx-1.0.24-2.fc34.aarch64",
+      "libuser-0.63-4.fc34.aarch64",
+      "libutempter-1.2.1-4.fc34.aarch64",
+      "libuuid-2.36.2-1.fc34.aarch64",
+      "libverto-0.3.2-1.fc34.aarch64",
+      "libxcrypt-4.4.27-1.fc34.aarch64",
+      "libxkbcommon-1.3.0-1.fc34.aarch64",
+      "libxml2-2.9.12-4.fc34.aarch64",
+      "libyaml-0.2.5-5.fc34.aarch64",
+      "libzstd-1.5.0-1.fc34.aarch64",
+      "linux-atm-libs-2.5.1-28.fc34.aarch64",
+      "linux-firmware-20211216-127.fc34.noarch",
+      "linux-firmware-whence-20211216-127.fc34.noarch",
+      "lmdb-libs-0.9.29-1.fc34.aarch64",
+      "lua-libs-5.4.3-1.fc34.aarch64",
+      "lz4-libs-1.9.3-2.fc34.aarch64",
+      "man-db-2.9.3-3.fc34.aarch64",
+      "memstrack-0.2.2-1.fc34.aarch64",
+      "mkpasswd-5.5.10-1.fc34.aarch64",
+      "mokutil-0.4.0-4.fc34.aarch64",
+      "mpfr-4.1.0-7.fc34.aarch64",
+      "ncurses-6.2-4.20200222.fc34.aarch64",
+      "ncurses-base-6.2-4.20200222.fc34.noarch",
+      "ncurses-libs-6.2-4.20200222.fc34.aarch64",
+      "net-tools-2.0-0.59.20160912git.fc34.aarch64",
+      "nettle-3.7.3-1.fc34.aarch64",
+      "npth-1.6-6.fc34.aarch64",
+      "openldap-2.4.57-6.fc34.aarch64",
+      "openssh-8.6p1-5.fc34.aarch64",
+      "openssh-clients-8.6p1-5.fc34.aarch64",
+      "openssh-server-8.6p1-5.fc34.aarch64",
+      "openssl-libs-1.1.1l-2.fc34.aarch64",
+      "openssl-pkcs11-0.4.11-2.fc34.aarch64",
+      "os-prober-1.77-7.fc34.aarch64",
+      "p11-kit-0.23.22-3.fc34.aarch64",
+      "p11-kit-trust-0.23.22-3.fc34.aarch64",
+      "pam-1.5.1-7.fc34.aarch64",
+      "parted-3.4-2.fc34.aarch64",
+      "passwd-0.80-10.fc34.aarch64",
+      "pcre-8.44-3.fc34.1.aarch64",
+      "pcre2-10.36-4.fc34.aarch64",
+      "pcre2-syntax-10.36-4.fc34.noarch",
+      "pigz-2.5-1.fc34.aarch64",
+      "pinentry-1.2.0-1.fc34.aarch64",
+      "policycoreutils-3.2-1.fc34.aarch64",
+      "popt-1.18-4.fc34.aarch64",
+      "procps-ng-3.3.17-1.fc34.1.aarch64",
+      "protobuf-c-1.3.3-7.fc34.aarch64",
+      "psmisc-23.4-1.fc34.aarch64",
+      "publicsuffix-list-dafsa-20190417-5.fc34.noarch",
+      "python-pip-wheel-21.0.1-4.fc34.noarch",
+      "python-setuptools-wheel-53.0.0-2.fc34.noarch",
+      "python-unversioned-command-3.9.9-2.fc34.noarch",
+      "python3-3.9.9-2.fc34.aarch64",
+      "python3-attrs-20.3.0-2.fc34.noarch",
+      "python3-audit-3.0.6-1.fc34.aarch64",
+      "python3-babel-2.9.1-1.fc34.noarch",
+      "python3-cffi-1.14.5-1.fc34.aarch64",
+      "python3-chardet-4.0.0-1.fc34.noarch",
+      "python3-configobj-5.0.6-23.fc34.noarch",
+      "python3-cryptography-3.4.6-1.fc34.aarch64",
+      "python3-dateutil-2.8.1-3.fc34.noarch",
+      "python3-dbus-1.2.18-1.fc34.aarch64",
+      "python3-distro-1.5.0-5.fc34.noarch",
+      "python3-dnf-4.9.0-1.fc34.noarch",
+      "python3-dnf-plugins-core-4.0.24-1.fc34.noarch",
+      "python3-gpg-1.15.1-2.fc34.aarch64",
+      "python3-hawkey-0.64.0-1.fc34.aarch64",
+      "python3-idna-2.10-3.fc34.noarch",
+      "python3-jinja2-2.11.3-1.fc34.noarch",
+      "python3-jsonpatch-1.21-14.fc34.noarch",
+      "python3-jsonpointer-2.0-2.fc34.noarch",
+      "python3-jsonschema-3.2.0-9.fc34.noarch",
+      "python3-jwt+crypto-1.7.1-11.fc34.noarch",
+      "python3-jwt-1.7.1-11.fc34.noarch",
+      "python3-libcomps-0.1.18-1.fc34.aarch64",
+      "python3-libdnf-0.64.0-1.fc34.aarch64",
+      "python3-libs-3.9.9-2.fc34.aarch64",
+      "python3-libselinux-3.2-1.fc34.aarch64",
+      "python3-libsemanage-3.2-1.fc34.aarch64",
+      "python3-markupsafe-1.1.1-10.fc34.aarch64",
+      "python3-oauthlib+signedtoken-3.0.2-9.fc34.noarch",
+      "python3-oauthlib-3.0.2-9.fc34.noarch",
+      "python3-pip-21.0.1-4.fc34.noarch",
+      "python3-ply-3.11-11.fc34.noarch",
+      "python3-policycoreutils-3.2-1.fc34.noarch",
+      "python3-prettytable-0.7.2-25.fc34.noarch",
+      "python3-pycparser-2.20-3.fc34.noarch",
+      "python3-pyrsistent-0.17.3-6.fc34.aarch64",
+      "python3-pyserial-3.4-10.fc34.noarch",
+      "python3-pysocks-1.7.1-8.fc34.noarch",
+      "python3-pytz-2021.3-1.fc34.noarch",
+      "python3-pyyaml-5.4.1-2.fc34.aarch64",
+      "python3-requests-2.25.1-1.fc34.noarch",
+      "python3-rpm-4.16.1.3-1.fc34.aarch64",
+      "python3-setools-4.4.0-1.fc34.aarch64",
+      "python3-setuptools-53.0.0-2.fc34.noarch",
+      "python3-six-1.15.0-5.fc34.noarch",
+      "python3-unbound-1.13.2-1.fc34.aarch64",
+      "python3-urllib3-1.25.10-5.fc34.noarch",
+      "qrencode-libs-4.1.1-1.fc34.aarch64",
+      "readline-8.1-2.fc34.aarch64",
+      "rootfiles-8.1-29.fc34.noarch",
+      "rpm-4.16.1.3-1.fc34.aarch64",
+      "rpm-build-libs-4.16.1.3-1.fc34.aarch64",
+      "rpm-libs-4.16.1.3-1.fc34.aarch64",
+      "rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64",
+      "rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64",
+      "rpm-sign-libs-4.16.1.3-1.fc34.aarch64",
+      "rsync-3.2.3-5.fc34.aarch64",
+      "sed-4.8-7.fc34.aarch64",
+      "selinux-policy-34.23-1.fc34.noarch",
+      "selinux-policy-targeted-34.23-1.fc34.noarch",
+      "setup-2.13.7-3.fc34.noarch",
+      "shadow-utils-4.8.1-10.fc34.aarch64",
+      "shared-mime-info-2.1-2.fc34.aarch64",
+      "shim-aa64-15.4-4.aarch64",
+      "sqlite-libs-3.34.1-2.fc34.aarch64",
+      "sssd-client-2.5.2-2.fc34.aarch64",
+      "sssd-common-2.5.2-2.fc34.aarch64",
+      "sssd-kcm-2.5.2-2.fc34.aarch64",
+      "sssd-nfs-idmap-2.5.2-2.fc34.aarch64",
+      "sudo-1.9.5p2-1.fc34.aarch64",
+      "sudo-python-plugin-1.9.5p2-1.fc34.aarch64",
+      "systemd-248.9-1.fc34.aarch64",
+      "systemd-libs-248.9-1.fc34.aarch64",
+      "systemd-networkd-248.9-1.fc34.aarch64",
+      "systemd-oomd-defaults-248.9-1.fc34.aarch64",
+      "systemd-pam-248.9-1.fc34.aarch64",
+      "systemd-rpm-macros-248.9-1.fc34.noarch",
+      "systemd-udev-248.9-1.fc34.aarch64",
+      "tar-1.34-1.fc34.aarch64",
+      "tpm2-tss-3.1.0-1.fc34.aarch64",
+      "trousers-0.3.15-2.fc34.aarch64",
+      "trousers-lib-0.3.15-2.fc34.aarch64",
+      "tzdata-2021e-1.fc34.noarch",
+      "unbound-libs-1.13.2-1.fc34.aarch64",
+      "util-linux-2.36.2-1.fc34.aarch64",
+      "vim-data-8.2.3755-1.fc34.noarch",
+      "vim-minimal-8.2.3755-1.fc34.aarch64",
+      "which-2.21-26.fc34.aarch64",
+      "whois-nls-5.5.10-1.fc34.noarch",
+      "xfsprogs-5.10.0-2.fc34.aarch64",
+      "xkeyboard-config-2.33-1.fc34.noarch",
+      "xz-5.2.5-5.fc34.aarch64",
+      "xz-libs-5.2.5-5.fc34.aarch64",
+      "yum-4.9.0-1.fc34.noarch",
+      "zchunk-libs-1.1.15-1.fc34.aarch64",
+      "zlib-1.2.11-26.fc34.aarch64"
+    ],
+    "partition-table": "gpt",
+    "partition-table-id": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
+    "partitions": [
+      {
+        "bootable": false,
+        "fstype": "vfat",
+        "label": "EFI-SYSTEM",
+        "partuuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
+        "size": 498073600,
+        "start": 1048576,
+        "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+        "uuid": "46BB-8120"
+      },
+      {
+        "bootable": false,
+        "fstype": "ext4",
+        "label": null,
+        "partuuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
+        "size": 1647296000,
+        "start": 500170752,
+        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+        "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+      }
+    ],
+    "passwd": [
+      "adm:x:3:4:adm:/var/adm:/sbin/nologin",
+      "bin:x:1:1:bin:/bin:/sbin/nologin",
+      "chrony:x:995:994::/var/lib/chrony:/sbin/nologin",
+      "daemon:x:2:2:daemon:/sbin:/sbin/nologin",
+      "dbus:x:81:81:System message bus:/:/sbin/nologin",
+      "ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin",
+      "games:x:12:100:games:/usr/games:/sbin/nologin",
+      "halt:x:7:0:halt:/sbin:/sbin/halt",
+      "lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin",
+      "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
+      "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
+      "operator:x:11:0:operator:/root:/sbin/nologin",
+      "redhat:x:1000:1000::/home/redhat:/bin/bash",
+      "root:x:0:0:root:/root:/bin/bash",
+      "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
+      "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
+      "sync:x:5:0:sync:/sbin:/bin/sync",
+      "systemd-coredump:x:999:999:systemd Core Dumper:/:/sbin/nologin",
+      "systemd-network:x:192:192:systemd Network Management:/:/sbin/nologin",
+      "systemd-oom:x:998:998:systemd Userspace OOM Killer:/:/sbin/nologin",
+      "systemd-resolve:x:193:193:systemd Resolver:/:/sbin/nologin",
+      "systemd-timesync:x:997:997:systemd Time Synchronization:/:/sbin/nologin",
+      "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
+      "unbound:x:996:995:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
+    ],
+    "rpm-verify": {
+      "changed": {
+        "/boot/efi/EFI": ".M.......",
+        "/boot/efi/EFI/fedora/grubaa64.efi": ".......T.",
+        "/etc/machine-id": ".M.......",
+        "/etc/udev/hwdb.bin": ".M.......",
+        "/proc": ".M.......",
+        "/sys": ".M.......",
+        "/var/log/lastlog": ".M....G.."
+      },
+      "missing": []
+    },
+    "selinux": {
+      "context-mismatch": [
+        {
+          "actual": "system_u:object_r:unlabeled_t:s0",
+          "expected": "system_u:object_r:lost_found_t:s0",
+          "filename": "/lost+found"
+        }
+      ],
+      "policy": {
+        "SELINUX": "enforcing",
+        "SELINUXTYPE": "targeted"
+      }
+    },
+    "services-disabled": [
+      "arp-ethers.service",
+      "chrony-wait.service",
+      "console-getty.service",
+      "console-login-helper-messages-gensnippet-os-release.service",
+      "console-login-helper-messages-gensnippet-ssh-keys.service",
+      "debug-shell.service",
+      "exit.target",
+      "halt.target",
+      "kexec.target",
+      "loadmodules.service",
+      "man-db-restart-cache-update.service",
+      "nis-domainname.service",
+      "poweroff.target",
+      "proc-sys-fs-binfmt_misc.mount",
+      "rdisc.service",
+      "remote-cryptsetup.target",
+      "remote-veritysetup.target",
+      "runlevel0.target",
+      "selinux-check-proper-disable.service",
+      "serial-getty@.service",
+      "sshd-keygen@.service",
+      "sshd.socket",
+      "sssd-autofs.socket",
+      "sssd-nss.socket",
+      "sssd-pac.socket",
+      "sssd-pam-priv.socket",
+      "sssd-pam.socket",
+      "sssd-ssh.socket",
+      "sssd-sudo.socket",
+      "systemd-boot-check-no-failures.service",
+      "systemd-network-generator.service",
+      "systemd-networkd-wait-online.service",
+      "systemd-networkd.service",
+      "systemd-networkd.socket",
+      "systemd-pstore.service",
+      "systemd-sysext.service",
+      "systemd-time-wait-sync.service",
+      "systemd-timesyncd.service",
+      "tcsd.service"
+    ],
+    "services-enabled": [
+      "NetworkManager-dispatcher.service",
+      "NetworkManager-wait-online.service",
+      "NetworkManager.service",
+      "auditd.service",
+      "autovt@.service",
+      "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
+      "ctrl-alt-del.target",
+      "dbus-broker.service",
+      "dbus-org.freedesktop.home1.service",
+      "dbus-org.freedesktop.nm-dispatcher.service",
+      "dbus-org.freedesktop.oom1.service",
+      "dbus-org.freedesktop.resolve1.service",
+      "dbus.service",
+      "dbus.socket",
+      "dnf-makecache.timer",
+      "fstrim.timer",
+      "getty@.service",
+      "import-state.service",
+      "reboot.target",
+      "remote-fs.target",
+      "rpmdb-rebuild.service",
+      "runlevel6.target",
+      "selinux-autorelabel-mark.service",
+      "sshd.service",
+      "sssd-kcm.socket",
+      "sssd.service",
+      "systemd-homed-activate.service",
+      "systemd-homed.service",
+      "systemd-oomd.service",
+      "systemd-resolved.service",
+      "systemd-userdbd.socket",
+      "unbound-anchor.timer"
+    ],
+    "sudoers": {
+      "/etc/sudoers": [
+        "Defaults   !visiblepw",
+        "Defaults    always_set_home",
+        "Defaults    match_group_by_gid",
+        "Defaults    always_query_group_plugin",
+        "Defaults    env_reset",
+        "Defaults    env_keep =  \"COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS\"",
+        "Defaults    env_keep += \"MAIL QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE\"",
+        "Defaults    env_keep += \"LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES\"",
+        "Defaults    env_keep += \"LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE\"",
+        "Defaults    env_keep += \"LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY\"",
+        "Defaults    secure_path = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+        "root\tALL=(ALL) \tALL",
+        "%wheel\tALL=(ALL)\tALL"
+      ]
+    },
+    "sysctl.d": {
+      "/usr/lib/sysctl.d": {
+        "10-default-yama-scope.conf": [
+          "kernel.yama.ptrace_scope = 0"
+        ],
+        "50-coredump.conf": [
+          "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h",
+          "kernel.core_pipe_limit=16",
+          "fs.suid_dumpable=2"
+        ],
+        "50-default.conf": [
+          "kernel.sysrq = 16",
+          "kernel.core_uses_pid = 1",
+          "net.ipv4.conf.default.rp_filter = 2",
+          "net.ipv4.conf.*.rp_filter = 2",
+          "-net.ipv4.conf.all.rp_filter",
+          "net.ipv4.conf.default.accept_source_route = 0",
+          "net.ipv4.conf.*.accept_source_route = 0",
+          "-net.ipv4.conf.all.accept_source_route",
+          "net.ipv4.conf.default.promote_secondaries = 1",
+          "net.ipv4.conf.*.promote_secondaries = 1",
+          "-net.ipv4.conf.all.promote_secondaries",
+          "-net.ipv4.ping_group_range = 0 2147483647",
+          "-net.core.default_qdisc = fq_codel",
+          "fs.protected_hardlinks = 1",
+          "fs.protected_symlinks = 1",
+          "fs.protected_regular = 1",
+          "fs.protected_fifos = 1"
+        ],
+        "50-libkcapi-optmem_max.conf": [
+          "net.core.optmem_max = 81920"
+        ],
+        "50-pid-max.conf": [
+          "kernel.pid_max = 4194304"
+        ]
+      }
+    },
+    "systemd-service-dropins": {
+      "/usr/lib/systemd/system": {
+        "systemd-hostnamed.service.d": {
+          "Service": {
+            "PrivateDevices": "no"
+          }
+        },
+        "systemd-logind.service.d": {
+          "Service": {
+            "Environment": "SYSTEMD_REBOOT_TO_BOOT_LOADER_MENU=true"
+          }
+        },
+        "systemd-udev-trigger.service.d": {
+          "Unit": {
+            "RefuseManualStop": "true"
+          }
+        },
+        "user@.service.d": {
+          "Service": {
+            "ManagedOOMMemoryPressure": "kill",
+            "ManagedOOMMemoryPressureLimit": "50%"
+          }
+        }
+      }
+    },
+    "timezone": "UTC",
+    "tmpfiles.d": {
+      "/usr/lib/tmpfiles.d": {
+        "cloud-init.conf": [
+          "d /run/cloud-init 0700 root root - -"
+        ],
+        "console-login-helper-messages-issuegen.conf": [
+          "r /etc/issue.d/*_clhm_*.issue - - - - -"
+        ],
+        "console-login-helper-messages-motdgen.conf": [
+          "d /run/motd.d - - - - -"
+        ],
+        "console-login-helper-messages-profile.conf": [
+          "L /etc/profile.d/console-login-helper-messages-profile.sh - - - - ../../usr/share/console-login-helper-messages/profile.sh"
+        ],
+        "console-login-helper-messages.conf": [
+          "d /run/console-login-helper-messages - - - - -"
+        ],
+        "cryptsetup.conf": [
+          "d /run/cryptsetup 0700 root root -"
+        ],
+        "dnf.conf": [
+          "R /var/tmp/dnf*/locks/*",
+          "r /var/cache/dnf/download_lock.pid",
+          "r /var/cache/dnf/metadata_lock.pid",
+          "r /var/lib/dnf/rpmdb_lock.pid",
+          "r /var/log/log_lock.pid"
+        ],
+        "etc.conf": [
+          "L /etc/os-release - - - - ../usr/lib/os-release",
+          "L+ /etc/mtab - - - - ../proc/self/mounts",
+          "L! /etc/resolv.conf - - - - ../run/systemd/resolve/stub-resolv.conf",
+          "C! /etc/nsswitch.conf - - - -",
+          "C! /etc/pam.d - - - -",
+          "C! /etc/issue - - - -"
+        ],
+        "home.conf": [
+          "Q /home 0755 - - -",
+          "q /srv 0755 - - -"
+        ],
+        "journal-nocow.conf": [
+          "h /var/log/journal - - - - +C",
+          "h /var/log/journal/%m - - - - +C",
+          "h /var/log/journal/remote - - - - +C"
+        ],
+        "legacy.conf": [
+          "d /run/lock 0755 root root -",
+          "L /var/lock - - - - ../run/lock",
+          "d /run/lock/subsys 0755 root root -",
+          "r! /forcefsck",
+          "r! /fastboot",
+          "r! /forcequotacheck"
+        ],
+        "libselinux.conf": [
+          "d /run/setrans 0755 root root"
+        ],
+        "man-db.conf": [
+          "d /var/cache/man 0755 root root 1w"
+        ],
+        "pam.conf": [
+          "d /run/console 0755 root root -",
+          "d /run/faillock 0755 root root -",
+          "d /run/sepermit 0755 root root -",
+          "d /run/motd.d 0755 root root -",
+          "f /var/log/tallylog 0600 root root -"
+        ],
+        "portables.conf": [
+          "Q /var/lib/portables 0700"
+        ],
+        "selinux-policy.conf": [
+          "z /sys/devices/system/cpu/online - - -",
+          "Z /sys/class/net - - -",
+          "z /sys/kernel/uevent_helper - - -",
+          "w /sys/fs/selinux/checkreqprot - - - - 0"
+        ],
+        "setup.conf": [
+          "f /run/motd 0644 root root -",
+          "d /run/motd.d 0755 root root -"
+        ],
+        "static-nodes-permissions.conf": [
+          "z /dev/snd/seq      0660 - audio -",
+          "z /dev/snd/timer    0660 - audio -",
+          "z /dev/loop-control 0660 - disk  -",
+          "z /dev/net/tun      0666 - -     -",
+          "z /dev/fuse         0666 - -     -",
+          "z /dev/kvm          0666 - kvm -",
+          "z /dev/vhost-net    0666 - kvm -",
+          "z /dev/vhost-vsock  0666 - kvm -"
+        ],
+        "sudo.conf": [
+          "d /run/sudo 0711 root root",
+          "D /run/sudo/ts 0700 root root"
+        ],
+        "systemd-nologin.conf": [
+          "F! /run/nologin 0644 - - - \"System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8).\""
+        ],
+        "systemd-pstore.conf": [
+          "d /var/lib/systemd/pstore 0755 root root 14d"
+        ],
+        "systemd-tmp.conf": [
+          "x /tmp/systemd-private-%b-*",
+          "X /tmp/systemd-private-%b-*/tmp",
+          "x /var/tmp/systemd-private-%b-*",
+          "X /var/tmp/systemd-private-%b-*/tmp",
+          "R! /tmp/systemd-private-*",
+          "R! /var/tmp/systemd-private-*",
+          "x  /var/lib/systemd/coredump/.#core*.%b*",
+          "r! /var/lib/systemd/coredump/.#*"
+        ],
+        "systemd.conf": [
+          "d /run/user 0755 root root -",
+          "F! /run/utmp 0664 root utmp -",
+          "d /run/systemd/ask-password 0755 root root -",
+          "d /run/systemd/seats 0755 root root -",
+          "d /run/systemd/sessions 0755 root root -",
+          "d /run/systemd/users 0755 root root -",
+          "d /run/systemd/machines 0755 root root -",
+          "d /run/systemd/shutdown 0755 root root -",
+          "d /run/systemd/netif 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/links 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/leases 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/lldp 0755 systemd-network systemd-network -",
+          "d /run/log 0755 root root -",
+          "z /run/log/journal 2755 root systemd-journal - -",
+          "Z /run/log/journal/%m ~2750 root systemd-journal - -",
+          "a+ /run/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m/*.journal* - - - - group:adm:r--,group:wheel:r--",
+          "z /var/log/journal 2755 root systemd-journal - -",
+          "z /var/log/journal/%m 2755 root systemd-journal - -",
+          "z /var/log/journal/%m/system.journal 0640 root systemd-journal - -",
+          "a+ /var/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m/system.journal - - - - group:adm:r--,group:wheel:r--",
+          "d /var/lib/systemd 0755 root root -",
+          "d /var/lib/systemd/coredump 0755 root root 3d",
+          "d /var/lib/private 0700 root root -",
+          "d /var/log/private 0700 root root -",
+          "d /var/cache/private 0700 root root -"
+        ],
+        "tmp.conf": [
+          "q /tmp 1777 root root 10d",
+          "q /var/tmp 1777 root root 30d"
+        ],
+        "tpm2-tss-fapi.conf": [
+          "d       /var/lib/tpm2-tss/system/keystore   2775 tss  tss   -           -",
+          "a+      /var/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx",
+          "d       /run/tpm2-tss/eventlog                2775 tss  tss   -           -",
+          "a+      /run/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx"
+        ],
+        "var.conf": [
+          "q /var 0755 - - -",
+          "L /var/run - - - - ../run",
+          "d /var/log 0755 - - -",
+          "f /var/log/wtmp 0664 root utmp -",
+          "f /var/log/btmp 0660 root utmp -",
+          "f /var/log/lastlog 0664 root utmp -",
+          "d /var/cache 0755 - - -",
+          "d /var/lib 0755 - - -",
+          "d /var/spool 0755 - - -"
+        ],
+        "x11.conf": [
+          "D! /tmp/.X11-unix 1777 root root 10d",
+          "D! /tmp/.ICE-unix 1777 root root 10d",
+          "D! /tmp/.XIM-unix 1777 root root 10d",
+          "D! /tmp/.font-unix 1777 root root 10d",
+          "D! /tmp/.Test-unix 1777 root root 10d",
+          "r! /tmp/.X[0-9]*-lock"
+        ]
+      }
+    }
+  }
+}

--- a/test/data/manifests/fedora_34-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-qcow2_customize-boot.json
@@ -1,0 +1,10301 @@
+{
+  "compose-request": {
+    "distro": "fedora-34",
+    "arch": "aarch64",
+    "image-type": "qcow2",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-modular-20210512/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-modular-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      }
+    ],
+    "filename": "disk.qcow2",
+    "blueprint": {
+      "name": "qcow2-customize-boot-test",
+      "description": "Image for boot test",
+      "packages": [
+        {
+          "name": "bash",
+          "version": "*"
+        }
+      ],
+      "modules": [],
+      "groups": [
+        {
+          "name": "core"
+        }
+      ],
+      "customizations": {
+        "hostname": "my-host",
+        "kernel": {
+          "append": "debug"
+        },
+        "sshkey": [
+          {
+            "user": "user1",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+          }
+        ],
+        "user": [
+          {
+            "name": "user2",
+            "description": "description 2",
+            "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+            "home": "/home/home2",
+            "shell": "/bin/sh",
+            "groups": [
+              "group1"
+            ],
+            "uid": 1020,
+            "gid": 1050
+          }
+        ],
+        "group": [
+          {
+            "name": "group1",
+            "gid": 1030
+          },
+          {
+            "name": "group2",
+            "gid": 1050
+          }
+        ],
+        "timezone": {
+          "timezone": "Europe/London",
+          "ntpservers": [
+            "time.example.com"
+          ]
+        },
+        "locale": {
+          "languages": [
+            "el_CY.UTF-8"
+          ],
+          "keyboard": "dvorak"
+        },
+        "services": {
+          "enabled": [
+            "sshd.socket"
+          ],
+          "disabled": [
+            "bluetooth.service"
+          ]
+        }
+      }
+    }
+  },
+  "manifest": {
+    "sources": {
+      "org.osbuild.files": {
+        "urls": {
+          "sha256:00c29524aad123ec44056e60b9625e75ac428a6c751878a05fadbca7e956c249": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dbus-1.2.18-1.fc34.aarch64.rpm"
+          },
+          "sha256:0176b42c6b51fb3c829f168571527a3559b6a9c8cc5f847b70e3c40fb69f89e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-100.fc34.aarch64.rpm"
+          },
+          "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-legacy-libs-1.8.7-8.fc34.aarch64.rpm"
+          },
+          "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-9.fc34.aarch64.rpm"
+          },
+          "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc34.aarch64.rpm"
+          },
+          "sha256:059f825547fe257247656c29049ebc7bfa1d54a17479f3dcfeff37fbab7084bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.33-20.fc34.aarch64.rpm"
+          },
+          "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libibverbs-37.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc34.aarch64.rpm"
+          },
+          "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.aarch64.rpm"
+          },
+          "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm"
+          },
+          "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pip-21.0.1-4.fc34.noarch.rpm"
+          },
+          "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cyrus-sasl-lib-2.1.27-8.fc34.aarch64.rpm"
+          },
+          "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxml2-2.9.12-4.fc34.aarch64.rpm"
+          },
+          "sha256:0ac62147585be2dae960ed37a3a0c3eb2f8a95d0fd0993991c8bf7238b1d5e27": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dhcp-client-4.4.2-11.b1.fc34.aarch64.rpm"
+          },
+          "sha256:0db1be9a78e5f329a519066a7b37379f6c73fe579154e0a6a26b2dcb4154ccd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-common-2.33-20.fc34.aarch64.rpm"
+          },
+          "sha256:0f9ebdf7f08a506a8d1d6c4b4788dd7ca3dbb832509072b66def4da5b86d7862": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/efibootmgr-16-10.fc34.aarch64.rpm"
+          },
+          "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm"
+          },
+          "sha256:1014763656c1578ae96b38fd3e87c4d07b548cb8423688cc928d0f9762d43a44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfido2-1.6.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libblkid-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:11a0c09b716f8071f0484278bec326fb82e93d987376c8b38188d1febcd5381d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libndp-1.7-7.fc34.aarch64.rpm"
+          },
+          "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:11cd6fae157eb9e4800163633b57bcce21d59a1df4b86a99ba03707b6cee0cfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dhcp-common-4.4.2-11.b1.fc34.noarch.rpm"
+          },
+          "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libuuid-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm"
+          },
+          "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-ng-0.8.2-4.fc34.aarch64.rpm"
+          },
+          "sha256:12b7666d61e7bd8b3b5b1a7c57539964531802287e592e33449e039799ea2071": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbasicobjects-0.1.1-47.fc34.aarch64.rpm"
+          },
+          "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/which-2.21-26.fc34.aarch64.rpm"
+          },
+          "sha256:131adc47f044c9f600f5295ded0f5431cda57fa7276100c3ec81c9d1ce3fa6f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jwt-1.7.1-11.fc34.noarch.rpm"
+          },
+          "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:139b9453b2038e52767d0102def782d58d558ca0603757eb0c97ddda28af1466": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-audit-3.0.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:148aea26e381b33badde0ac2ae716a78f7b565f54f0b6970189a89713f335eaf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-3.0.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:164e1c0e3e8c89aeda4f272b3158932649a69b16aea058105117a64d3cdef517": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rootfiles-8.1-29.fc34.noarch.rpm"
+          },
+          "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm"
+          },
+          "sha256:1877af369228dd661ae1adfc43bbb8d53d3464d59ead0f5bcf6c2be88f8e8685": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-0.21.2-1.fc34.noarch.rpm"
+          },
+          "sha256:1af86c0a8c11e44958b022bf7dad5f48ad974fa8537cf41a12d5b0643444b1dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.3755-1.fc34.aarch64.rpm"
+          },
+          "sha256:1b1af6b54050ec223c3289b107a9695a686c9d46d17a80ec9cd5d0201ec5d544": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonpointer-2.0-2.fc34.noarch.rpm"
+          },
+          "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.aarch64.rpm"
+          },
+          "sha256:1feb6a045cb3e95e3c8e0112ecb4b8ffeb9986a503b52c5497fefce217846b90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc34.noarch.rpm"
+          },
+          "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.aarch64.rpm"
+          },
+          "sha256:2027da420b35a0b70ae5045d2fd79cdccb820f03e5ff4018a2205d3d413ff1af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtdb-1.4.3-6.fc34.aarch64.rpm"
+          },
+          "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm"
+          },
+          "sha256:23a539a271c92906ac0a12c7d877c7f4d0ad8e6b9bbd8642b5232f861b79ed22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shim-aa64-15.4-4.aarch64.rpm"
+          },
+          "sha256:23e3ed871799a9209915359f71660babf451b0b44902e3ed488b7b22aff37718": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-ply-3.11-11.fc34.noarch.rpm"
+          },
+          "sha256:2414cb7345bc193f7ff7983c020c8b0e706aab013ee30af5d457d35c4de4a698": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jinja2-2.11.3-1.fc34.noarch.rpm"
+          },
+          "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/whois-nls-5.5.10-1.fc34.noarch.rpm"
+          },
+          "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpsl-0.21.1-3.fc34.aarch64.rpm"
+          },
+          "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm"
+          },
+          "sha256:27920113489e3260e58d4a033d31401c6ae22ded72895c6b8c0e43ebf89a62df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/parted-3.4-2.fc34.aarch64.rpm"
+          },
+          "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/nettle-3.7.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-all-langpacks-5.1.0-3.fc34.aarch64.rpm"
+          },
+          "sha256:2968703dd232a37620a0ae12146c9d1ec5220f62c40bfb0ecfc60b621d8e1eac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-dicts-2.9.6-27.fc34.aarch64.rpm"
+          },
+          "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-34.23-1.fc34.noarch.rpm"
+          },
+          "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-8.32-30.fc34.aarch64.rpm"
+          },
+          "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxkbcommon-1.3.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:30bc3583e503e0f459e323b27551f7b9a8ab784de15437b5b29f447b31f8d9cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/y/yum-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.aarch64.rpm"
+          },
+          "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:32220dc513a6ebcd4994e7140ecb5859108baf44d12fe6b1f0c0459dbefc54e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pycparser-2.20-3.fc34.noarch.rpm"
+          },
+          "sha256:3228a36807658c7e4d881013aa26f877353388bf3bac6c948984f751c264a359": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xfsprogs-5.10.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:330a36b1dabaf76daafeff3f7fd7a276880bf65d790ee84cb823a1958a4d99d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libnfsidmap-2.5.4-2.rc3.fc34.aarch64.rpm"
+          },
+          "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-6.2-4.20200222.fc34.aarch64.rpm"
+          },
+          "sha256:33b878000610ca3ba875b72f2a454e4fac9471f80579824304ca81e6f3e3f79d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/checkpolicy-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-20210213-1.git5c710c0.fc34.noarch.rpm"
+          },
+          "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm"
+          },
+          "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-setuptools-wheel-53.0.0-2.fc34.noarch.rpm"
+          },
+          "sha256:37cda2c179e4311a1aeeb0ea8d07d3eacc8ea8bf97d122ec22cd596c61b8e770": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/groff-base-1.22.4-7.fc34.aarch64.rpm"
+          },
+          "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.aarch64.rpm"
+          },
+          "sha256:39160ef65b3519a70f14f992edc5967380ef86a6940896751db681781961903d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-server-8.6p1-5.fc34.aarch64.rpm"
+          },
+          "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sed-4.8-7.fc34.aarch64.rpm"
+          },
+          "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.aarch64.rpm"
+          },
+          "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grep-3.6-2.fc34.aarch64.rpm"
+          },
+          "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.0.1-4.fc34.noarch.rpm"
+          },
+          "sha256:3b3bba1d61529a1dde47f234f34d0fdee07a38aa5958d87e30357ea04bbff142": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.aarch64.rpm"
+          },
+          "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/keyutils-libs-1.6.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-0.21-4.fc34.aarch64.rpm"
+          },
+          "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/setup-2.13.7-3.fc34.noarch.rpm"
+          },
+          "sha256:3e69e8412d5914ec01c5e82264833698e92a1b88a7c7b5ed9b1f0351fc91f5d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-34-39.noarch.rpm"
+          },
+          "sha256:3f7bde703045c2651fbd4142131ea1e303a565269388a08e2312af0eb83307a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-issuegen-0.21.2-1.fc34.noarch.rpm"
+          },
+          "sha256:3fb05067cbd7fcf3283f2ab306c2dae668d818d3a69422e729c2ef62974810a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fonts-filesystem-2.0.5-5.fc34.noarch.rpm"
+          },
+          "sha256:3fdab509a59e0a765364d6f119c38c796a4420cc49b46595a37d98eb649d6c80": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm"
+          },
+          "sha256:40e231991444a589b17e0b5b338be8874d071e3d17e210aba6f6639620775f79": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-1.9.5p2-1.fc34.aarch64.rpm"
+          },
+          "sha256:4123331b5d06f91ff31d147e4769806052f59b620e7677f69b0073eaf7beccb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:424f73b97c7d7541d35685108bdcddb03100cd0f3d6e0fd9def576462ca65b59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-profile-0.21.2-1.fc34.noarch.rpm"
+          },
+          "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.aarch64.rpm"
+          },
+          "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.9.9-2.fc34.noarch.rpm"
+          },
+          "sha256:43b0b5d425a2041daeb6b41db2858abda1f92ecc38c6125f7de3b7502580a9f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:45d38ed1d2247e17e3e8faf7d6755216c5ef4422736129f55b712f160532d8f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libini_config-1.3.1-47.fc34.aarch64.rpm"
+          },
+          "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm"
+          },
+          "sha256:47c92a952b162b7bafbe49a7e409a7a81825adc77b3e139651913d52d8aa84fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/h/hostname-3.23-4.fc34.aarch64.rpm"
+          },
+          "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsemanage-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnl3-3.5.0-6.fc34.aarch64.rpm"
+          },
+          "sha256:4a74ae08a713e9b4e74ff27bfaf57374312370402f90e2796e66c504557ae189": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pysocks-1.7.1-8.fc34.noarch.rpm"
+          },
+          "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:4b65dc9856b0d0ce555dd9bce88dcfb680ba689a2c6b88ae9f84b016553d96af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iputils-20210202-2.fc34.aarch64.rpm"
+          },
+          "sha256:4baf8ba6a5ed4609695f79a8bbc8324d7efa322a3573c8c5fa3942361eac0f1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.30.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-1.12.20-3.fc34.aarch64.rpm"
+          },
+          "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-2.9.6-27.fc34.aarch64.rpm"
+          },
+          "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/curl-7.76.1-12.fc34.aarch64.rpm"
+          },
+          "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-common-1.12.20-3.fc34.noarch.rpm"
+          },
+          "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gdbm-libs-1.19-2.fc34.aarch64.rpm"
+          },
+          "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/gnutls-3.7.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:55833f669ed1dbd32e79f494824c309b71bc373d2bf28eb5cdb663459dc6f7cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-100.fc34.aarch64.rpm"
+          },
+          "sha256:56634e58fc7499d719a3f431dd188e8f2655ebfa402e94ce105794a47debf45b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtalloc-2.3.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.aarch64.rpm"
+          },
+          "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc34.aarch64.rpm"
+          },
+          "sha256:59cc4d563ecb4c8b517f5dd7505f1cda297f950f32fc700344aa7789b69ca99c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-babel-2.9.1-1.fc34.noarch.rpm"
+          },
+          "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:5d2c28837f0573ae2647b8fbba85f7c502f9c3da0a3eab1c9ba121de4a1a6cee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-dateutil-2.8.1-3.fc34.noarch.rpm"
+          },
+          "sha256:5dcac7772d73ad1523f87cbeb1dc76dd62af4d2bb73dd06896a47d2bcf503e5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-8.6p1-5.fc34.aarch64.rpm"
+          },
+          "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm"
+          },
+          "sha256:6046f881a5c0822c30bd037aec040c65594b6328b1c0d72b6681fe1575eac765": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcbor-0.7.0-3.fc34.aarch64.rpm"
+          },
+          "sha256:60ddc7b15e9742ff9995d1b336489b92721e21a45034d20f20d2fc800e419d1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/popt-1.18-4.fc34.aarch64.rpm"
+          },
+          "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:61a9dbd9020e29012947978acf33a0c1150e6c3e078de372f1e38fb9c4ef529a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/chrony-4.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:61ba1ecff8f8578cbd3445df596d001067bb0281745191ac168fcc6079d8e1cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/man-db-2.9.3-3.fc34.aarch64.rpm"
+          },
+          "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-3.9.9-2.fc34.aarch64.rpm"
+          },
+          "sha256:6297d7eee103c679a0f1ea411568d3940af3fe8f38e19388a1544df70bda8b3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-requests-2.25.1-1.fc34.noarch.rpm"
+          },
+          "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpcap-1.10.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-0.23.22-3.fc34.aarch64.rpm"
+          },
+          "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbrotli-1.0.9-4.fc34.aarch64.rpm"
+          },
+          "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-libs-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm"
+          },
+          "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtirpc-1.3.2-0.fc34.aarch64.rpm"
+          },
+          "sha256:668a30c6f526e51705af9cb9d98fd11f279f5e86f7d905876ae9a86f486a8c36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-common-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm"
+          },
+          "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm"
+          },
+          "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-34.23-1.fc34.noarch.rpm"
+          },
+          "sha256:686e015d81c1be2e6b88c7e8a50d45109d7273143a034caa9c935ecd014e1c62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libref_array-0.1.5-47.fc34.aarch64.rpm"
+          },
+          "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-trust-0.23.22-3.fc34.aarch64.rpm"
+          },
+          "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/procps-ng-3.3.17-1.fc34.1.aarch64.rpm"
+          },
+          "sha256:69de3dd68dc2b76e2a85c710a51e9c8acefe595d6ac5d9f19113c4062a5f0d92": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/ipcalc-1.0.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:6a864bec34b7d39de3e6ae1e39ec07fa3a2d21837a9a2d7151228d7f0ac38e73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/passwd-0.80-10.fc34.aarch64.rpm"
+          },
+          "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-34-2.noarch.rpm"
+          },
+          "sha256:6d1b95e06ec98f6d65c64e18fec693d379b98128a3e94b4dec8929321354c549": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cloud-utils-growpart-0.31-8.fc34.noarch.rpm"
+          },
+          "sha256:6d1c024b295c423746b44f120cf36ceb0fd898f8ce5a276813d7c78a3c8ece52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-34-39.noarch.rpm"
+          },
+          "sha256:6d3301f6e99d9728698822e81fc2d170694cc367b7e7fea5c7a019f7b1a6073b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/inih-49-3.fc34.aarch64.rpm"
+          },
+          "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm"
+          },
+          "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fuse-libs-2.9.9-11.fc34.aarch64.rpm"
+          },
+          "sha256:70a90c6c682016e91fb4745eedbd23f28e150a38b01d18f85ce4e50fb4e0ca6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pyserial-3.4-10.fc34.noarch.rpm"
+          },
+          "sha256:71427f6f8f3f6370dccde81a76d566ff17144e7e375381ef13e04a661e63cba1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-9.fc34.aarch64.rpm"
+          },
+          "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtextstyle-0.21-4.fc34.aarch64.rpm"
+          },
+          "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-config-0.9.6-1.fc34.noarch.rpm"
+          },
+          "sha256:7285fcc290a8af2cf845beb845e661cd4c06c2275417b15eb507824dedec7c69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnghttp2-1.43.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtasn1-4.16.0-4.fc34.aarch64.rpm"
+          },
+          "sha256:7721bc647c521d96e07e665f7da306326d3bd1499d610c58552317815aaf3c45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lmdb-libs-0.9.29-1.fc34.aarch64.rpm"
+          },
+          "sha256:79834af7f95c0d1e5dcf85b794819bd854197a52d2966594abdb3c3de0fcceb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dejavu-sans-fonts-2.37-16.fc34.noarch.rpm"
+          },
+          "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:79864051052858a1c95538888ca61a43b509b6eae4ae269ae6ea7bf8b076a2b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmnl-1.0.4-13.fc34.aarch64.rpm"
+          },
+          "sha256:7c24e53e12891046bb6721e624cf9effd1946c0d076464427c2a86b29671318e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/c-ares-1.17.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:7cc0891a9e7c19757c03cba6c8155738d9db9f5774380c412106adf0eca44077": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/less-590-2.fc34.aarch64.rpm"
+          },
+          "sha256:7d00ccbb224617a00f58053afd88e7a49062446f1306ba39c72b78d20aeee1ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-cffi-1.14.5-1.fc34.aarch64.rpm"
+          },
+          "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/z/zlib-1.2.11-26.fc34.aarch64.rpm"
+          },
+          "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/filesystem-3.14-5.fc34.aarch64.rpm"
+          },
+          "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm"
+          },
+          "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-common-34-39.noarch.rpm"
+          },
+          "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch.rpm"
+          },
+          "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/findutils-4.8.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bzip2-libs-1.0.8-6.fc34.aarch64.rpm"
+          },
+          "sha256:820fee96d610178c7c7b8ce2b115bd02063d2f6dfcae5da4bf5d411de0b575f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-attrs-20.3.0-2.fc34.noarch.rpm"
+          },
+          "sha256:82b51ca6bec551d74a6d8c43194b0fd4e8bfdf19d1d68b58c1787723edd88bd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-en-3.0-14.fc34.noarch.rpm"
+          },
+          "sha256:82cbc5e0339e832d2fc0160541c30f3dee59b3d28d83907ae7b55e22d5092c51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-core-font-en-3.0-14.fc34.noarch.rpm"
+          },
+          "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-common-8.32-30.fc34.aarch64.rpm"
+          },
+          "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-29-2.fc34.aarch64.rpm"
+          },
+          "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:86cb1e5e80642b1575df57287c9549749603bf94b1ba652995b59ea45ac4272b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libldb-2.3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-libs-1.02.175-1.fc34.aarch64.rpm"
+          },
+          "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pam-1.5.1-7.fc34.aarch64.rpm"
+          },
+          "sha256:87749765dbe5ce8f098279170c39bb8a89abbf3f8430c2a6dbfb973117e11dfa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-libsemanage-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libidn2-2.3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.aarch64.rpm"
+          },
+          "sha256:8ab032e2a86f300d978e521ab030db1e7bb7eeccca205a5d2a4d68b51566f43f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc34.noarch.rpm"
+          },
+          "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openldap-2.4.57-6.fc34.aarch64.rpm"
+          },
+          "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libs-3.9.9-2.fc34.aarch64.rpm"
+          },
+          "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre-8.44-3.fc34.1.aarch64.rpm"
+          },
+          "sha256:8fbfbaf3b107b540428634c19c4cb05e7c46f9672cfbf14d1f44306ed3413a46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/efi-filesystem-5-4.fc34.noarch.rpm"
+          },
+          "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm"
+          },
+          "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc34.aarch64.rpm"
+          },
+          "sha256:92e42b63fcc56dd21984abb722e8fa7ebbb58f6d54c529ac11871b4bbc63b290": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pyyaml-5.4.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gmp-6.2.0-6.fc34.aarch64.rpm"
+          },
+          "sha256:96c7a26b707d4038a50b4ab0fd8d79ba3997466bed543f13c10d30e7ec256b5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/net-tools-2.0-0.59.20160912git.fc34.aarch64.rpm"
+          },
+          "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm"
+          },
+          "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/basesystem-11-11.fc34.noarch.rpm"
+          },
+          "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-5.2.5-5.fc34.aarch64.rpm"
+          },
+          "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/openssl-pkcs11-0.4.11-2.fc34.aarch64.rpm"
+          },
+          "sha256:9aee2549d3ff9e5652dffaaa9b91ab7a243687cc2a85b8e45f4290d53d44702d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc34.aarch64.rpm"
+          },
+          "sha256:9cc240ac305a862146e85d8dcc4ad981f5233a58b6901ecfac691d0b39966b49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jwt+crypto-1.7.1-11.fc34.noarch.rpm"
+          },
+          "sha256:9ce3f0c0904ac22ab5769babebf43e7dcdb488b0ef999b2e9e88a5b5eb424e51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-chardet-4.0.0-1.fc34.noarch.rpm"
+          },
+          "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm"
+          },
+          "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsepol-3.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-libs-0.21-4.fc34.aarch64.rpm"
+          },
+          "sha256:9f2f2a20f285a2ac306ce72475beecf967cf92308b426aafca68215a6c3c12ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/jansson-2.13.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-misc-2.4.0-2.fc34.noarch.rpm"
+          },
+          "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.aarch64.rpm"
+          },
+          "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm"
+          },
+          "sha256:a0f1b653f889bb95e6edec2c525dfc71e280076b29394cf9c06ffa81ecd8b9fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/efivar-libs-37-15.fc34.aarch64.rpm"
+          },
+          "sha256:a1a996e8da4733b14c449b69e34484fe4f2b88c0f2963145bf0402cf04baf30e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpath_utils-0.2.1-47.fc34.aarch64.rpm"
+          },
+          "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc34.noarch.rpm"
+          },
+          "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-gpg-keys-34-2.noarch.rpm"
+          },
+          "sha256:a60e3e035883de829c5778417d316ffc47a0b4a304953e3fdc44def8f2f172ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/linux-atm-libs-2.5.1-28.fc34.aarch64.rpm"
+          },
+          "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:a72bb74400b447af71600da141aebdc46da7776ef875abfdd635881f939891d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtevent-0.11.0-0.fc34.aarch64.rpm"
+          },
+          "sha256:a86ec8f7284ee01574bb06bba726d8609e464f41d003215097e626c583f73ed0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-python-plugin-1.9.5p2-1.fc34.aarch64.rpm"
+          },
+          "sha256:a9828dc2c4215e6bcb9aa14370d854f24637b0510e4b1a63709135049314e2b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rsync-3.2.3-5.fc34.aarch64.rpm"
+          },
+          "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-2.33-20.fc34.aarch64.rpm"
+          },
+          "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssl-libs-1.1.1l-2.fc34.aarch64.rpm"
+          },
+          "sha256:ac901ae730144d1e75b86d9991c1c6a9d6d0a44ce6e52b4d330df3a26d09e1ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/u/util-linux-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnsl2-1.3.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm"
+          },
+          "sha256:adb1b49ec7038eec956edd77d0ad2a72179b4f37c14548e3c9637d8a75c276a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.33-20.fc34.aarch64.rpm"
+          },
+          "sha256:adcd36cb0e582f5fb2d0465cf88bb813ffac17d25d6ec8aa608b647d008bebc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.3755-1.fc34.noarch.rpm"
+          },
+          "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-networkd-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/policycoreutils-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm"
+          },
+          "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libgpg-error-1.42-1.fc34.aarch64.rpm"
+          },
+          "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/os-prober-1.77-7.fc34.aarch64.rpm"
+          },
+          "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-pam-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-libs-5.2.5-5.fc34.aarch64.rpm"
+          },
+          "sha256:b30db4e3d9605e7263387ff91f91508667693d28e8b8835a2b7fcefd64f24388": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-oauthlib+signedtoken-3.0.2-9.fc34.noarch.rpm"
+          },
+          "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm"
+          },
+          "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-lib-0.3.15-2.fc34.aarch64.rpm"
+          },
+          "sha256:b5d5e7255c85c3aa9d63598ef140de35843ab2485adf1cb9a9130be80aa0297f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-six-1.15.0-5.fc34.noarch.rpm"
+          },
+          "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:b6687e9977e337e5d029de0d42cb79d57bd44f2f642450440756ba1a0494a113": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libedit-3.1-38.20210714cvs.fc34.aarch64.rpm"
+          },
+          "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libattr-2.5.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.aarch64.rpm"
+          },
+          "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cpio-2.13-10.fc34.aarch64.rpm"
+          },
+          "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-1.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm"
+          },
+          "sha256:bab19da8b6f553325decae00748f88fc0924b918136f065ab8995e1ebf5bde5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc34.noarch.rpm"
+          },
+          "sha256:bb078ccf6e7372cf22e55901c005517daff0b8cffa14fa3dec5e9804b4f65897": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmaxminddb-1.5.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm"
+          },
+          "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm"
+          },
+          "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mkpasswd-5.5.10-1.fc34.aarch64.rpm"
+          },
+          "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-syntax-10.36-4.fc34.noarch.rpm"
+          },
+          "sha256:bfd008fce37b2ec17dc4142c38a6e808c2e0031eed802a0253fca812989845d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iproute-tc-5.10.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:c04a67670d45f576c5a8b23fe64d5ce31b04ddf4792cbf78448fd4c96899f9c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnfnetlink-1.0.1-19.fc34.aarch64.rpm"
+          },
+          "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-rpm-macros-248.9-1.fc34.noarch.rpm"
+          },
+          "sha256:c20caffb4d2a500416dab0e8418a24ae5e25c02c831ae02ee10f97a0dcc80374": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-core-en-3.0-14.fc34.noarch.rpm"
+          },
+          "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm"
+          },
+          "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc34.aarch64.rpm"
+          },
+          "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-2.48-2.fc34.aarch64.rpm"
+          },
+          "sha256:c814f83bcf3cfc590d84897c810a087354cfb0c961dd232af5031cfe8bd63a37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-client-2.5.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-10.36-4.fc34.aarch64.rpm"
+          },
+          "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm"
+          },
+          "sha256:ca8f4843c8b23ce16b957143550d8dc83ae630cd64587fa2dd127e4ecbe9bb23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnetfilter_conntrack-1.0.8-2.fc34.aarch64.rpm"
+          },
+          "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.aarch64.rpm"
+          },
+          "sha256:cc4401d1e292b28d771a2038081b929b342ffa3b60358aed91697fdbc668546a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-prettytable-0.7.2-25.fc34.noarch.rpm"
+          },
+          "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.aarch64.rpm"
+          },
+          "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcrypt-1.9.3-3.fc34.aarch64.rpm"
+          },
+          "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-0.9.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc34.noarch.rpm"
+          },
+          "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsigsegv-2.13-2.fc34.aarch64.rpm"
+          },
+          "sha256:cf18d61c8f526fe86cd24073dfdce942b6a463ea909ed5a59a5cc4378d9101a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcollection-0.7.0-47.fc34.aarch64.rpm"
+          },
+          "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/memstrack-0.2.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pigz-2.5-1.fc34.aarch64.rpm"
+          },
+          "sha256:d1c8a2302e64fc856aff6a05a78140986e89eddd8f110deb9ba78d44aebcd411": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/psmisc-23.4-1.fc34.aarch64.rpm"
+          },
+          "sha256:d2bac91a1969f555ea2641b161bb23fa0aaaffaba3284d9973ad696594b73f18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-motdgen-0.21.2-1.fc34.noarch.rpm"
+          },
+          "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-libs-29-2.fc34.aarch64.rpm"
+          },
+          "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bash-5.1.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm"
+          },
+          "sha256:d54b628e6d0b7813ec0b4cc0beb1b8f3f8510ffbaff8ae1d9c4b9993095e4edf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-cloud-34-39.noarch.rpm"
+          },
+          "sha256:d5d622f60e97d43b095a98f2bb46982d91451e4e6018492da20944b294480af3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.6p1-5.fc34.aarch64.rpm"
+          },
+          "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.3.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:d6810c97f24d93cd54a61bb288ada8591a94e4083b5165e0719915bceb637504": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonschema-3.2.0-9.fc34.noarch.rpm"
+          },
+          "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/readline-8.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mpfr-4.1.0-7.fc34.aarch64.rpm"
+          },
+          "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-libs-3.0.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-9.fc34.aarch64.rpm"
+          },
+          "sha256:dbf3fb9e356236575a06e4fdcd532331f418236aa4ff4e024260c24be2b9a7cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-libselinux-3.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/json-c-0.14-8.fc34.aarch64.rpm"
+          },
+          "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/alternatives-1.15-2.fc34.aarch64.rpm"
+          },
+          "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/acl-2.3.1-1.fc34.aarch64.rpm"
+          },
+          "sha256:e035a5041c721ea40e47cbbc19eb1b91c520183f85137ee1dd3ed3b42a47c180": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-cloud-34-39.noarch.rpm"
+          },
+          "sha256:e0dffa204780c20c16357a51b992351aa1cf9f9cdda6182939ecd0cd7ab2c2bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonpatch-1.21-14.fc34.noarch.rpm"
+          },
+          "sha256:e1e89027213f00ae1014bbb1253058ed8d5d476e7246921f03736ea129d2a162": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iproute-5.10.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:e1f1b9c4b78fe9d84a87d7de67fdd8559fe2bea9969ca1632d137de635d7e898": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-setools-4.4.0-1.fc34.aarch64.rpm"
+          },
+          "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm"
+          },
+          "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-0.3.15-2.fc34.aarch64.rpm"
+          },
+          "sha256:e530795e5c9bc27de609fcbbacdc43c226026fee95e47a1f783f1c03ba5d48ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-distro-1.5.0-5.fc34.noarch.rpm"
+          },
+          "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libutempter-1.2.1-4.fc34.aarch64.rpm"
+          },
+          "sha256:e76f1401d9e119eae4cc461c8b68e9eae075d4b69f61870cb5c19ba7d69cf1a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-policycoreutils-3.2-1.fc34.noarch.rpm"
+          },
+          "sha256:e7d1d0b85ac49d8b0c9dd3fce4613e6229ac8720cfb74c80a496b9f0beaa7a22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cloud-init-20.4-2.fc34.noarch.rpm"
+          },
+          "sha256:e9814c1b1a22b8cbd39413dc4f0eab452ef7380ce01f05ecab0e41e2d00ba3c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libdhash-0.5.0-47.fc34.aarch64.rpm"
+          },
+          "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm"
+          },
+          "sha256:ea8067f2310d30b31f7b1f13825b2a5a5e679c114fefd072267b6c369a365a63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-cryptography-3.4.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:eab8d30db6004f8c21247689cac52f143e1bde1da817db9761420cf3cf855c38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/initscripts-10.09-1.fc34.aarch64.rpm"
+          },
+          "sha256:eb88e660b9fd02e695a90c0266831b79e513c2f65ba5d6353e82726af96e9752": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-modular-34-2.noarch.rpm"
+          },
+          "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/krb5-libs-1.19.2-2.fc34.aarch64.rpm"
+          },
+          "sha256:ebd4a9473543a5ca50ec5f9de069fc0c240527516ae262cf3e28a5d914b99cb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-libs-1.8.7-8.fc34.aarch64.rpm"
+          },
+          "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-1.02.175-1.fc34.aarch64.rpm"
+          },
+          "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.aarch64.rpm"
+          },
+          "sha256:ee147f5a7017de1c77abfbb79dd32eb97c923fc7c1b74c32bda6020b9025938c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpipeline-1.5.3-2.fc34.aarch64.rpm"
+          },
+          "sha256:eecc86b828ad436a9f397d2f7acdf5705bfd36bcad3edd2da73f3acc94363411": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc34.noarch.rpm"
+          },
+          "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-5.39-7.fc34.aarch64.rpm"
+          },
+          "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm"
+          },
+          "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grubby-8.40-51.fc34.aarch64.rpm"
+          },
+          "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.25.10-5.fc34.noarch.rpm"
+          },
+          "sha256:f3c940f33c6c8edb73b98527e0fff17aa211e823f06e3f732762d0c86cc0268c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-100.fc34.aarch64.rpm"
+          },
+          "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-doc-2.33-20.fc34.noarch.rpm"
+          },
+          "sha256:f68c93c0461c149bb17282dededf421cbc1fbfa5ac133b59bd362526f59e0d57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-idna-2.10-3.fc34.noarch.rpm"
+          },
+          "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.aarch64.rpm"
+          },
+          "sha256:f695ed244a1d9f3eb814947fb1da343d7d6fb3aaa2bf72965235e4b45a58a784": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.30.6-1.fc34.aarch64.rpm"
+          },
+          "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm"
+          },
+          "sha256:f7c7dc1d8e5cf4776a1fde155871a2bb1fdd0676f897a43334cfbb60eb69e52a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/mokutil-0.4.0-4.fc34.aarch64.rpm"
+          },
+          "sha256:f7f8832ccaedd7ddad064956309478b9bf366f0576517356ee68481e196236cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-configobj-5.0.6-23.fc34.noarch.rpm"
+          },
+          "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm"
+          },
+          "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:f9b2e7232d0b2d33bf52993c31b43b31520601f52f44fe792acd6dee4d84afc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-oauthlib-3.0.2-9.fc34.noarch.rpm"
+          },
+          "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfdisk-2.36.2-1.fc34.aarch64.rpm"
+          },
+          "sha256:fbf45cda87a05418a72f4bf3877da5ebcabbe68d393bc5bec007a8b01ef6bafe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-markupsafe-1.1.1-10.fc34.aarch64.rpm"
+          },
+          "sha256:fc4104e014beee44b5003e72a32e45e689936a4ffdcf07e119b02be3ed4ab8d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.17.3-6.fc34.aarch64.rpm"
+          },
+          "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lz4-libs-1.9.3-2.fc34.aarch64.rpm"
+          },
+          "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.8.1-10.fc34.aarch64.rpm"
+          },
+          "sha256:fd7dc918a1e3ad0114ecaa41d78c6652cc559271ad6653e5bba0bc780af35faa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libuser-0.63-4.fc34.aarch64.rpm"
+          },
+          "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.aarch64.rpm"
+          }
+        }
+      }
+    },
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.rpm",
+              "options": {
+                "gpgkeys": [
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n"
+                ],
+                "packages": [
+                  {
+                    "checksum": "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3e69e8412d5914ec01c5e82264833698e92a1b88a7c7b5ed9b1f0351fc91f5d2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6d1c024b295c423746b44f120cf36ceb0fd898f8ce5a276813d7c78a3c8ece52",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:adb1b49ec7038eec956edd77d0ad2a72179b4f37c14548e3c9637d8a75c276a1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
+                    "check_gpg": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "org.osbuild.selinux",
+              "options": {
+                "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+                "labels": {
+                  "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+                }
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.fedora33"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8"
+          }
+        },
+        {
+          "name": "org.osbuild.rpm",
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "packages": [
+              {
+                "checksum": "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:33b878000610ca3ba875b72f2a454e4fac9471f80579824304ca81e6f3e3f79d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e7d1d0b85ac49d8b0c9dd3fce4613e6229ac8720cfb74c80a496b9f0beaa7a22",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6d1b95e06ec98f6d65c64e18fec693d379b98128a3e94b4dec8929321354c549",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1877af369228dd661ae1adfc43bbb8d53d3464d59ead0f5bcf6c2be88f8e8685",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3f7bde703045c2651fbd4142131ea1e303a565269388a08e2312af0eb83307a4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d2bac91a1969f555ea2641b161bb23fa0aaaffaba3284d9973ad696594b73f18",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:424f73b97c7d7541d35685108bdcddb03100cd0f3d6e0fd9def576462ca65b59",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:79834af7f95c0d1e5dcf85b794819bd854197a52d2966594abdb3c3de0fcceb6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0f9ebdf7f08a506a8d1d6c4b4788dd7ca3dbb832509072b66def4da5b86d7862",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a0f1b653f889bb95e6edec2c525dfc71e280076b29394cf9c06ffa81ecd8b9fa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3fb05067cbd7fcf3283f2ab306c2dae668d818d3a69422e729c2ef62974810a5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:37cda2c179e4311a1aeeb0ea8d07d3eacc8ea8bf97d122ec22cd596c61b8e770",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:47c92a952b162b7bafbe49a7e409a7a81825adc77b3e139651913d52d8aa84fb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6d3301f6e99d9728698822e81fc2d170694cc367b7e7fea5c7a019f7b1a6073b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eab8d30db6004f8c21247689cac52f143e1bde1da817db9761420cf3cf855c38",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e1e89027213f00ae1014bbb1253058ed8d5d476e7246921f03736ea129d2a162",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bfd008fce37b2ec17dc4142c38a6e808c2e0031eed802a0253fca812989845d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4b65dc9856b0d0ce555dd9bce88dcfb680ba689a2c6b88ae9f84b016553d96af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9f2f2a20f285a2ac306ce72475beecf967cf92308b426aafca68215a6c3c12ca",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c20caffb4d2a500416dab0e8418a24ae5e25c02c831ae02ee10f97a0dcc80374",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:82cbc5e0339e832d2fc0160541c30f3dee59b3d28d83907ae7b55e22d5092c51",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:82b51ca6bec551d74a6d8c43194b0fd4e8bfdf19d1d68b58c1787723edd88bd0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:12b7666d61e7bd8b3b5b1a7c57539964531802287e592e33449e039799ea2071",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6046f881a5c0822c30bd037aec040c65594b6328b1c0d72b6681fe1575eac765",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cf18d61c8f526fe86cd24073dfdce942b6a463ea909ed5a59a5cc4378d9101a1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e9814c1b1a22b8cbd39413dc4f0eab452ef7380ce01f05ecab0e41e2d00ba3c0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1014763656c1578ae96b38fd3e87c4d07b548cb8423688cc928d0f9762d43a44",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:45d38ed1d2247e17e3e8faf7d6755216c5ef4422736129f55b712f160532d8f2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bb078ccf6e7372cf22e55901c005517daff0b8cffa14fa3dec5e9804b4f65897",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:79864051052858a1c95538888ca61a43b509b6eae4ae269ae6ea7bf8b076a2b8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11a0c09b716f8071f0484278bec326fb82e93d987376c8b38188d1febcd5381d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ca8f4843c8b23ce16b957143550d8dc83ae630cd64587fa2dd127e4ecbe9bb23",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c04a67670d45f576c5a8b23fe64d5ce31b04ddf4792cbf78448fd4c96899f9c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a1a996e8da4733b14c449b69e34484fe4f2b88c0f2963145bf0402cf04baf30e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ee147f5a7017de1c77abfbb79dd32eb97c923fc7c1b74c32bda6020b9025938c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:686e015d81c1be2e6b88c7e8a50d45109d7273143a034caa9c935ecd014e1c62",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:56634e58fc7499d719a3f431dd188e8f2655ebfa402e94ce105794a47debf45b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2027da420b35a0b70ae5045d2fd79cdccb820f03e5ff4018a2205d3d413ff1af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a60e3e035883de829c5778417d316ffc47a0b4a304953e3fdc44def8f2f172ab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7721bc647c521d96e07e665f7da306326d3bd1499d610c58552317815aaf3c45",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61ba1ecff8f8578cbd3445df596d001067bb0281745191ac168fcc6079d8e1cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f7c7dc1d8e5cf4776a1fde155871a2bb1fdd0676f897a43334cfbb60eb69e52a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:96c7a26b707d4038a50b4ab0fd8d79ba3997466bed543f13c10d30e7ec256b5e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:27920113489e3260e58d4a033d31401c6ae22ded72895c6b8c0e43ebf89a62df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6a864bec34b7d39de3e6ae1e39ec07fa3a2d21837a9a2d7151228d7f0ac38e73",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d1c8a2302e64fc856aff6a05a78140986e89eddd8f110deb9ba78d44aebcd411",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:820fee96d610178c7c7b8ce2b115bd02063d2f6dfcae5da4bf5d411de0b575f7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7d00ccbb224617a00f58053afd88e7a49062446f1306ba39c72b78d20aeee1ef",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9ce3f0c0904ac22ab5769babebf43e7dcdb488b0ef999b2e9e88a5b5eb424e51",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f7f8832ccaedd7ddad064956309478b9bf366f0576517356ee68481e196236cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ea8067f2310d30b31f7b1f13825b2a5a5e679c114fefd072267b6c369a365a63",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d2c28837f0573ae2647b8fbba85f7c502f9c3da0a3eab1c9ba121de4a1a6cee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e530795e5c9bc27de609fcbbacdc43c226026fee95e47a1f783f1c03ba5d48ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f68c93c0461c149bb17282dededf421cbc1fbfa5ac133b59bd362526f59e0d57",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2414cb7345bc193f7ff7983c020c8b0e706aab013ee30af5d457d35c4de4a698",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e0dffa204780c20c16357a51b992351aa1cf9f9cdda6182939ecd0cd7ab2c2bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1b1af6b54050ec223c3289b107a9695a686c9d46d17a80ec9cd5d0201ec5d544",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d6810c97f24d93cd54a61bb288ada8591a94e4083b5165e0719915bceb637504",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9cc240ac305a862146e85d8dcc4ad981f5233a58b6901ecfac691d0b39966b49",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:131adc47f044c9f600f5295ded0f5431cda57fa7276100c3ec81c9d1ce3fa6f7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dbf3fb9e356236575a06e4fdcd532331f418236aa4ff4e024260c24be2b9a7cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:87749765dbe5ce8f098279170c39bb8a89abbf3f8430c2a6dbfb973117e11dfa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fbf45cda87a05418a72f4bf3877da5ebcabbe68d393bc5bec007a8b01ef6bafe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b30db4e3d9605e7263387ff91f91508667693d28e8b8835a2b7fcefd64f24388",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f9b2e7232d0b2d33bf52993c31b43b31520601f52f44fe792acd6dee4d84afc8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:23e3ed871799a9209915359f71660babf451b0b44902e3ed488b7b22aff37718",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e76f1401d9e119eae4cc461c8b68e9eae075d4b69f61870cb5c19ba7d69cf1a3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cc4401d1e292b28d771a2038081b929b342ffa3b60358aed91697fdbc668546a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:32220dc513a6ebcd4994e7140ecb5859108baf44d12fe6b1f0c0459dbefc54e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:70a90c6c682016e91fb4745eedbd23f28e150a38b01d18f85ce4e50fb4e0ca6c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4a74ae08a713e9b4e74ff27bfaf57374312370402f90e2796e66c504557ae189",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:92e42b63fcc56dd21984abb722e8fa7ebbb58f6d54c529ac11871b4bbc63b290",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6297d7eee103c679a0f1ea411568d3940af3fe8f38e19388a1544df70bda8b3c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e1f1b9c4b78fe9d84a87d7de67fdd8559fe2bea9969ca1632d137de635d7e898",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5d5e7255c85c3aa9d63598ef140de35843ab2485adf1cb9a9130be80aa0297f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:164e1c0e3e8c89aeda4f272b3158932649a69b16aea058105117a64d3cdef517",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a9828dc2c4215e6bcb9aa14370d854f24637b0510e4b1a63709135049314e2b3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:23a539a271c92906ac0a12c7d877c7f4d0ad8e6b9bbd8642b5232f861b79ed22",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:40e231991444a589b17e0b5b338be8874d071e3d17e210aba6f6639620775f79",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a86ec8f7284ee01574bb06bba726d8609e464f41d003215097e626c583f73ed0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3228a36807658c7e4d881013aa26f877353388bf3bac6c948984f751c264a359",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4baf8ba6a5ed4609695f79a8bbc8324d7efa322a3573c8c5fa3942361eac0f1c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f695ed244a1d9f3eb814947fb1da343d7d6fb3aaa2bf72965235e4b45a58a784",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:148aea26e381b33badde0ac2ae716a78f7b565f54f0b6970189a89713f335eaf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7c24e53e12891046bb6721e624cf9effd1946c0d076464427c2a86b29671318e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61a9dbd9020e29012947978acf33a0c1150e6c3e078de372f1e38fb9c4ef529a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2968703dd232a37620a0ae12146c9d1ec5220f62c40bfb0ecfc60b621d8e1eac",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0ac62147585be2dae960ed37a3a0c3eb2f8a95d0fd0993991c8bf7238b1d5e27",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11cd6fae157eb9e4800163633b57bcce21d59a1df4b86a99ba03707b6cee0cfc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1feb6a045cb3e95e3c8e0112ecb4b8ffeb9986a503b52c5497fefce217846b90",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9aee2549d3ff9e5652dffaaa9b91ab7a243687cc2a85b8e45f4290d53d44702d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8fbfbaf3b107b540428634c19c4cb05e7c46f9672cfbf14d1f44306ed3413a46",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d54b628e6d0b7813ec0b4cc0beb1b8f3f8510ffbaff8ae1d9c4b9993095e4edf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e035a5041c721ea40e47cbbc19eb1b91c520183f85137ee1dd3ed3b42a47c180",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eb88e660b9fd02e695a90c0266831b79e513c2f65ba5d6353e82726af96e9752",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:059f825547fe257247656c29049ebc7bfa1d54a17479f3dcfeff37fbab7084bd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:71427f6f8f3f6370dccde81a76d566ff17144e7e375381ef13e04a661e63cba1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:69de3dd68dc2b76e2a85c710a51e9c8acefe595d6ac5d9f19113c4062a5f0d92",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ebd4a9473543a5ca50ec5f9de069fc0c240527516ae262cf3e28a5d914b99cb1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:55833f669ed1dbd32e79f494824c309b71bc373d2bf28eb5cdb663459dc6f7cd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0176b42c6b51fb3c829f168571527a3559b6a9c8cc5f847b70e3c40fb69f89e4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3c940f33c6c8edb73b98527e0fff17aa211e823f06e3f732762d0c86cc0268c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7cc0891a9e7c19757c03cba6c8155738d9db9f5774380c412106adf0eca44077",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b6687e9977e337e5d029de0d42cb79d57bd44f2f642450440756ba1a0494a113",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:86cb1e5e80642b1575df57287c9549749603bf94b1ba652995b59ea45ac4272b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:330a36b1dabaf76daafeff3f7fd7a276880bf65d790ee84cb823a1958a4d99d7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b3bba1d61529a1dde47f234f34d0fdee07a38aa5958d87e30357ea04bbff142",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac901ae730144d1e75b86d9991c1c6a9d6d0a44ce6e52b4d330df3a26d09e1ff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3fdab509a59e0a765364d6f119c38c796a4420cc49b46595a37d98eb649d6c80",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:60ddc7b15e9742ff9995d1b336489b92721e21a45034d20f20d2fc800e419d1c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4123331b5d06f91ff31d147e4769806052f59b620e7677f69b0073eaf7beccb6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a72bb74400b447af71600da141aebdc46da7776ef875abfdd635881f939891d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fd7dc918a1e3ad0114ecaa41d78c6652cc559271ad6653e5bba0bc780af35faa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8ab032e2a86f300d978e521ab030db1e7bb7eeccca205a5d2a4d68b51566f43f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5dcac7772d73ad1523f87cbeb1dc76dd62af4d2bb73dd06896a47d2bcf503e5e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d5d622f60e97d43b095a98f2bb46982d91451e4e6018492da20944b294480af3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:39160ef65b3519a70f14f992edc5967380ef86a6940896751db681781961903d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:139b9453b2038e52767d0102def782d58d558ca0603757eb0c97ddda28af1466",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59cc4d563ecb4c8b517f5dd7505f1cda297f950f32fc700344aa7789b69ca99c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:00c29524aad123ec44056e60b9625e75ac428a6c751878a05fadbca7e956c249",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bab19da8b6f553325decae00748f88fc0924b918136f065ab8995e1ebf5bde5b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fc4104e014beee44b5003e72a32e45e689936a4ffdcf07e119b02be3ed4ab8d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eecc86b828ad436a9f397d2f7acdf5705bfd36bcad3edd2da73f3acc94363411",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c814f83bcf3cfc590d84897c810a087354cfb0c961dd232af5031cfe8bd63a37",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:668a30c6f526e51705af9cb9d98fd11f279f5e86f7d905876ae9a86f486a8c36",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7285fcc290a8af2cf845beb845e661cd4c06c2275417b15eb507824dedec7c69",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0db1be9a78e5f329a519066a7b37379f6c73fe579154e0a6a26b2dcb4154ccd6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:43b0b5d425a2041daeb6b41db2858abda1f92ecc38c6125f7de3b7502580a9f7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:adcd36cb0e582f5fb2d0465cf88bb813ffac17d25d6ec8aa608b647d008bebc3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1af86c0a8c11e44958b022bf7dad5f48ad974fa8537cf41a12d5b0643444b1dc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30bc3583e503e0f459e323b27551f7b9a8ab784de15437b5b29f447b31f8d9cd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
+                "check_gpg": true
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "el_CY.UTF-8"
+          }
+        },
+        {
+          "name": "org.osbuild.keymap",
+          "options": {
+            "keymap": "dvorak"
+          }
+        },
+        {
+          "name": "org.osbuild.hostname",
+          "options": {
+            "hostname": "my-host"
+          }
+        },
+        {
+          "name": "org.osbuild.timezone",
+          "options": {
+            "zone": "Europe/London"
+          }
+        },
+        {
+          "name": "org.osbuild.chrony",
+          "options": {
+            "timeservers": [
+              "time.example.com"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.groups",
+          "options": {
+            "groups": {
+              "group1": {
+                "name": "group1",
+                "gid": 1030
+              },
+              "group2": {
+                "name": "group2",
+                "gid": 1050
+              }
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "user1": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              },
+              "user2": {
+                "uid": 1020,
+                "gid": 1050,
+                "groups": [
+                  "group1"
+                ],
+                "description": "description 2",
+                "home": "/home/home2",
+                "shell": "/bin/sh",
+                "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              },
+              {
+                "uuid": "46BB-8120",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "umask=0077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": " debug",
+            "uefi": {
+              "vendor": "fedora"
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service",
+              "sshd.socket"
+            ],
+            "disabled_services": [
+              "bluetooth.service"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
+        "options": {
+          "format": "qcow2",
+          "filename": "disk.qcow2",
+          "size": 2147483648,
+          "ptuuid": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
+          "pttype": "gpt",
+          "partitions": [
+            {
+              "start": 2048,
+              "size": 972800,
+              "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+              "uuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
+              "filesystem": {
+                "type": "vfat",
+                "uuid": "46BB-8120",
+                "label": "EFI-SYSTEM",
+                "mountpoint": "/boot/efi"
+              }
+            },
+            {
+              "start": 976896,
+              "uuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build-packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/acl-2.3.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/alternatives-1.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/basesystem-11-11.fc34.noarch.rpm",
+        "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bash-5.1.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bzip2-libs-1.0.8-6.fc34.aarch64.rpm",
+        "checksum": "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cpio-2.13-10.fc34.aarch64.rpm",
+        "checksum": "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cyrus-sasl-lib-2.1.27-8.fc34.aarch64.rpm",
+        "checksum": "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-1.12.20-3.fc34.aarch64.rpm",
+        "checksum": "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-common-1.12.20-3.fc34.noarch.rpm",
+        "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm",
+        "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm",
+        "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-1.02.175-1.fc34.aarch64.rpm",
+        "checksum": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-libs-1.02.175-1.fc34.aarch64.rpm",
+        "checksum": "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cd1389701cf86cd09b78c8c4dbbf2b37e3a1f7b8ba4e2828e5df995a8095ba38",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/filesystem-3.14-5.fc34.aarch64.rpm",
+        "checksum": "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/findutils-4.8.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "11.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fuse-libs-2.9.9-11.fc34.aarch64.rpm",
+        "checksum": "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-all-langpacks-5.1.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.19",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gdbm-libs-1.19-2.fc34.aarch64.rpm",
+        "checksum": "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-libs-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gmp-6.2.0-6.fc34.aarch64.rpm",
+        "checksum": "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm",
+        "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grep-3.6-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "51.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grubby-8.40-51.fc34.aarch64.rpm",
+        "checksum": "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm",
+        "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.14",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/json-c-0.14-8.fc34.aarch64.rpm",
+        "checksum": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-misc-2.4.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/keyutils-libs-1.6.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.5",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "11.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.aarch64.rpm",
+        "checksum": "sha256:30eee02314cec35c28cbecbc721eefbb02ff49aeceb6c9710b50d24400fd3d3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.aarch64.rpm",
+        "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libattr-2.5.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libblkid-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbrotli-1.0.9-4.fc34.aarch64.rpm",
+        "checksum": "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-2.48-2.fc34.aarch64.rpm",
+        "checksum": "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-ng-0.8.2-4.fc34.aarch64.rpm",
+        "checksum": "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm",
+        "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfdisk-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "28.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.aarch64.rpm",
+        "checksum": "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.42",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libgpg-error-1.42-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-1.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.43.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnghttp2-1.43.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnl3-3.5.0-6.fc34.aarch64.rpm",
+        "checksum": "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnsl2-1.3.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpsl-0.21.1-3.fc34.aarch64.rpm",
+        "checksum": "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm",
+        "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsemanage-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsigsegv-2.13-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.17",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm",
+        "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtasn1-4.16.0-4.fc34.aarch64.rpm",
+        "checksum": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
+        "check_gpg": true
+      },
+      {
+        "name": "libtextstyle",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtextstyle-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.aarch64.rpm",
+        "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
+        "check_gpg": true
+      },
+      {
+        "name": "liburing",
+        "epoch": 0,
+        "version": "0.7",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.aarch64.rpm",
+        "checksum": "sha256:120206a3de178a7362d9e40ab54718a6368e1c331b9dfa1c6404e66854fecb87",
+        "check_gpg": true
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libutempter-1.2.1-4.fc34.aarch64.rpm",
+        "checksum": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libuuid-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lz4-libs-1.9.3-2.fc34.aarch64.rpm",
+        "checksum": "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/memstrack-0.2.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-6.2-4.20200222.fc34.aarch64.rpm",
+        "checksum": "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm",
+        "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm",
+        "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm",
+        "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/openssl-pkcs11-0.4.11-2.fc34.aarch64.rpm",
+        "checksum": "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/os-prober-1.77-7.fc34.aarch64.rpm",
+        "checksum": "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-0.23.22-3.fc34.aarch64.rpm",
+        "checksum": "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-trust-0.23.22-3.fc34.aarch64.rpm",
+        "checksum": "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.44",
+        "release": "3.fc34.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre-8.44-3.fc34.1.aarch64.rpm",
+        "checksum": "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-10.36-4.fc34.aarch64.rpm",
+        "checksum": "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-syntax-10.36-4.fc34.noarch.rpm",
+        "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pigz-2.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/policycoreutils-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/popt-1.18-4.fc34.aarch64.rpm",
+        "checksum": "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm",
+        "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20190417",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
+        "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/readline-8.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sed-4.8-7.fc34.aarch64.rpm",
+        "checksum": "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.7",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/setup-2.13.7-3.fc34.noarch.rpm",
+        "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.34.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm",
+        "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-0.3.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-lib-0.3.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/u/util-linux-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-5.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-libs-5.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "26.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/z/zlib-1.2.11-26.fc34.aarch64.rpm",
+        "checksum": "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-libs-3.0.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm",
+        "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-8.32-30.fc34.aarch64.rpm",
+        "checksum": "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-common-8.32-30.fc34.aarch64.rpm",
+        "checksum": "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-2.9.6-27.fc34.aarch64.rpm",
+        "checksum": "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.3.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/curl-7.76.1-12.fc34.aarch64.rpm",
+        "checksum": "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc34.aarch64.rpm",
+        "checksum": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc34.noarch.rpm",
+        "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-gpg-keys-34-2.noarch.rpm",
+        "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-34-39.noarch.rpm",
+        "checksum": "sha256:3e69e8412d5914ec01c5e82264833698e92a1b88a7c7b5ed9b1f0351fc91f5d2",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-common-34-39.noarch.rpm",
+        "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-34-39.noarch.rpm",
+        "checksum": "sha256:6d1c024b295c423746b44f120cf36ceb0fd898f8ce5a276813d7c78a3c8ece52",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-34-2.noarch.rpm",
+        "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-5.39-7.fc34.aarch64.rpm",
+        "checksum": "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.aarch64.rpm",
+        "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.68.4",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.aarch64.rpm",
+        "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-common-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-doc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-doc-2.33-20.fc34.noarch.rpm",
+        "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:adb1b49ec7038eec956edd77d0ad2a72179b4f37c14548e3c9637d8a75c276a1",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/gnutls-3.7.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm",
+        "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-legacy-libs-1.8.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-libs-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/krb5-libs-1.19.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.aarch64.rpm",
+        "checksum": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "49.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm",
+        "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcrypt-1.9.3-3.fc34.aarch64.rpm",
+        "checksum": "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "37.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libibverbs-37.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libidn2-2.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpcap-1.10.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm",
+        "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
+        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsepol-3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-0.9.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-config-0.9.6-1.fc34.noarch.rpm",
+        "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "0.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtirpc-1.3.2-0.fc34.aarch64.rpm",
+        "checksum": "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc34.aarch64.rpm",
+        "checksum": "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxkbcommon-1.3.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxml2-2.9.12-4.fc34.aarch64.rpm",
+        "checksum": "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mkpasswd-5.5.10-1.fc34.aarch64.rpm",
+        "checksum": "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mpfr-4.1.0-7.fc34.aarch64.rpm",
+        "checksum": "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/nettle-3.7.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.57",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openldap-2.4.57-6.fc34.aarch64.rpm",
+        "checksum": "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssl-libs-1.1.1l-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pam-1.5.1-7.fc34.aarch64.rpm",
+        "checksum": "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "1.fc34.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/procps-ng-3.3.17-1.fc34.1.aarch64.rpm",
+        "checksum": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-setuptools-wheel-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.9.9-2.fc34.noarch.rpm",
+        "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-3.9.9-2.fc34.aarch64.rpm",
+        "checksum": "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libs-3.9.9-2.fc34.aarch64.rpm",
+        "checksum": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pip-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
+        "check_gpg": true
+      },
+      {
+        "name": "qemu-img",
+        "epoch": 2,
+        "version": "5.2.0",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.aarch64.rpm",
+        "checksum": "sha256:17fce9df2309a10bc24fb311924d9b5618a54f8f25758f594ebc80d1b581ae82",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.8.1",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.8.1-10.fc34.aarch64.rpm",
+        "checksum": "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-networkd-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-pam-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-rpm-macros",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-rpm-macros-248.9-1.fc34.noarch.rpm",
+        "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
+        "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "26.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/which-2.21-26.fc34.aarch64.rpm",
+        "checksum": "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/whois-nls-5.5.10-1.fc34.noarch.rpm",
+        "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
+        "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm",
+        "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
+        "check_gpg": true
+      }
+    ],
+    "packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/acl-2.3.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:de2fd1421e63b7311ccf9064723174b578b48ad799e9a599483506f6f0b140fa",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/a/alternatives-1.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:dde7825431c7492e768c4ceabf722e7191719d6ea57c3ce86a4e23d8ce0902cf",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/basesystem-11-11.fc34.noarch.rpm",
+        "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bash-5.1.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d526eca98c431ed01ed883048fb7878758a3716160c14785e29a486f60ad9f7a",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/b/bzip2-libs-1.0.8-6.fc34.aarch64.rpm",
+        "checksum": "sha256:81da04c950611d6a2dbbd85806d44aa2b79ef96020a6712e4f72b84b14f6ede4",
+        "check_gpg": true
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/checkpolicy-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:33b878000610ca3ba875b72f2a454e4fac9471f80579824304ca81e6f3e3f79d",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "20.4",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cloud-init-20.4-2.fc34.noarch.rpm",
+        "checksum": "sha256:e7d1d0b85ac49d8b0c9dd3fce4613e6229ac8720cfb74c80a496b9f0beaa7a22",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-utils-growpart",
+        "epoch": 0,
+        "version": "0.31",
+        "release": "8.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cloud-utils-growpart-0.31-8.fc34.noarch.rpm",
+        "checksum": "sha256:6d1b95e06ec98f6d65c64e18fec693d379b98128a3e94b4dec8929321354c549",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-0.21.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:1877af369228dd661ae1adfc43bbb8d53d3464d59ead0f5bcf6c2be88f8e8685",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-issuegen",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-issuegen-0.21.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:3f7bde703045c2651fbd4142131ea1e303a565269388a08e2312af0eb83307a4",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-motdgen",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-motdgen-0.21.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:d2bac91a1969f555ea2641b161bb23fa0aaaffaba3284d9973ad696594b73f18",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-profile",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/console-login-helper-messages-profile-0.21.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:424f73b97c7d7541d35685108bdcddb03100cd0f3d6e0fd9def576462ca65b59",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cpio-2.13-10.fc34.aarch64.rpm",
+        "checksum": "sha256:b8dd105be883f9c905f174375454be3e48e69c58009bbd178b058b3cb4c5f51d",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/c/cyrus-sasl-lib-2.1.27-8.fc34.aarch64.rpm",
+        "checksum": "sha256:09c2b04aaa6ca7a843c2dcc843109d0f5517e576f323174ed66c07a8e8003db6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-1.12.20-3.fc34.aarch64.rpm",
+        "checksum": "sha256:4de42f31385a3fbde6fe5b2111b98bddc82132e5129a8b4dffcebb6e6508aa0f",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-common-1.12.20-3.fc34.noarch.rpm",
+        "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.aarch64.rpm",
+        "checksum": "sha256:9fedd5ff21a2343385413ca1223245cba6ac7095f8c7e0f0199b894fedb39ecb",
+        "check_gpg": true
+      },
+      {
+        "name": "dejavu-sans-fonts",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "16.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/dejavu-sans-fonts-2.37-16.fc34.noarch.rpm",
+        "checksum": "sha256:79834af7f95c0d1e5dcf85b794819bd854197a52d2966594abdb3c3de0fcceb6",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.aarch64.rpm",
+        "checksum": "sha256:e9bf9ef9b5f246dfabf88be8f30dd6035f289bf94da51757f23949a9f8b8cd71",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-1.02.175-1.fc34.aarch64.rpm",
+        "checksum": "sha256:ecee09501ff356074d527796c51f78e00e03a473d4b2fdc41c80f17e61110c7c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/device-mapper-libs-1.02.175-1.fc34.aarch64.rpm",
+        "checksum": "sha256:86f1b151d96aec200eac6e5adff2642cd39066657f47a4a1897ffa5624c248e7",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:9fb2f80cae183c988781cc298cc8414b1cb4a79affc99ae32e0db63242c08fb2",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:3886bb4c2cfad25ceaf8665461d8dce8ff4ba8912c30e906ab45581a483581fd",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:8a455888a649549019171c255f523f1c03cf5d2276dad976b341b8cfd5d850da",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/efibootmgr-16-10.fc34.aarch64.rpm",
+        "checksum": "sha256:0f9ebdf7f08a506a8d1d6c4b4788dd7ca3dbb832509072b66def4da5b86d7862",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "37",
+        "release": "15.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/e/efivar-libs-37-15.fc34.aarch64.rpm",
+        "checksum": "sha256:a0f1b653f889bb95e6edec2c525dfc71e280076b29394cf9c06ffa81ecd8b9fa",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/filesystem-3.14-5.fc34.aarch64.rpm",
+        "checksum": "sha256:7ed82506675d48df06697382270f2a275babb483fefd1af9e5ea239475c695cf",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/findutils-4.8.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:8162e62c0cfaf5f3909668a04c7fb3e0e4b77718975c5cc3ce308f9f5c6b1501",
+        "check_gpg": true
+      },
+      {
+        "name": "fonts-filesystem",
+        "epoch": 1,
+        "version": "2.0.5",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fonts-filesystem-2.0.5-5.fc34.noarch.rpm",
+        "checksum": "sha256:3fb05067cbd7fcf3283f2ab306c2dae668d818d3a69422e729c2ef62974810a5",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "11.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/f/fuse-libs-2.9.9-11.fc34.aarch64.rpm",
+        "checksum": "sha256:70195fc833b761ca0449f6c1b64667dbf5d11e797e402eddbbd8caa246b6b71a",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:3b833739d4b4dbac50bc492c6dd905c02dbda9d7d3cb62b705d686ec97c6bba1",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gawk-all-langpacks-5.1.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:2935062f20923e64a27ca9bc4ea69aef3c4cf22426fde18b1a3511b8d57cacae",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.19",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gdbm-libs-1.19-2.fc34.aarch64.rpm",
+        "checksum": "sha256:50fba3883822792d7430b26f9baafb3f5d65a745a392b2c972dfb1c45b2c3d06",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3ccee45582ccd0a162de4674bda2df363e0d068f9a9695f83175803b5c342358",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gettext-libs-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:9e590ddc8fd92f8aca24ba95eb38aa44c0df2f65d312f38e42f925af5ac36915",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gmp-6.2.0-6.fc34.aarch64.rpm",
+        "checksum": "sha256:96434229099cdf1d1e73f2ee9a0596b8a29a1563c2d0c3956df3a86c17dd1bf9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.aarch64.rpm",
+        "checksum": "sha256:b52a0d9f34fab5cd0ba400c7a0956b57eb6dbbd2e4b70700e0411c17b77be04f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3751d457fcb143a45a003d24e04a7c447144be416a17c00d636859adf925ff0e",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b34c3ff7179ee802674cce38970555b667d9e2e2265e399e2adca519589e5692",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grep-3.6-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3af9d31974f009f055de3e9ae357c2b4c26c2c4ed097948f72a5d5c9624d0047",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/groff-base-1.22.4-7.fc34.aarch64.rpm",
+        "checksum": "sha256:37cda2c179e4311a1aeeb0ea8d07d3eacc8ea8bf97d122ec22cd596c61b8e770",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "51.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/grubby-8.40-51.fc34.aarch64.rpm",
+        "checksum": "sha256:f20c8e0cfcae827d54dd2056ef2dde37b8234a51db919862909bf2a820ff083f",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.aarch64.rpm",
+        "checksum": "sha256:b1bc4e9a6afd9082aa46c7dab6d43d7eaaa8aa697fbdf0f85e3f16607949f05b",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/h/hostname-3.23-4.fc34.aarch64.rpm",
+        "checksum": "sha256:47c92a952b162b7bafbe49a7e409a7a81825adc77b3e139651913d52d8aa84fb",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:14cb3ce57874d272aa4a813c70f0817bdfbfdc0dc26f86219fe11d9a58d0bbed",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "49",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/inih-49-3.fc34.aarch64.rpm",
+        "checksum": "sha256:6d3301f6e99d9728698822e81fc2d170694cc367b7e7fea5c7a019f7b1a6073b",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.09",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/initscripts-10.09-1.fc34.aarch64.rpm",
+        "checksum": "sha256:eab8d30db6004f8c21247689cac52f143e1bde1da817db9761420cf3cf855c38",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.10.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iproute-5.10.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e1e89027213f00ae1014bbb1253058ed8d5d476e7246921f03736ea129d2a162",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute-tc",
+        "epoch": 0,
+        "version": "5.10.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iproute-tc-5.10.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:bfd008fce37b2ec17dc4142c38a6e808c2e0031eed802a0253fca812989845d1",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20210202",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/i/iputils-20210202-2.fc34.aarch64.rpm",
+        "checksum": "sha256:4b65dc9856b0d0ce555dd9bce88dcfb680ba689a2c6b88ae9f84b016553d96af",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/jansson-2.13.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:9f2f2a20f285a2ac306ce72475beecf967cf92308b426aafca68215a6c3c12ca",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.14",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/j/json-c-0.14-8.fc34.aarch64.rpm",
+        "checksum": "sha256:ddc2a34de1fab989fe919f813f90b473a1cb0facbb42d675d0754ee6117aad19",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:349866fe8aad6229041a6c5f7687e727c22dcb7c5f6680fc580afbe4102dfc70",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kbd-misc-2.4.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/keyutils-libs-1.6.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3cb584a519b977447fd2aa70888442b919ae122d9d06423db5919d1359102fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.5",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.aarch64.rpm",
+        "checksum": "sha256:3aef567862f9223ebd3cb810e10a477ee54cb4efb063b9730b90f91474d09d7b",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-core-en-3.0-14.fc34.noarch.rpm",
+        "checksum": "sha256:c20caffb4d2a500416dab0e8418a24ae5e25c02c831ae02ee10f97a0dcc80374",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-font-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-core-font-en-3.0-14.fc34.noarch.rpm",
+        "checksum": "sha256:82cbc5e0339e832d2fc0160541c30f3dee59b3d28d83907ae7b55e22d5092c51",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/langpacks-en-3.0-14.fc34.noarch.rpm",
+        "checksum": "sha256:82b51ca6bec551d74a6d8c43194b0fd4e8bfdf19d1d68b58c1787723edd88bd0",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:736c27ad225f4ea3bb414a9319eafc65d1ba8027552272b16cffcfdb3f1d104c",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.aarch64.rpm",
+        "checksum": "sha256:cc2a6c0297288b79259c96e6a7da5472eade3b7338fc45cd51758cb8e9569e24",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f05ea9854639fbfd1ffcdb3a8479d3b2feb2b32ac43045ae9d74041215d68e81",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libattr-2.5.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b72f2d5646b6db4fd9ad5a1331e0cd8aeaa2212caa54033bc60e52bd9184d180",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbasicobjects-0.1.1-47.fc34.aarch64.rpm",
+        "checksum": "sha256:12b7666d61e7bd8b3b5b1a7c57539964531802287e592e33449e039799ea2071",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libblkid-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:10f28e1bda7fd453de627d12382e0658035ebec6413280e319518bd850f9c092",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libbrotli-1.0.9-4.fc34.aarch64.rpm",
+        "checksum": "sha256:644ead91154bbe9edf8374abe53c627596c5f60ffd4c836020a2d7223024b80e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-2.48-2.fc34.aarch64.rpm",
+        "checksum": "sha256:c7f6ae2d9f759a14e92fa2cddf497aa5d2e7c836685ec3da0b293c2774a8501c",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcap-ng-0.8.2-4.fc34.aarch64.rpm",
+        "checksum": "sha256:127d83d2158b70d294dbd8e9eb7f62ed9bd086db2efe07186ef1582d71b5be16",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcbor-0.7.0-3.fc34.aarch64.rpm",
+        "checksum": "sha256:6046f881a5c0822c30bd037aec040c65594b6328b1c0d72b6681fe1575eac765",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcollection-0.7.0-47.fc34.aarch64.rpm",
+        "checksum": "sha256:cf18d61c8f526fe86cd24073dfdce942b6a463ea909ed5a59a5cc4378d9101a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:5826d5e13f3623f0991082ff2010f92b6d0273170c0241d2bf20fe4815c19050",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libdhash-0.5.0-47.fc34.aarch64.rpm",
+        "checksum": "sha256:e9814c1b1a22b8cbd39413dc4f0eab452ef7380ce01f05ecab0e41e2d00ba3c0",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.aarch64.rpm",
+        "checksum": "sha256:c9c3482b0f664cd8e5bcc4c92a545130e3cd52166b01d60733032c2d84839709",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfdisk-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:fa5b9be314438aff0293aa05debbf5afd25ae73f1a1196d773d8cf9db61add02",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "28.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.aarch64.rpm",
+        "checksum": "sha256:1dc9ae7ed75ea292106687b418d93a9a89eb3f6e3b2fc603919af3d36c97e75c",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libfido2-1.6.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:1014763656c1578ae96b38fd3e87c4d07b548cb8423688cc928d0f9762d43a44",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.42",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libgpg-error-1.42-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b1cafb76fcd40565d11628facff701b513f81b6f028291be31aa918b75543f7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libini_config-1.3.1-47.fc34.aarch64.rpm",
+        "checksum": "sha256:45d38ed1d2247e17e3e8faf7d6755216c5ef4422736129f55b712f160532d8f2",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-1.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b91f376e77ff3a15a0233e02bfe6b4966dbfda572e7f958325065b3265165f01",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:97800bca88780757038c2582cf07736ffd3721b658697648a7f0406bc42d3670",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e39aea4454a63051d0a199632f7e08c0a4e04fa8eadbd1a758c752a65979a221",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmaxminddb-1.5.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bb078ccf6e7372cf22e55901c005517daff0b8cffa14fa3dec5e9804b4f65897",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "13.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmnl-1.0.4-13.fc34.aarch64.rpm",
+        "checksum": "sha256:79864051052858a1c95538888ca61a43b509b6eae4ae269ae6ea7bf8b076a2b8",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:95ddcb4d22680b00dd042d6287c8ecbccaa5cc51d2d373088b15f999d92b2d35",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.7",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libndp-1.7-7.fc34.aarch64.rpm",
+        "checksum": "sha256:11a0c09b716f8071f0484278bec326fb82e93d987376c8b38188d1febcd5381d",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnetfilter_conntrack-1.0.8-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ca8f4843c8b23ce16b957143550d8dc83ae630cd64587fa2dd127e4ecbe9bb23",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "19.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnfnetlink-1.0.1-19.fc34.aarch64.rpm",
+        "checksum": "sha256:c04a67670d45f576c5a8b23fe64d5ce31b04ddf4792cbf78448fd4c96899f9c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.43.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnghttp2-1.43.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:73f4d07c4e8214d65df507a8db08d42c595b8e2deaa73161a419b71214216bc8",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnl3-3.5.0-6.fc34.aarch64.rpm",
+        "checksum": "sha256:4842fe2d403da0f6ddbff813ec187608c5f275c509e1148f26801191571702de",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libnsl2-1.3.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:acbeb0c719fbfd9d4127be183ec58a867f282ffe98f26f1cd36e4fcf1341709b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpath_utils-0.2.1-47.fc34.aarch64.rpm",
+        "checksum": "sha256:a1a996e8da4733b14c449b69e34484fe4f2b88c0f2963145bf0402cf04baf30e",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpipeline-1.5.3-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ee147f5a7017de1c77abfbb79dd32eb97c923fc7c1b74c32bda6020b9025938c",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libpsl-0.21.1-3.fc34.aarch64.rpm",
+        "checksum": "sha256:2544eb6c238c5dd8e753a378a59260f5d1209ae6f0cf4e47780a5d69972cdc5b",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "47.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libref_array-0.1.5-47.fc34.aarch64.rpm",
+        "checksum": "sha256:686e015d81c1be2e6b88c7e8a50d45109d7273143a034caa9c935ecd014e1c62",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.aarch64.rpm",
+        "checksum": "sha256:09754ab556afb5bfa33891ac629ce295c639bf3fd0042d866ea1f9f455a6cd84",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:029c904ab27495f37f2da92f901312c486f97dd86c9f8df3d2a4ec1a6b225c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11fea790c5e62176df8f4f6c3ec3f2e0664e345a3f7c72979d522bb95ee3d5c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsemanage-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4806ee0cc42fc0f474f7743eef967bb1bd66d68727d7075dfe9fe0b6f6985506",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsigsegv-2.13-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ce907b4e2490686a4523c1df75ae7d40b1d5789b8fa55f5da1df53d0c207ef58",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c3d123b9fa3077ed1180f3fa0731b30264c71f9fe265a55378a3429dd66876b8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.17",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.aarch64.rpm",
+        "checksum": "sha256:ad45a94e624290d513c48f2e9216a536a39e7299266c5317016d3f9722c3d251",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.aarch64.rpm",
+        "checksum": "sha256:cd96decf3855b7cfc243d282e76dbb81ba467fe2912623fb47edf6181245e54e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtalloc-2.3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:56634e58fc7499d719a3f431dd188e8f2655ebfa402e94ce105794a47debf45b",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtasn1-4.16.0-4.fc34.aarch64.rpm",
+        "checksum": "sha256:755537a142983a64e77b9625cdf0811aec9735f087b54fe09f65adfde3ccb736",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.3",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtdb-1.4.3-6.fc34.aarch64.rpm",
+        "checksum": "sha256:2027da420b35a0b70ae5045d2fd79cdccb820f03e5ff4018a2205d3d413ff1af",
+        "check_gpg": true
+      },
+      {
+        "name": "libtextstyle",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libtextstyle-0.21-4.fc34.aarch64.rpm",
+        "checksum": "sha256:71c2e227ee09681e3f70108e29d314b5e565b6f33ca6f2460219b15a418980e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.aarch64.rpm",
+        "checksum": "sha256:b85fe67b8aee772469e8257bfa5488ded6ce9ab05ba47b23fb3b26e26235fd8a",
+        "check_gpg": true
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b98cdd810f0174ef5440a65ae19d7c0104f1e7a341da50906a150f01acf7e66d",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libutempter-1.2.1-4.fc34.aarch64.rpm",
+        "checksum": "sha256:e62f9682b8aae33fd26505889123f9c9e015a7ef50fdd57613b53bd4dbf3c095",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libuuid-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11f26bb81b542e6ab63f1cf106340dc0a865376afce4da797529709aa0c845cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:079910323f2c5e5b29ede76df068ec26f4bc5b887ffd7a992bbdcd499a050f69",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:6d5c91a42ffa2b094fa2492491ca425ebeb4aa3e6fc93feae17d6d6119dc3235",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-atm-libs",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "28.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/linux-atm-libs-2.5.1-28.fc34.aarch64.rpm",
+        "checksum": "sha256:a60e3e035883de829c5778417d316ffc47a0b4a304953e3fdc44def8f2f172ab",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lmdb-libs-0.9.29-1.fc34.aarch64.rpm",
+        "checksum": "sha256:7721bc647c521d96e07e665f7da306326d3bd1499d610c58552317815aaf3c45",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/l/lz4-libs-1.9.3-2.fc34.aarch64.rpm",
+        "checksum": "sha256:fc6f4af16cdeb886f47551776232a271e51c5beada34b41cd1a6b4cf27e5e796",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.9.3",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/man-db-2.9.3-3.fc34.aarch64.rpm",
+        "checksum": "sha256:61ba1ecff8f8578cbd3445df596d001067bb0281745191ac168fcc6079d8e1cf",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/memstrack-0.2.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cfcd409a124dfe9725bffd40fbad3da12d3035f38dc35b2cfcfa70189ca3f88d",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.4.0",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/m/mokutil-0.4.0-4.fc34.aarch64.rpm",
+        "checksum": "sha256:f7c7dc1d8e5cf4776a1fde155871a2bb1fdd0676f897a43334cfbb60eb69e52a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-6.2-4.20200222.fc34.aarch64.rpm",
+        "checksum": "sha256:337b323f056294d726deaecafe0e3d2a983b807cbd715d7156184e0fa0c4fd1a",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm",
+        "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.aarch64.rpm",
+        "checksum": "sha256:0ff2f2dde525d037f437115ec55005be06e1758a40c6622df26b3297a1a747d2",
+        "check_gpg": true
+      },
+      {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.59.20160912git.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/net-tools-2.0-0.59.20160912git.fc34.aarch64.rpm",
+        "checksum": "sha256:96c7a26b707d4038a50b4ab0fd8d79ba3997466bed543f13c10d30e7ec256b5e",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/n/npth-1.6-6.fc34.aarch64.rpm",
+        "checksum": "sha256:46193b02a55ce72bd14d8c4eb217b9b7a8bbed070c5872a19cb4febba305bf39",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/openssl-pkcs11-0.4.11-2.fc34.aarch64.rpm",
+        "checksum": "sha256:999966166e030f0685cb62f15ca381205d6138b9ef3849b53223d0da136a3783",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/o/os-prober-1.77-7.fc34.aarch64.rpm",
+        "checksum": "sha256:b1d5db37110417f26145ce3facada2b0a0441721a071de725daf4677f1b78350",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-0.23.22-3.fc34.aarch64.rpm",
+        "checksum": "sha256:63943bbef4e23cf08721be7acce1bcf1efbe45ef7c76ef51dad747a5cc243c72",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/p11-kit-trust-0.23.22-3.fc34.aarch64.rpm",
+        "checksum": "sha256:68807949e4eeb22eb384bc91e461bc8d911ce291a79b6a3ebd4be19acea61777",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/parted-3.4-2.fc34.aarch64.rpm",
+        "checksum": "sha256:27920113489e3260e58d4a033d31401c6ae22ded72895c6b8c0e43ebf89a62df",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/passwd-0.80-10.fc34.aarch64.rpm",
+        "checksum": "sha256:6a864bec34b7d39de3e6ae1e39ec07fa3a2d21837a9a2d7151228d7f0ac38e73",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.44",
+        "release": "3.fc34.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre-8.44-3.fc34.1.aarch64.rpm",
+        "checksum": "sha256:8f1c3aa57aa2dc98417c89c0ec4b31ccf4ad2678647b7eb817ae8c2e63452e2c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-10.36-4.fc34.aarch64.rpm",
+        "checksum": "sha256:c93635b4c74058a38ab8061f4fda9d8a3ba427eaf1f019277fa3812d87a5c3ab",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pcre2-syntax-10.36-4.fc34.noarch.rpm",
+        "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/pigz-2.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d163bb5a5326cd6e2222a120ce37afe3819761c65f9d672fbcce7e507ab0ba8f",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/policycoreutils-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b0c474592ddef52cbcdb604f9384d0822c34906bd3dfc7f05fd92ef4130b3c86",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/popt-1.18-4.fc34.aarch64.rpm",
+        "checksum": "sha256:61749f8ee34bd9e23f34b5e8baa84c2ae999ef96fd5f51857e5e9a72b43b3e63",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.aarch64.rpm",
+        "checksum": "sha256:96d94210aa3e6c72dc8e7239f893f30ddf708565f24a3a3ec6aaa4f7a8d0642c",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/psmisc-23.4-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d1c8a2302e64fc856aff6a05a78140986e89eddd8f110deb9ba78d44aebcd411",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20190417",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
+        "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-attrs",
+        "epoch": 0,
+        "version": "20.3.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-attrs-20.3.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:820fee96d610178c7c7b8ce2b115bd02063d2f6dfcae5da4bf5d411de0b575f7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cffi",
+        "epoch": 0,
+        "version": "1.14.5",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-cffi-1.14.5-1.fc34.aarch64.rpm",
+        "checksum": "sha256:7d00ccbb224617a00f58053afd88e7a49062446f1306ba39c72b78d20aeee1ef",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-chardet-4.0.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:9ce3f0c0904ac22ab5769babebf43e7dcdb488b0ef999b2e9e88a5b5eb424e51",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-configobj",
+        "epoch": 0,
+        "version": "5.0.6",
+        "release": "23.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-configobj-5.0.6-23.fc34.noarch.rpm",
+        "checksum": "sha256:f7f8832ccaedd7ddad064956309478b9bf366f0576517356ee68481e196236cf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cryptography",
+        "epoch": 0,
+        "version": "3.4.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-cryptography-3.4.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:ea8067f2310d30b31f7b1f13825b2a5a5e679c114fefd072267b6c369a365a63",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-dateutil-2.8.1-3.fc34.noarch.rpm",
+        "checksum": "sha256:5d2c28837f0573ae2647b8fbba85f7c502f9c3da0a3eab1c9ba121de4a1a6cee",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-distro-1.5.0-5.fc34.noarch.rpm",
+        "checksum": "sha256:e530795e5c9bc27de609fcbbacdc43c226026fee95e47a1f783f1c03ba5d48ae",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:61a56c674cacb699d045edc0de0d10de0c745400ef7f9109239203ee28a761c3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-idna-2.10-3.fc34.noarch.rpm",
+        "checksum": "sha256:f68c93c0461c149bb17282dededf421cbc1fbfa5ac133b59bd362526f59e0d57",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jinja2",
+        "epoch": 0,
+        "version": "2.11.3",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jinja2-2.11.3-1.fc34.noarch.rpm",
+        "checksum": "sha256:2414cb7345bc193f7ff7983c020c8b0e706aab013ee30af5d457d35c4de4a698",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpatch",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonpatch-1.21-14.fc34.noarch.rpm",
+        "checksum": "sha256:e0dffa204780c20c16357a51b992351aa1cf9f9cdda6182939ecd0cd7ab2c2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpointer",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonpointer-2.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:1b1af6b54050ec223c3289b107a9695a686c9d46d17a80ec9cd5d0201ec5d544",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonschema",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jsonschema-3.2.0-9.fc34.noarch.rpm",
+        "checksum": "sha256:d6810c97f24d93cd54a61bb288ada8591a94e4083b5165e0719915bceb637504",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt+crypto",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jwt+crypto-1.7.1-11.fc34.noarch.rpm",
+        "checksum": "sha256:9cc240ac305a862146e85d8dcc4ad981f5233a58b6901ecfac691d0b39966b49",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-jwt-1.7.1-11.fc34.noarch.rpm",
+        "checksum": "sha256:131adc47f044c9f600f5295ded0f5431cda57fa7276100c3ec81c9d1ce3fa6f7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libselinux",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-libselinux-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:dbf3fb9e356236575a06e4fdcd532331f418236aa4ff4e024260c24be2b9a7cf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-libsemanage-3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:87749765dbe5ce8f098279170c39bb8a89abbf3f8430c2a6dbfb973117e11dfa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-markupsafe-1.1.1-10.fc34.aarch64.rpm",
+        "checksum": "sha256:fbf45cda87a05418a72f4bf3877da5ebcabbe68d393bc5bec007a8b01ef6bafe",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib+signedtoken",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-oauthlib+signedtoken-3.0.2-9.fc34.noarch.rpm",
+        "checksum": "sha256:b30db4e3d9605e7263387ff91f91508667693d28e8b8835a2b7fcefd64f24388",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-oauthlib-3.0.2-9.fc34.noarch.rpm",
+        "checksum": "sha256:f9b2e7232d0b2d33bf52993c31b43b31520601f52f44fe792acd6dee4d84afc8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ply",
+        "epoch": 0,
+        "version": "3.11",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-ply-3.11-11.fc34.noarch.rpm",
+        "checksum": "sha256:23e3ed871799a9209915359f71660babf451b0b44902e3ed488b7b22aff37718",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-policycoreutils-3.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:e76f1401d9e119eae4cc461c8b68e9eae075d4b69f61870cb5c19ba7d69cf1a3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "25.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-prettytable-0.7.2-25.fc34.noarch.rpm",
+        "checksum": "sha256:cc4401d1e292b28d771a2038081b929b342ffa3b60358aed91697fdbc668546a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pycparser",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pycparser-2.20-3.fc34.noarch.rpm",
+        "checksum": "sha256:32220dc513a6ebcd4994e7140ecb5859108baf44d12fe6b1f0c0459dbefc54e7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyserial",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "10.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pyserial-3.4-10.fc34.noarch.rpm",
+        "checksum": "sha256:70a90c6c682016e91fb4745eedbd23f28e150a38b01d18f85ce4e50fb4e0ca6c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "8.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pysocks-1.7.1-8.fc34.noarch.rpm",
+        "checksum": "sha256:4a74ae08a713e9b4e74ff27bfaf57374312370402f90e2796e66c504557ae189",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-pyyaml-5.4.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:92e42b63fcc56dd21984abb722e8fa7ebbb58f6d54c529ac11871b4bbc63b290",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-requests-2.25.1-1.fc34.noarch.rpm",
+        "checksum": "sha256:6297d7eee103c679a0f1ea411568d3940af3fe8f38e19388a1544df70bda8b3c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c53d595cca70c09d051f39fb0fec0e3ea075578a2a136f889bf60643c2527ec8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.4.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-setools-4.4.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:e1f1b9c4b78fe9d84a87d7de67fdd8559fe2bea9969ca1632d137de635d7e898",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/p/python3-six-1.15.0-5.fc34.noarch.rpm",
+        "checksum": "sha256:b5d5e7255c85c3aa9d63598ef140de35843ab2485adf1cb9a9130be80aa0297f",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/readline-8.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d7663f3f8c0020c94842980997414bd0d8f11349590c57d07c095abbf200060b",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "29.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rootfiles-8.1-29.fc34.noarch.rpm",
+        "checksum": "sha256:164e1c0e3e8c89aeda4f272b3158932649a69b16aea058105117a64d3cdef517",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4a938ee7d2e4186206d827bdb479e77a4f424381afba966969134950d956861e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:346fd5ecd1abaf11ccece4f60f4c28e01dbdb3d6146c81c7b3cb306a6e40dc35",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:64ad2dd81ff87ca9768c7b52e5dfaaff3725a555d0067b4f1ce6b9e3c9d33ae7",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:318505947abefdc9984295fee08b4fc443ae55a2ab660037f426ee9b63eef5f3",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d530a51997c3f1e19681dec4617140ba6bc02457e6dd5a50ce3f18321edf80c5",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:133e184c93710dd935e0cbaa9fbdc42010407e0f1cb0d9331b152b414f149f27",
+        "check_gpg": true
+      },
+      {
+        "name": "rsync",
+        "epoch": 0,
+        "version": "3.2.3",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/r/rsync-3.2.3-5.fc34.aarch64.rpm",
+        "checksum": "sha256:a9828dc2c4215e6bcb9aa14370d854f24637b0510e4b1a63709135049314e2b3",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sed-4.8-7.fc34.aarch64.rpm",
+        "checksum": "sha256:39ccd72b9b4d7b34354c2dba54a6289657b8537686d2634629e6e297eb86a249",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.7",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/setup-2.13.7-3.fc34.noarch.rpm",
+        "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:739b63ca3df163f473cfdb9274debe3176c5cf3a190bc54c6126cfdae22d5e62",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.4",
+        "release": "4",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/shim-aa64-15.4-4.aarch64.rpm",
+        "checksum": "sha256:23a539a271c92906ac0a12c7d877c7f4d0ad8e6b9bbd8642b5232f861b79ed22",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.34.1",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.aarch64.rpm",
+        "checksum": "sha256:f690ad2c14282fcb5deebf239dd1f55240cb5ced9471ed900a10a1ef46cc5b3d",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.5p2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-1.9.5p2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:40e231991444a589b17e0b5b338be8874d071e3d17e210aba6f6639620775f79",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.5p2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/s/sudo-python-plugin-1.9.5p2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:a86ec8f7284ee01574bb06bba726d8609e464f41d003215097e626c583f73ed0",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/tar-1.34-1.fc34.aarch64.rpm",
+        "checksum": "sha256:91014381674db9bec0b8344f6ceccc1e6ce29f4309853a2b4fe03f3fcd60bcc8",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-0.3.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:e42d8de952be0c83d441ece7c1ec56a5b6e3e82f3971e49a43a50bf53033f267",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/t/trousers-lib-0.3.15-2.fc34.aarch64.rpm",
+        "checksum": "sha256:b5cb16d2f2fc576193289c19962decedeeea9f9e8126ff89aebeb46b394df120",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/u/util-linux-2.36.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:acb40f5859f50876a7243abcb3825d2ac75c44fc04b77eb53fe8525873e57e21",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.10.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xfsprogs-5.10.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3228a36807658c7e4d881013aa26f877353388bf3bac6c948984f751c264a359",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-5.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:997436d321aefe304388f25f7694516d0e6d36a456c6028af94056a41721a7ca",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/x/xz-libs-5.2.5-5.fc34.aarch64.rpm",
+        "checksum": "sha256:b2f446c7e91c724a30eb22d6541907627b60ce6f4f840b8ade4cac791fd8e51c",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "26.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512/Packages/z/zlib-1.2.11-26.fc34.aarch64.rpm",
+        "checksum": "sha256:7e0dd8cb56ff363ba9fde9771c1e65955fe1d5931a59a57a0d9d2b90a348b8da",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.30.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.30.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:4baf8ba6a5ed4609695f79a8bbc8324d7efa322a3573c8c5fa3942361eac0f1c",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.30.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.30.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f695ed244a1d9f3eb814947fb1da343d7d6fb3aaa2bf72965235e4b45a58a784",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-3.0.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:148aea26e381b33badde0ac2ae716a78f7b565f54f0b6970189a89713f335eaf",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/a/audit-libs-3.0.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d8c9a6cd9b95282207048b833f2117f1b7e7bd9ef2225f9da6666aee5ac66ed0",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/c-ares-1.17.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:7c24e53e12891046bb6721e624cf9effd1946c0d076464427c2a86b29671318e",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm",
+        "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+        "check_gpg": true
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/chrony-4.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:61a9dbd9020e29012947978acf33a0c1150e6c3e078de372f1e38fb9c4ef529a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-8.32-30.fc34.aarch64.rpm",
+        "checksum": "sha256:2f4f6d46c61b1a1d8ab21402dd2389c4e6f0fa8ba93d055b1cd8475420a39af6",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/coreutils-common-8.32-30.fc34.aarch64.rpm",
+        "checksum": "sha256:82f857cc9804185d4d5209f5bd8a1a26f168d0f5805d1f9b00a3b99392c81228",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-2.9.6-27.fc34.aarch64.rpm",
+        "checksum": "sha256:4f09bb25c6abce235a16a03a60651db8b5b935549e0b5a85abb14c308142e82e",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cracklib-dicts-2.9.6-27.fc34.aarch64.rpm",
+        "checksum": "sha256:2968703dd232a37620a0ae12146c9d1ec5220f62c40bfb0ecfc60b621d8e1eac",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.3.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d5f8cfe338c0af6182269ff2e6a6e97e3e8a229b14c36458c3969889e7abfc6a",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/c/curl-7.76.1-12.fc34.aarch64.rpm",
+        "checksum": "sha256:4f7717e61e79eafd828d97c4a098b293c49364f18414c1baae18a17880f37924",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:403aad57974b80c82a56d8ee11f270252e78fef498b6b467a9ad979b390eb331",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "11.b1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dhcp-client-4.4.2-11.b1.fc34.aarch64.rpm",
+        "checksum": "sha256:0ac62147585be2dae960ed37a3a0c3eb2f8a95d0fd0993991c8bf7238b1d5e27",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "11.b1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dhcp-common-4.4.2-11.b1.fc34.noarch.rpm",
+        "checksum": "sha256:11cd6fae157eb9e4800163633b57bcce21d59a1df4b86a99ba03707b6cee0cfc",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc34.noarch.rpm",
+        "checksum": "sha256:1feb6a045cb3e95e3c8e0112ecb4b8ffeb9986a503b52c5497fefce217846b90",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc34.aarch64.rpm",
+        "checksum": "sha256:9243ecf98ce2285b77849f101ede9314d07601cc169898fa449bd146cebb5a53",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc34.aarch64.rpm",
+        "checksum": "sha256:9aee2549d3ff9e5652dffaaa9b91ab7a243687cc2a85b8e45f4290d53d44702d",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/efi-filesystem-5-4.fc34.noarch.rpm",
+        "checksum": "sha256:8fbfbaf3b107b540428634c19c4cb05e7c46f9672cfbf14d1f44306ed3413a46",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:588d380c2dcbaa0983a8ec9da3fe3f1f937a1598028f9571236aca7e04f2892e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc34.noarch.rpm",
+        "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:04f711daa1ffdd2cb94141ae493758fc22fc45c13230db4c437146418cf77394",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c71b583ea926cf5d6abed9329d48c445353f8189a9584e29ce58b15caffb9cff",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bc56e1e0849059e436ee8d272dd1402563a25ad74429d2c9f3f325d83b0dcd73",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-gpg-keys-34-2.noarch.rpm",
+        "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-cloud",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-cloud-34-39.noarch.rpm",
+        "checksum": "sha256:d54b628e6d0b7813ec0b4cc0beb1b8f3f8510ffbaff8ae1d9c4b9993095e4edf",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-common-34-39.noarch.rpm",
+        "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-cloud",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-cloud-34-39.noarch.rpm",
+        "checksum": "sha256:e035a5041c721ea40e47cbbc19eb1b91c520183f85137ee1dd3ed3b42a47c180",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-34-2.noarch.rpm",
+        "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/fedora-repos-modular-34-2.noarch.rpm",
+        "checksum": "sha256:eb88e660b9fd02e695a90c0266831b79e513c2f65ba5d6353e82726af96e9752",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-5.39-7.fc34.aarch64.rpm",
+        "checksum": "sha256:f043c06c0f3f8813721a88a91d6ed77d3ed8a5adb3c2e227f551b2c4efe216bb",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.aarch64.rpm",
+        "checksum": "sha256:43238383fc8e55c3fb7889dcea7deb68f591a10103140a6589cf8c9502443470",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.68.4",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.aarch64.rpm",
+        "checksum": "sha256:20263391301ab008d6f15098b94c4c6fe7bfb10b612b667727c3e451b5baea9b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:ab1481a0f0f628ca4d20dc43b9d6eac16f7e62f104b933a70b042e943ef779ea",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-common-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:0db4726a87efd9adc3b5528568405d51c1685a7345b17669bd9fc9776778159f",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-doc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-doc-2.33-20.fc34.noarch.rpm",
+        "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-langpack-en",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.33-20.fc34.aarch64.rpm",
+        "checksum": "sha256:059f825547fe257247656c29049ebc7bfa1d54a17479f3dcfeff37fbab7084bd",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/gnutls-3.7.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:5438e867e2851e48a5051814494494959417e597b99c5cbba2500547ee4c5770",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm",
+        "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:71427f6f8f3f6370dccde81a76d566ff17144e7e375381ef13e04a661e63cba1",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:d8dc81a96a05dde1751a4441fa7b5d57c8f871e78a7724006bb8bd23fce50b7a",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-9.fc34.aarch64.rpm",
+        "checksum": "sha256:03d70272e7ff5e232fe7fab2f88a5c33005b113a56e2d3e2dfb53aaf238d8013",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/ipcalc-1.0.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:69de3dd68dc2b76e2a85c710a51e9c8acefe595d6ac5d9f19113c4062a5f0d92",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-legacy-libs-1.8.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:0360693d0f475867a573f459e237953b4cd44e6c069f40a4b0f2aceb3fb3f2c0",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "8.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/i/iptables-libs-1.8.7-8.fc34.aarch64.rpm",
+        "checksum": "sha256:ebd4a9473543a5ca50ec5f9de069fc0c240527516ae262cf3e28a5d914b99cb1",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "100.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-100.fc34.aarch64.rpm",
+        "checksum": "sha256:55833f669ed1dbd32e79f494824c309b71bc373d2bf28eb5cdb663459dc6f7cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "100.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-100.fc34.aarch64.rpm",
+        "checksum": "sha256:0176b42c6b51fb3c829f168571527a3559b6a9c8cc5f847b70e3c40fb69f89e4",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "100.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-100.fc34.aarch64.rpm",
+        "checksum": "sha256:f3c940f33c6c8edb73b98527e0fff17aa211e823f06e3f732762d0c86cc0268c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:83614a96fc04ebbdfe77a79aab416b7141730d86b6b1669cbb6fe8e1ba8a3612",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/kmod-libs-29-2.fc34.aarch64.rpm",
+        "checksum": "sha256:d41c145c642518d0631c1c5cd5109b00bb4f2d55dc984420bb4dc8aeced02093",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/k/krb5-libs-1.19.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ebd31647978c435e3f887a3a90a2bdea46de55f154e95d0e6ba2a82ff61cd3df",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/less-590-2.fc34.aarch64.rpm",
+        "checksum": "sha256:7cc0891a9e7c19757c03cba6c8155738d9db9f5774380c412106adf0eca44077",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ffd88545700faadfd122788e2ba1f1fba52d5e73c52d8d610293eec589e99d04",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:65846278a34fdf9179698c3fdda404dfc3e37636cc0301f5fb7e0ef82464a124",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.aarch64.rpm",
+        "checksum": "sha256:07ef2753836df4e152ea7eabc21b9a8d18ec0b847cf8f022a784e98f8c056044",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "49.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.aarch64.rpm",
+        "checksum": "sha256:f6b491fbc63cd4da1a723a937d4aad5753936051d53503d9e03527d5d68c5690",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:a6345078302096af8540f371f17419ab20ee4ae04e863273471e3d20ffdae70b",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:2e618be488e955ca134698104fe79d09a912faf03872ec7a8de8e7c4d8971e50",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "38.20210714cvs.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libedit-3.1-38.20210714cvs.fc34.aarch64.rpm",
+        "checksum": "sha256:b6687e9977e337e5d029de0d42cb79d57bd44f2f642450440756ba1a0494a113",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:d62ec3c8cc2d7b96fac0686b462fbb73366fa393e96d8e189984e62c9a440c24",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgcrypt-1.9.3-3.fc34.aarch64.rpm",
+        "checksum": "sha256:cdb3dcc68cb0800dcdc04851be7fdbde119f24222975cafa89514ac4678676d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:862f7be1caa18625a7a44b3e3fcd1a3db8382ef3991dc2dfba3cf1c7dd3f13df",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "37.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libibverbs-37.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:05a874bfa814e94708a58415bc616688e3630ce6e314f58763dca1c7c937a35b",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libidn2-2.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:89247124c896238298f9b9f99ded6a3e283fadbaf21aedf9f087829dc420455b",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libldb-2.3.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:86cb1e5e80642b1575df57287c9549749603bf94b1ba652995b59ea45ac4272b",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.aarch64.rpm",
+        "checksum": "sha256:a4d4d393112ea13b61112328b224cda0d7dd826689d0bf80efd2307005df9548",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.5.4",
+        "release": "2.rc3.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libnfsidmap-2.5.4-2.rc3.fc34.aarch64.rpm",
+        "checksum": "sha256:330a36b1dabaf76daafeff3f7fd7a276880bf65d790ee84cb823a1958a4d99d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpcap-1.10.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:62fc224d0485fec46c86a6314ff24a8336ed15b26b89d98a78b1f32c7d462810",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.aarch64.rpm",
+        "checksum": "sha256:66e278d001cf4d3f7d3a951aa03c5ff10872424c4b13b13ca04b39a409f19dc8",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:f97458c24f279af39359837748a9e4f501eda82f393ce8b258dda944bbf1fc38",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
+        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b5d7ed76c37151e461592e5c8d164faa3ac5cbbf192c9cb58c15573bd292ac40",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsepol-3.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:9e1028c71054e6eabc8bc70205fa5671502f6a02c9ed9aeb0d399de9eadd8850",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-0.9.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:cdb470f5254c29f076685beadb9c3a324ee1b96eac867f602db1384651a38108",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libssh-config-0.9.6-1.fc34.noarch.rpm",
+        "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3b3bba1d61529a1dde47f234f34d0fdee07a38aa5958d87e30357ea04bbff142",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ac901ae730144d1e75b86d9991c1c6a9d6d0a44ce6e52b4d330df3a26d09e1ff",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:3fdab509a59e0a765364d6f119c38c796a4420cc49b46595a37d98eb649d6c80",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:60ddc7b15e9742ff9995d1b336489b92721e21a45034d20f20d2fc800e419d1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:4123331b5d06f91ff31d147e4769806052f59b620e7677f69b0073eaf7beccb6",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:45f23f05c1048bd7f8d21dbc293d744ed6fdb10590774502fcc63f5fb13e1cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "0.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtevent-0.11.0-0.fc34.aarch64.rpm",
+        "checksum": "sha256:a72bb74400b447af71600da141aebdc46da7776ef875abfdd635881f939891d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "0.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libtirpc-1.3.2-0.fc34.aarch64.rpm",
+        "checksum": "sha256:65c26d213cf59db3c5dab193bdefe7a940894d6f6920dbab083bf32d647d92f6",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libuser-0.63-4.fc34.aarch64.rpm",
+        "checksum": "sha256:fd7dc918a1e3ad0114ecaa41d78c6652cc559271ad6653e5bba0bc780af35faa",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc34.aarch64.rpm",
+        "checksum": "sha256:07a241e54a411bde47dc0ad110ebf2aa8dfa2069c1f4a3603809133ea9f764e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxkbcommon-1.3.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:30aa7a73e18f1d65b90eaa7bdd680e3f79ebf4252bfaf3e86f8c71b8e9c01330",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "4.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libxml2-2.9.12-4.fc34.aarch64.rpm",
+        "checksum": "sha256:0a74834272ee0b90ac0299f7b37b8cfc73ec1d02ae74ae97eac26d80dbaf1448",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b1a602156fbfc3a3a48955e3436f6ff339f7703e11f1a63ff2cd31cd0a4ea40e",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc34.noarch.rpm",
+        "checksum": "sha256:8ab032e2a86f300d978e521ab030db1e7bb7eeccca205a5d2a4d68b51566f43f",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc34.noarch.rpm",
+        "checksum": "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:59f0e931e8ba6e0e800f7a9ff0ae7047fb128d2d45aad844f07919cc5acba7d8",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mkpasswd-5.5.10-1.fc34.aarch64.rpm",
+        "checksum": "sha256:be320b33950877b7fb4022d9bfeb8113872ae5fd4d5b5298414f5351e8562c83",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/m/mpfr-4.1.0-7.fc34.aarch64.rpm",
+        "checksum": "sha256:d79a9b837ae8f6673a30e846cea7389151f9d519d2c56c002c657b8257d72f85",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/n/nettle-3.7.3-1.fc34.aarch64.rpm",
+        "checksum": "sha256:2927a30c2c30d462960e2501e2037454372e3627f81534741396c35cd6f9fd87",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.57",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openldap-2.4.57-6.fc34.aarch64.rpm",
+        "checksum": "sha256:8d86466947089164d7c28e3682ca869046df965d1a3606fa0bd7e6df89cc9630",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.6p1",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-8.6p1-5.fc34.aarch64.rpm",
+        "checksum": "sha256:5dcac7772d73ad1523f87cbeb1dc76dd62af4d2bb73dd06896a47d2bcf503e5e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.6p1",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.6p1-5.fc34.aarch64.rpm",
+        "checksum": "sha256:d5d622f60e97d43b095a98f2bb46982d91451e4e6018492da20944b294480af3",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.6p1",
+        "release": "5.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssh-server-8.6p1-5.fc34.aarch64.rpm",
+        "checksum": "sha256:39160ef65b3519a70f14f992edc5967380ef86a6940896751db681781961903d",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/o/openssl-libs-1.1.1l-2.fc34.aarch64.rpm",
+        "checksum": "sha256:ac30426412a4a691635925df51b1eb71b989ccb11de740c34440b6c276bd0520",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "7.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pam-1.5.1-7.fc34.aarch64.rpm",
+        "checksum": "sha256:874a7fff8a75b017b2846ca7acb795ed5a4751a5234295dea08f76b1b1363d22",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:07cce6e8f6a8345dafde56cc034f3577ed60fa2de9df31ef52bb10324f4f8ed3",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "1.fc34.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/procps-ng-3.3.17-1.fc34.1.aarch64.rpm",
+        "checksum": "sha256:68debade3024ef212f11eacd15fc7d6638ff3638bc9b054fc6bbb1740fe60c16",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-setuptools-wheel-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.9.9-2.fc34.noarch.rpm",
+        "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-3.9.9-2.fc34.aarch64.rpm",
+        "checksum": "sha256:6249392b192fe0549663b5b6ba730c11850f3b781b60a8c874f9003f9e52abb9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-audit-3.0.6-1.fc34.aarch64.rpm",
+        "checksum": "sha256:139b9453b2038e52767d0102def782d58d558ca0603757eb0c97ddda28af1466",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-babel",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-babel-2.9.1-1.fc34.noarch.rpm",
+        "checksum": "sha256:59cc4d563ecb4c8b517f5dd7505f1cda297f950f32fc700344aa7789b69ca99c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dbus-1.2.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:00c29524aad123ec44056e60b9625e75ac428a6c751878a05fadbca7e956c249",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc34.noarch.rpm",
+        "checksum": "sha256:bab19da8b6f553325decae00748f88fc0924b918136f065ab8995e1ebf5bde5b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:79858dee841d4eb81cd7fe69fa0038bb2f15b279199206b70596d7f4df3f5329",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.aarch64.rpm",
+        "checksum": "sha256:c3109d2a955a6ec26c9ae5c014fe58d71c1bba66b089c1a9a3d0ee670e0d415c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:08a116adeb32a1b9f1b485abe6d4bf89d2b4e4f1443d5d26cb3f6d115868158f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-libs-3.9.9-2.fc34.aarch64.rpm",
+        "checksum": "sha256:8e308dcaea9e8d32b23a6eb75a85dba9e352717504006bb6ab9483ed9aeae394",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pip-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyrsistent",
+        "epoch": 0,
+        "version": "0.17.3",
+        "release": "6.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.17.3-6.fc34.aarch64.rpm",
+        "checksum": "sha256:fc4104e014beee44b5003e72a32e45e689936a4ffdcf07e119b02be3ed4ab8d9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pytz",
+        "epoch": 0,
+        "version": "2021.3",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc34.noarch.rpm",
+        "checksum": "sha256:eecc86b828ad436a9f397d2f7acdf5705bfd36bcad3edd2da73f3acc94363411",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:dce4d9c726016d57213558adc1ef7a45d1ff01422607a588774e11fcb5a6add3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.25.10",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.25.10-5.fc34.noarch.rpm",
+        "checksum": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc34.aarch64.rpm",
+        "checksum": "sha256:11bc1ad30eb70c6e6da039bfef0f59b7860b381e3d90acb55e161e28e59a040b",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.8.1",
+        "release": "10.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.8.1-10.fc34.aarch64.rpm",
+        "checksum": "sha256:fd0ebe3b5beb5d37de20cc2d31c92b44e4a02fb8974c0050d4b2e31746400f99",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-client-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:c814f83bcf3cfc590d84897c810a087354cfb0c961dd232af5031cfe8bd63a37",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-common-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:668a30c6f526e51705af9cb9d98fd11f279f5e86f7d905876ae9a86f486a8c36",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:7285fcc290a8af2cf845beb845e661cd4c06c2275417b15eb507824dedec7c69",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.5.2-2.fc34.aarch64.rpm",
+        "checksum": "sha256:0db1be9a78e5f329a519066a7b37379f6c73fe579154e0a6a26b2dcb4154ccd6",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:bb11bbfb768e1fc85280f6336a6bbef2e6315358d18560f78c2afc4e3e302da3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:edceb287d98e98de1e1f092c89ea30124a29dc5dcd2c53d291ff374649dcb9b5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-networkd-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:aec98e619dc66e407984f2c9379b606640e680f82a374ab99759ae18d271e4fe",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:43b0b5d425a2041daeb6b41db2858abda1f92ecc38c6125f7de3b7502580a9f7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-pam-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b2d4b08f9509e1c734e68bbabc20a4f914b1bd31a0bf529dbe49331c1c4cd00b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-rpm-macros",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-rpm-macros-248.9-1.fc34.noarch.rpm",
+        "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.aarch64.rpm",
+        "checksum": "sha256:b42e4b106f5ab67a408eedf5ed92c69564fc9e14940266900f4eb5f61ddcd894",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.aarch64.rpm",
+        "checksum": "sha256:3103c979a734783892f2964e3cd4dc2bb0f8d17474fda51cad994ba85ecfc590",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
+        "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.aarch64.rpm",
+        "checksum": "sha256:5bad81279459f172d57733df8e197c0eda89c252bceec55835e1c622b3273eb3",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.3755",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.3755-1.fc34.noarch.rpm",
+        "checksum": "sha256:adcd36cb0e582f5fb2d0465cf88bb813ffac17d25d6ec8aa608b647d008bebc3",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.3755",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.3755-1.fc34.aarch64.rpm",
+        "checksum": "sha256:1af86c0a8c11e44958b022bf7dad5f48ad974fa8537cf41a12d5b0643444b1dc",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "26.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/which-2.21-26.fc34.aarch64.rpm",
+        "checksum": "sha256:12cda23b14ae1a658b4b3eaf5c65749092aa5de01467a771edce1670acef7f20",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/w/whois-nls-5.5.10-1.fc34.noarch.rpm",
+        "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
+        "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/y/yum-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:30bc3583e503e0f459e323b27551f7b9a8ab784de15437b5b29f447b31f8d9cd",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "1.fc34",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.aarch64.rpm",
+        "checksum": "sha256:674da2debda201fd2fb4aee7d3e017feab4b64b0433a814ef70cc5215d41772e",
+        "check_gpg": true
+      }
+    ]
+  },
+  "image-info": {
+    "/etc/resolv.conf": [],
+    "boot-environment": {
+      "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac  debug"
+    },
+    "bootloader": "unknown",
+    "bootmenu": [
+      {
+        "grub_arg": "--unrestricted",
+        "grub_class": "fedora",
+        "grub_users": "$grub_users",
+        "initrd": "/boot/initramfs-5.15.13-100.fc34.aarch64.img",
+        "linux": "/boot/vmlinuz-5.15.13-100.fc34.aarch64",
+        "options": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8",
+        "title": "Fedora (5.15.13-100.fc34.aarch64) 34 (Cloud Edition)",
+        "version": "5.15.13-100.fc34.aarch64"
+      }
+    ],
+    "chrony": {
+      "leapsectz": [
+        "right/UTC"
+      ],
+      "server": [
+        "time.example.com iburst"
+      ]
+    },
+    "cloud-init": {
+      "/etc/cloud": {
+        "cloud.cfg": {
+          "cloud_config_modules": [
+            "ssh-import-id",
+            "locale",
+            "set-passwords",
+            "spacewalk",
+            "yum-add-repo",
+            "ntp",
+            "timezone",
+            "disable-ec2-metadata",
+            "runcmd"
+          ],
+          "cloud_final_modules": [
+            "package-update-upgrade-install",
+            "puppet",
+            "chef",
+            "mcollective",
+            "salt-minion",
+            "reset_rmc",
+            "refresh_rmc_and_interface",
+            "rightscale_userdata",
+            "scripts-vendor",
+            "scripts-per-once",
+            "scripts-per-boot",
+            "scripts-per-instance",
+            "scripts-user",
+            "ssh-authkey-fingerprints",
+            "keys-to-console",
+            "phone-home",
+            "final-message",
+            "power-state-change"
+          ],
+          "cloud_init_modules": [
+            "migrator",
+            "seed_random",
+            "bootcmd",
+            "write-files",
+            "growpart",
+            "resizefs",
+            "disk_setup",
+            "mounts",
+            "set_hostname",
+            "update_hostname",
+            "update_etc_hosts",
+            "ca-certs",
+            "rsyslog",
+            "users-groups",
+            "ssh"
+          ],
+          "disable_root": true,
+          "mount_default_fields": [
+            null,
+            null,
+            "auto",
+            "defaults,nofail",
+            "0",
+            "2"
+          ],
+          "preserve_hostname": false,
+          "resize_rootfs_tmp": "/dev",
+          "ssh_pwauth": 0,
+          "system_info": {
+            "default_user": {
+              "gecos": "fedora Cloud User",
+              "groups": [
+                "wheel",
+                "adm",
+                "systemd-journal"
+              ],
+              "lock_passwd": true,
+              "name": "fedora",
+              "shell": "/bin/bash",
+              "sudo": [
+                "ALL=(ALL) NOPASSWD:ALL"
+              ]
+            },
+            "distro": "fedora",
+            "paths": {
+              "cloud_dir": "/var/lib/cloud/",
+              "templates_dir": "/etc/cloud/templates/"
+            },
+            "ssh_svcname": "sshd"
+          },
+          "users": [
+            "default"
+          ]
+        }
+      },
+      "/etc/cloud/cloud.cfg.d": {
+        "05_logging.cfg": {
+          "_log": [
+            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
+            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
+          ],
+          "log_cfgs": [
+            [
+              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
+            ]
+          ],
+          "output": {
+            "all": "| tee -a /var/log/cloud-init-output.log"
+          }
+        }
+      }
+    },
+    "default-target": "graphical.target",
+    "dracut": {
+      "/usr/lib/dracut/dracut.conf.d": {
+        "01-dist.conf": {
+          "dbus": "/usr/share/dbus-1",
+          "dbusconfdir": "/etc/dbus-1",
+          "dbusinterfaces": "/usr/share/dbus-1/interfaces",
+          "dbusinterfacesconfdir": "/etc/dbus-1/interfaces",
+          "dbusservices": "/usr/share/dbus-1/services",
+          "dbusservicesconfdir": "/etc/dbus-1/services",
+          "dbussession": "/usr/share/dbus-1/session.d",
+          "dbussessionconfdir": "/etc/dbus-1/session.d",
+          "dbussystem": "confdir/etc/dbus-1/system.d",
+          "dbussystemservices": "/usr/share/dbus-1/system-services",
+          "dbussystemservicesconfdir": "/etc/dbus-1/system-services",
+          "early_microcode": "yes",
+          "environment": "/usr/lib/environment.d",
+          "environmentconfdir": "/etc/environment.d",
+          "hostonly": "yes",
+          "hostonly_cmdline": "no",
+          "i18n_default_font": "eurlatgr",
+          "i18n_install_all": "yes",
+          "i18n_vars": "/etc/sysconfig/keyboard:KEYTABLE-KEYMAP /etc/sysconfig/i18n:SYSFONT-FONT,FONTACM-FONT_MAP,FONT_UNIMAP",
+          "install_optional_items": " vi /etc/virc ps grep cat rm ",
+          "prefix": "/",
+          "reproducible": "yes",
+          "stdloglvl": "3",
+          "sysctlconfdir": "/etc/sysctl.d",
+          "sysctld": "/usr/lib/sysctl.d",
+          "sysloglvl": "5",
+          "systemdcatalog": "/usr/lib/systemd/catalog",
+          "systemdntpunits": "/usr/lib/systemd/ntp-units.d",
+          "systemdntpunitsconfdir": "/etc/systemd/ntp-units.d",
+          "systemdportable": "/usr/lib/systemd/portable",
+          "systemdportableconfdir": "/etc/systemd/portable",
+          "systemdsystemconfdir": "/etc/systemd/system",
+          "systemdsystemunitdir": "/usr/lib/systemd/system",
+          "systemduser": "/usr/lib/systemd/user",
+          "systemduserconfdir": "/etc/systemd/user",
+          "systemdutilconfdir": "/etc/systemd",
+          "systemdutildir": "/usr/lib/systemd",
+          "sysusers": "/usr/lib/sysusers.d",
+          "sysusersconfdir": "/etc/sysusers.d",
+          "udevdir": "/usr/lib/udev"
+        },
+        "02-generic-image.conf": {
+          "hostonly": "no"
+        }
+      }
+    },
+    "fstab": [
+      [
+        "UUID=46BB-8120",
+        "/boot/efi",
+        "vfat",
+        "umask=0077,shortname=winnt",
+        "0",
+        "2"
+      ],
+      [
+        "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+        "/",
+        "ext4",
+        "defaults",
+        "1",
+        "1"
+      ]
+    ],
+    "groups": [
+      "adm:x:4:",
+      "audio:x:63:",
+      "bin:x:1:",
+      "cdrom:x:11:",
+      "chrony:x:994:",
+      "daemon:x:2:",
+      "dbus:x:81:",
+      "dialout:x:18:",
+      "disk:x:6:",
+      "floppy:x:19:",
+      "ftp:x:50:",
+      "games:x:20:",
+      "group1:x:1030:user2",
+      "group2:x:1050:",
+      "input:x:104:",
+      "kmem:x:9:",
+      "kvm:x:36:",
+      "lock:x:54:",
+      "lp:x:7:",
+      "mail:x:12:",
+      "man:x:15:",
+      "mem:x:8:",
+      "nobody:x:65534:",
+      "render:x:105:",
+      "root:x:0:",
+      "sgx:x:106:",
+      "ssh_keys:x:996:",
+      "sshd:x:74:",
+      "sys:x:3:",
+      "systemd-coredump:x:999:",
+      "systemd-journal:x:190:",
+      "systemd-network:x:192:",
+      "systemd-oom:x:998:",
+      "systemd-resolve:x:193:",
+      "systemd-timesync:x:997:",
+      "tape:x:33:",
+      "tss:x:59:",
+      "tty:x:5:",
+      "unbound:x:995:",
+      "user1:x:1000:",
+      "users:x:100:",
+      "utempter:x:35:",
+      "utmp:x:22:",
+      "video:x:39:",
+      "wheel:x:10:"
+    ],
+    "hostname": "my-host",
+    "hosts": [
+      "127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4",
+      "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
+    ],
+    "image-format": {
+      "compat": "1.1",
+      "type": "qcow2"
+    },
+    "keyboard": {
+      "vconsole": {
+        "KEYMAP": "dvorak"
+      }
+    },
+    "locale": {
+      "LANG": "el_CY.UTF-8"
+    },
+    "machine-id": "",
+    "os-release": {
+      "ANSI_COLOR": "0;38;2;60;110;180",
+      "BUG_REPORT_URL": "https://bugzilla.redhat.com/",
+      "CPE_NAME": "cpe:/o:fedoraproject:fedora:34",
+      "DOCUMENTATION_URL": "https://docs.fedoraproject.org/en-US/fedora/f34/system-administrators-guide/",
+      "HOME_URL": "https://fedoraproject.org/",
+      "ID": "fedora",
+      "LOGO": "fedora-logo-icon",
+      "NAME": "Fedora",
+      "PLATFORM_ID": "platform:f34",
+      "PRETTY_NAME": "Fedora 34 (Cloud Edition)",
+      "PRIVACY_POLICY_URL": "https://fedoraproject.org/wiki/Legal:PrivacyPolicy",
+      "REDHAT_BUGZILLA_PRODUCT": "Fedora",
+      "REDHAT_BUGZILLA_PRODUCT_VERSION": "34",
+      "REDHAT_SUPPORT_PRODUCT": "Fedora",
+      "REDHAT_SUPPORT_PRODUCT_VERSION": "34",
+      "SUPPORT_URL": "https://fedoraproject.org/wiki/Communicating_and_getting_help",
+      "VARIANT": "Cloud Edition",
+      "VARIANT_ID": "cloud",
+      "VERSION": "34 (Cloud Edition)",
+      "VERSION_CODENAME": "",
+      "VERSION_ID": "34"
+    },
+    "packages": [
+      "NetworkManager-1.30.6-1.fc34.aarch64",
+      "NetworkManager-libnm-1.30.6-1.fc34.aarch64",
+      "acl-2.3.1-1.fc34.aarch64",
+      "alternatives-1.15-2.fc34.aarch64",
+      "audit-3.0.6-1.fc34.aarch64",
+      "audit-libs-3.0.6-1.fc34.aarch64",
+      "basesystem-11-11.fc34.noarch",
+      "bash-5.1.0-2.fc34.aarch64",
+      "bzip2-libs-1.0.8-6.fc34.aarch64",
+      "c-ares-1.17.2-1.fc34.aarch64",
+      "ca-certificates-2021.2.52-1.0.fc34.noarch",
+      "checkpolicy-3.2-1.fc34.aarch64",
+      "chrony-4.1-1.fc34.aarch64",
+      "cloud-init-20.4-2.fc34.noarch",
+      "cloud-utils-growpart-0.31-8.fc34.noarch",
+      "console-login-helper-messages-0.21.2-1.fc34.noarch",
+      "console-login-helper-messages-issuegen-0.21.2-1.fc34.noarch",
+      "console-login-helper-messages-motdgen-0.21.2-1.fc34.noarch",
+      "console-login-helper-messages-profile-0.21.2-1.fc34.noarch",
+      "coreutils-8.32-30.fc34.aarch64",
+      "coreutils-common-8.32-30.fc34.aarch64",
+      "cpio-2.13-10.fc34.aarch64",
+      "cracklib-2.9.6-27.fc34.aarch64",
+      "cracklib-dicts-2.9.6-27.fc34.aarch64",
+      "crypto-policies-20210213-1.git5c710c0.fc34.noarch",
+      "crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch",
+      "cryptsetup-libs-2.3.6-1.fc34.aarch64",
+      "curl-7.76.1-12.fc34.aarch64",
+      "cyrus-sasl-lib-2.1.27-8.fc34.aarch64",
+      "dbus-1.12.20-3.fc34.aarch64",
+      "dbus-broker-29-2.fc34.aarch64",
+      "dbus-common-1.12.20-3.fc34.noarch",
+      "dbus-libs-1.12.20-3.fc34.aarch64",
+      "dejavu-sans-fonts-2.37-16.fc34.noarch",
+      "deltarpm-3.6.2-8.fc34.aarch64",
+      "device-mapper-1.02.175-1.fc34.aarch64",
+      "device-mapper-libs-1.02.175-1.fc34.aarch64",
+      "dhcp-client-4.4.2-11.b1.fc34.aarch64",
+      "dhcp-common-4.4.2-11.b1.fc34.noarch",
+      "diffutils-3.7-8.fc34.aarch64",
+      "dnf-4.9.0-1.fc34.noarch",
+      "dnf-data-4.9.0-1.fc34.noarch",
+      "dnf-plugins-core-4.0.24-1.fc34.noarch",
+      "dracut-055-6.fc34.aarch64",
+      "dracut-config-generic-055-6.fc34.aarch64",
+      "e2fsprogs-1.45.6-5.fc34.aarch64",
+      "e2fsprogs-libs-1.45.6-5.fc34.aarch64",
+      "efi-filesystem-5-4.fc34.noarch",
+      "efibootmgr-16-10.fc34.aarch64",
+      "efivar-libs-37-15.fc34.aarch64",
+      "elfutils-debuginfod-client-0.186-1.fc34.aarch64",
+      "elfutils-default-yama-scope-0.186-1.fc34.noarch",
+      "elfutils-libelf-0.186-1.fc34.aarch64",
+      "elfutils-libs-0.186-1.fc34.aarch64",
+      "expat-2.4.1-1.fc34.aarch64",
+      "fedora-gpg-keys-34-2.noarch",
+      "fedora-release-cloud-34-39.noarch",
+      "fedora-release-common-34-39.noarch",
+      "fedora-release-identity-cloud-34-39.noarch",
+      "fedora-repos-34-2.noarch",
+      "fedora-repos-modular-34-2.noarch",
+      "file-5.39-7.fc34.aarch64",
+      "file-libs-5.39-7.fc34.aarch64",
+      "filesystem-3.14-5.fc34.aarch64",
+      "findutils-4.8.0-2.fc34.aarch64",
+      "fonts-filesystem-2.0.5-5.fc34.noarch",
+      "fuse-libs-2.9.9-11.fc34.aarch64",
+      "gawk-5.1.0-3.fc34.aarch64",
+      "gawk-all-langpacks-5.1.0-3.fc34.aarch64",
+      "gdbm-libs-1.19-2.fc34.aarch64",
+      "gettext-0.21-4.fc34.aarch64",
+      "gettext-libs-0.21-4.fc34.aarch64",
+      "glib2-2.68.4-1.fc34.aarch64",
+      "glibc-2.33-20.fc34.aarch64",
+      "glibc-common-2.33-20.fc34.aarch64",
+      "glibc-doc-2.33-20.fc34.noarch",
+      "glibc-langpack-en-2.33-20.fc34.aarch64",
+      "gmp-6.2.0-6.fc34.aarch64",
+      "gnupg2-2.2.27-4.fc34.aarch64",
+      "gnupg2-smime-2.2.27-4.fc34.aarch64",
+      "gnutls-3.7.2-1.fc34.aarch64",
+      "gpg-pubkey-45719a39-5f2c0192",
+      "gpgme-1.15.1-2.fc34.aarch64",
+      "grep-3.6-2.fc34.aarch64",
+      "groff-base-1.22.4-7.fc34.aarch64",
+      "grub2-common-2.06-9.fc34.noarch",
+      "grub2-efi-aa64-2.06-9.fc34.aarch64",
+      "grub2-tools-2.06-9.fc34.aarch64",
+      "grub2-tools-minimal-2.06-9.fc34.aarch64",
+      "grubby-8.40-51.fc34.aarch64",
+      "gzip-1.10-4.fc34.aarch64",
+      "hostname-3.23-4.fc34.aarch64",
+      "ima-evm-utils-1.3.2-2.fc34.aarch64",
+      "inih-49-3.fc34.aarch64",
+      "initscripts-10.09-1.fc34.aarch64",
+      "ipcalc-1.0.1-1.fc34.aarch64",
+      "iproute-5.10.0-2.fc34.aarch64",
+      "iproute-tc-5.10.0-2.fc34.aarch64",
+      "iptables-legacy-libs-1.8.7-8.fc34.aarch64",
+      "iptables-libs-1.8.7-8.fc34.aarch64",
+      "iputils-20210202-2.fc34.aarch64",
+      "jansson-2.13.1-2.fc34.aarch64",
+      "json-c-0.14-8.fc34.aarch64",
+      "kbd-2.4.0-2.fc34.aarch64",
+      "kbd-misc-2.4.0-2.fc34.noarch",
+      "kernel-5.15.13-100.fc34.aarch64",
+      "kernel-core-5.15.13-100.fc34.aarch64",
+      "kernel-modules-5.15.13-100.fc34.aarch64",
+      "keyutils-libs-1.6.1-2.fc34.aarch64",
+      "kmod-29-2.fc34.aarch64",
+      "kmod-libs-29-2.fc34.aarch64",
+      "kpartx-0.8.5-4.fc34.aarch64",
+      "krb5-libs-1.19.2-2.fc34.aarch64",
+      "langpacks-core-en-3.0-14.fc34.noarch",
+      "langpacks-core-font-en-3.0-14.fc34.noarch",
+      "langpacks-en-3.0-14.fc34.noarch",
+      "less-590-2.fc34.aarch64",
+      "libacl-2.3.1-1.fc34.aarch64",
+      "libarchive-3.5.2-2.fc34.aarch64",
+      "libargon2-20171227-6.fc34.aarch64",
+      "libassuan-2.5.5-1.fc34.aarch64",
+      "libattr-2.5.1-1.fc34.aarch64",
+      "libbasicobjects-0.1.1-47.fc34.aarch64",
+      "libblkid-2.36.2-1.fc34.aarch64",
+      "libbrotli-1.0.9-4.fc34.aarch64",
+      "libcap-2.48-2.fc34.aarch64",
+      "libcap-ng-0.8.2-4.fc34.aarch64",
+      "libcbor-0.7.0-3.fc34.aarch64",
+      "libcollection-0.7.0-47.fc34.aarch64",
+      "libcom_err-1.45.6-5.fc34.aarch64",
+      "libcomps-0.1.18-1.fc34.aarch64",
+      "libcurl-7.76.1-12.fc34.aarch64",
+      "libdb-5.3.28-49.fc34.aarch64",
+      "libdhash-0.5.0-47.fc34.aarch64",
+      "libdnf-0.64.0-1.fc34.aarch64",
+      "libeconf-0.4.0-1.fc34.aarch64",
+      "libedit-3.1-38.20210714cvs.fc34.aarch64",
+      "libevent-2.1.12-3.fc34.aarch64",
+      "libfdisk-2.36.2-1.fc34.aarch64",
+      "libffi-3.1-28.fc34.aarch64",
+      "libfido2-1.6.0-2.fc34.aarch64",
+      "libgcc-11.2.1-1.fc34.aarch64",
+      "libgcrypt-1.9.3-3.fc34.aarch64",
+      "libgomp-11.2.1-1.fc34.aarch64",
+      "libgpg-error-1.42-1.fc34.aarch64",
+      "libibverbs-37.0-1.fc34.aarch64",
+      "libidn2-2.3.2-1.fc34.aarch64",
+      "libini_config-1.3.1-47.fc34.aarch64",
+      "libkcapi-1.2.1-1.fc34.aarch64",
+      "libkcapi-hmaccalc-1.2.1-1.fc34.aarch64",
+      "libksba-1.5.0-2.fc34.aarch64",
+      "libldb-2.3.2-1.fc34.aarch64",
+      "libmaxminddb-1.5.2-1.fc34.aarch64",
+      "libmnl-1.0.4-13.fc34.aarch64",
+      "libmodulemd-2.13.0-2.fc34.aarch64",
+      "libmount-2.36.2-1.fc34.aarch64",
+      "libndp-1.7-7.fc34.aarch64",
+      "libnetfilter_conntrack-1.0.8-2.fc34.aarch64",
+      "libnfnetlink-1.0.1-19.fc34.aarch64",
+      "libnfsidmap-2.5.4-2.rc3.fc34.aarch64",
+      "libnghttp2-1.43.0-2.fc34.aarch64",
+      "libnl3-3.5.0-6.fc34.aarch64",
+      "libnsl2-1.3.0-2.fc34.aarch64",
+      "libpath_utils-0.2.1-47.fc34.aarch64",
+      "libpcap-1.10.1-1.fc34.aarch64",
+      "libpipeline-1.5.3-2.fc34.aarch64",
+      "libpsl-0.21.1-3.fc34.aarch64",
+      "libpwquality-1.4.4-6.fc34.aarch64",
+      "libref_array-0.1.5-47.fc34.aarch64",
+      "librepo-1.14.2-1.fc34.aarch64",
+      "libreport-filesystem-2.15.2-2.fc34.noarch",
+      "libseccomp-2.5.3-1.fc34.aarch64",
+      "libsecret-0.20.4-2.fc34.aarch64",
+      "libselinux-3.2-1.fc34.aarch64",
+      "libselinux-utils-3.2-1.fc34.aarch64",
+      "libsemanage-3.2-1.fc34.aarch64",
+      "libsepol-3.2-2.fc34.aarch64",
+      "libsigsegv-2.13-2.fc34.aarch64",
+      "libsmartcols-2.36.2-1.fc34.aarch64",
+      "libsolv-0.7.17-3.fc34.aarch64",
+      "libss-1.45.6-5.fc34.aarch64",
+      "libssh-0.9.6-1.fc34.aarch64",
+      "libssh-config-0.9.6-1.fc34.noarch",
+      "libsss_autofs-2.5.2-2.fc34.aarch64",
+      "libsss_certmap-2.5.2-2.fc34.aarch64",
+      "libsss_idmap-2.5.2-2.fc34.aarch64",
+      "libsss_nss_idmap-2.5.2-2.fc34.aarch64",
+      "libsss_sudo-2.5.2-2.fc34.aarch64",
+      "libstdc++-11.2.1-1.fc34.aarch64",
+      "libtalloc-2.3.2-2.fc34.aarch64",
+      "libtasn1-4.16.0-4.fc34.aarch64",
+      "libtdb-1.4.3-6.fc34.aarch64",
+      "libtevent-0.11.0-0.fc34.aarch64",
+      "libtextstyle-0.21-4.fc34.aarch64",
+      "libtirpc-1.3.2-0.fc34.aarch64",
+      "libunistring-0.9.10-10.fc34.aarch64",
+      "libusbx-1.0.24-2.fc34.aarch64",
+      "libuser-0.63-4.fc34.aarch64",
+      "libutempter-1.2.1-4.fc34.aarch64",
+      "libuuid-2.36.2-1.fc34.aarch64",
+      "libverto-0.3.2-1.fc34.aarch64",
+      "libxcrypt-4.4.27-1.fc34.aarch64",
+      "libxkbcommon-1.3.0-1.fc34.aarch64",
+      "libxml2-2.9.12-4.fc34.aarch64",
+      "libyaml-0.2.5-5.fc34.aarch64",
+      "libzstd-1.5.0-1.fc34.aarch64",
+      "linux-atm-libs-2.5.1-28.fc34.aarch64",
+      "linux-firmware-20211216-127.fc34.noarch",
+      "linux-firmware-whence-20211216-127.fc34.noarch",
+      "lmdb-libs-0.9.29-1.fc34.aarch64",
+      "lua-libs-5.4.3-1.fc34.aarch64",
+      "lz4-libs-1.9.3-2.fc34.aarch64",
+      "man-db-2.9.3-3.fc34.aarch64",
+      "memstrack-0.2.2-1.fc34.aarch64",
+      "mkpasswd-5.5.10-1.fc34.aarch64",
+      "mokutil-0.4.0-4.fc34.aarch64",
+      "mpfr-4.1.0-7.fc34.aarch64",
+      "ncurses-6.2-4.20200222.fc34.aarch64",
+      "ncurses-base-6.2-4.20200222.fc34.noarch",
+      "ncurses-libs-6.2-4.20200222.fc34.aarch64",
+      "net-tools-2.0-0.59.20160912git.fc34.aarch64",
+      "nettle-3.7.3-1.fc34.aarch64",
+      "npth-1.6-6.fc34.aarch64",
+      "openldap-2.4.57-6.fc34.aarch64",
+      "openssh-8.6p1-5.fc34.aarch64",
+      "openssh-clients-8.6p1-5.fc34.aarch64",
+      "openssh-server-8.6p1-5.fc34.aarch64",
+      "openssl-libs-1.1.1l-2.fc34.aarch64",
+      "openssl-pkcs11-0.4.11-2.fc34.aarch64",
+      "os-prober-1.77-7.fc34.aarch64",
+      "p11-kit-0.23.22-3.fc34.aarch64",
+      "p11-kit-trust-0.23.22-3.fc34.aarch64",
+      "pam-1.5.1-7.fc34.aarch64",
+      "parted-3.4-2.fc34.aarch64",
+      "passwd-0.80-10.fc34.aarch64",
+      "pcre-8.44-3.fc34.1.aarch64",
+      "pcre2-10.36-4.fc34.aarch64",
+      "pcre2-syntax-10.36-4.fc34.noarch",
+      "pigz-2.5-1.fc34.aarch64",
+      "pinentry-1.2.0-1.fc34.aarch64",
+      "policycoreutils-3.2-1.fc34.aarch64",
+      "popt-1.18-4.fc34.aarch64",
+      "procps-ng-3.3.17-1.fc34.1.aarch64",
+      "protobuf-c-1.3.3-7.fc34.aarch64",
+      "psmisc-23.4-1.fc34.aarch64",
+      "publicsuffix-list-dafsa-20190417-5.fc34.noarch",
+      "python-pip-wheel-21.0.1-4.fc34.noarch",
+      "python-setuptools-wheel-53.0.0-2.fc34.noarch",
+      "python-unversioned-command-3.9.9-2.fc34.noarch",
+      "python3-3.9.9-2.fc34.aarch64",
+      "python3-attrs-20.3.0-2.fc34.noarch",
+      "python3-audit-3.0.6-1.fc34.aarch64",
+      "python3-babel-2.9.1-1.fc34.noarch",
+      "python3-cffi-1.14.5-1.fc34.aarch64",
+      "python3-chardet-4.0.0-1.fc34.noarch",
+      "python3-configobj-5.0.6-23.fc34.noarch",
+      "python3-cryptography-3.4.6-1.fc34.aarch64",
+      "python3-dateutil-2.8.1-3.fc34.noarch",
+      "python3-dbus-1.2.18-1.fc34.aarch64",
+      "python3-distro-1.5.0-5.fc34.noarch",
+      "python3-dnf-4.9.0-1.fc34.noarch",
+      "python3-dnf-plugins-core-4.0.24-1.fc34.noarch",
+      "python3-gpg-1.15.1-2.fc34.aarch64",
+      "python3-hawkey-0.64.0-1.fc34.aarch64",
+      "python3-idna-2.10-3.fc34.noarch",
+      "python3-jinja2-2.11.3-1.fc34.noarch",
+      "python3-jsonpatch-1.21-14.fc34.noarch",
+      "python3-jsonpointer-2.0-2.fc34.noarch",
+      "python3-jsonschema-3.2.0-9.fc34.noarch",
+      "python3-jwt+crypto-1.7.1-11.fc34.noarch",
+      "python3-jwt-1.7.1-11.fc34.noarch",
+      "python3-libcomps-0.1.18-1.fc34.aarch64",
+      "python3-libdnf-0.64.0-1.fc34.aarch64",
+      "python3-libs-3.9.9-2.fc34.aarch64",
+      "python3-libselinux-3.2-1.fc34.aarch64",
+      "python3-libsemanage-3.2-1.fc34.aarch64",
+      "python3-markupsafe-1.1.1-10.fc34.aarch64",
+      "python3-oauthlib+signedtoken-3.0.2-9.fc34.noarch",
+      "python3-oauthlib-3.0.2-9.fc34.noarch",
+      "python3-pip-21.0.1-4.fc34.noarch",
+      "python3-ply-3.11-11.fc34.noarch",
+      "python3-policycoreutils-3.2-1.fc34.noarch",
+      "python3-prettytable-0.7.2-25.fc34.noarch",
+      "python3-pycparser-2.20-3.fc34.noarch",
+      "python3-pyrsistent-0.17.3-6.fc34.aarch64",
+      "python3-pyserial-3.4-10.fc34.noarch",
+      "python3-pysocks-1.7.1-8.fc34.noarch",
+      "python3-pytz-2021.3-1.fc34.noarch",
+      "python3-pyyaml-5.4.1-2.fc34.aarch64",
+      "python3-requests-2.25.1-1.fc34.noarch",
+      "python3-rpm-4.16.1.3-1.fc34.aarch64",
+      "python3-setools-4.4.0-1.fc34.aarch64",
+      "python3-setuptools-53.0.0-2.fc34.noarch",
+      "python3-six-1.15.0-5.fc34.noarch",
+      "python3-unbound-1.13.2-1.fc34.aarch64",
+      "python3-urllib3-1.25.10-5.fc34.noarch",
+      "qrencode-libs-4.1.1-1.fc34.aarch64",
+      "readline-8.1-2.fc34.aarch64",
+      "rootfiles-8.1-29.fc34.noarch",
+      "rpm-4.16.1.3-1.fc34.aarch64",
+      "rpm-build-libs-4.16.1.3-1.fc34.aarch64",
+      "rpm-libs-4.16.1.3-1.fc34.aarch64",
+      "rpm-plugin-selinux-4.16.1.3-1.fc34.aarch64",
+      "rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.aarch64",
+      "rpm-sign-libs-4.16.1.3-1.fc34.aarch64",
+      "rsync-3.2.3-5.fc34.aarch64",
+      "sed-4.8-7.fc34.aarch64",
+      "selinux-policy-34.23-1.fc34.noarch",
+      "selinux-policy-targeted-34.23-1.fc34.noarch",
+      "setup-2.13.7-3.fc34.noarch",
+      "shadow-utils-4.8.1-10.fc34.aarch64",
+      "shared-mime-info-2.1-2.fc34.aarch64",
+      "shim-aa64-15.4-4.aarch64",
+      "sqlite-libs-3.34.1-2.fc34.aarch64",
+      "sssd-client-2.5.2-2.fc34.aarch64",
+      "sssd-common-2.5.2-2.fc34.aarch64",
+      "sssd-kcm-2.5.2-2.fc34.aarch64",
+      "sssd-nfs-idmap-2.5.2-2.fc34.aarch64",
+      "sudo-1.9.5p2-1.fc34.aarch64",
+      "sudo-python-plugin-1.9.5p2-1.fc34.aarch64",
+      "systemd-248.9-1.fc34.aarch64",
+      "systemd-libs-248.9-1.fc34.aarch64",
+      "systemd-networkd-248.9-1.fc34.aarch64",
+      "systemd-oomd-defaults-248.9-1.fc34.aarch64",
+      "systemd-pam-248.9-1.fc34.aarch64",
+      "systemd-rpm-macros-248.9-1.fc34.noarch",
+      "systemd-udev-248.9-1.fc34.aarch64",
+      "tar-1.34-1.fc34.aarch64",
+      "tpm2-tss-3.1.0-1.fc34.aarch64",
+      "trousers-0.3.15-2.fc34.aarch64",
+      "trousers-lib-0.3.15-2.fc34.aarch64",
+      "tzdata-2021e-1.fc34.noarch",
+      "unbound-libs-1.13.2-1.fc34.aarch64",
+      "util-linux-2.36.2-1.fc34.aarch64",
+      "vim-data-8.2.3755-1.fc34.noarch",
+      "vim-minimal-8.2.3755-1.fc34.aarch64",
+      "which-2.21-26.fc34.aarch64",
+      "whois-nls-5.5.10-1.fc34.noarch",
+      "xfsprogs-5.10.0-2.fc34.aarch64",
+      "xkeyboard-config-2.33-1.fc34.noarch",
+      "xz-5.2.5-5.fc34.aarch64",
+      "xz-libs-5.2.5-5.fc34.aarch64",
+      "yum-4.9.0-1.fc34.noarch",
+      "zchunk-libs-1.1.15-1.fc34.aarch64",
+      "zlib-1.2.11-26.fc34.aarch64"
+    ],
+    "partition-table": "gpt",
+    "partition-table-id": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
+    "partitions": [
+      {
+        "bootable": false,
+        "fstype": "vfat",
+        "label": "EFI-SYSTEM",
+        "partuuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
+        "size": 498073600,
+        "start": 1048576,
+        "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+        "uuid": "46BB-8120"
+      },
+      {
+        "bootable": false,
+        "fstype": "ext4",
+        "label": null,
+        "partuuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
+        "size": 1647296000,
+        "start": 500170752,
+        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+        "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+      }
+    ],
+    "passwd": [
+      "adm:x:3:4:adm:/var/adm:/sbin/nologin",
+      "bin:x:1:1:bin:/bin:/sbin/nologin",
+      "chrony:x:995:994::/var/lib/chrony:/sbin/nologin",
+      "daemon:x:2:2:daemon:/sbin:/sbin/nologin",
+      "dbus:x:81:81:System message bus:/:/sbin/nologin",
+      "ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin",
+      "games:x:12:100:games:/usr/games:/sbin/nologin",
+      "halt:x:7:0:halt:/sbin:/sbin/halt",
+      "lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin",
+      "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
+      "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
+      "operator:x:11:0:operator:/root:/sbin/nologin",
+      "root:x:0:0:root:/root:/bin/bash",
+      "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
+      "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
+      "sync:x:5:0:sync:/sbin:/bin/sync",
+      "systemd-coredump:x:999:999:systemd Core Dumper:/:/sbin/nologin",
+      "systemd-network:x:192:192:systemd Network Management:/:/sbin/nologin",
+      "systemd-oom:x:998:998:systemd Userspace OOM Killer:/:/sbin/nologin",
+      "systemd-resolve:x:193:193:systemd Resolver:/:/sbin/nologin",
+      "systemd-timesync:x:997:997:systemd Time Synchronization:/:/sbin/nologin",
+      "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
+      "unbound:x:996:995:Unbound DNS resolver:/etc/unbound:/sbin/nologin",
+      "user1:x:1000:1000::/home/user1:/bin/bash",
+      "user2:x:1020:1050:description 2:/home/home2:/bin/sh"
+    ],
+    "rpm-verify": {
+      "changed": {
+        "/boot/efi/EFI": ".M.......",
+        "/boot/efi/EFI/fedora/grubaa64.efi": ".......T.",
+        "/etc/chrony.conf": "S.5....T.",
+        "/etc/machine-id": ".M.......",
+        "/etc/udev/hwdb.bin": ".M.......",
+        "/proc": ".M.......",
+        "/sys": ".M.......",
+        "/var/log/lastlog": ".M....G.."
+      },
+      "missing": []
+    },
+    "selinux": {
+      "context-mismatch": [
+        {
+          "actual": "system_u:object_r:unlabeled_t:s0",
+          "expected": "system_u:object_r:lost_found_t:s0",
+          "filename": "/lost+found"
+        }
+      ],
+      "policy": {
+        "SELINUX": "enforcing",
+        "SELINUXTYPE": "targeted"
+      }
+    },
+    "services-disabled": [
+      "arp-ethers.service",
+      "chrony-wait.service",
+      "console-getty.service",
+      "console-login-helper-messages-gensnippet-os-release.service",
+      "console-login-helper-messages-gensnippet-ssh-keys.service",
+      "debug-shell.service",
+      "exit.target",
+      "halt.target",
+      "kexec.target",
+      "loadmodules.service",
+      "man-db-restart-cache-update.service",
+      "nis-domainname.service",
+      "poweroff.target",
+      "proc-sys-fs-binfmt_misc.mount",
+      "rdisc.service",
+      "remote-cryptsetup.target",
+      "remote-veritysetup.target",
+      "runlevel0.target",
+      "selinux-check-proper-disable.service",
+      "serial-getty@.service",
+      "sshd-keygen@.service",
+      "sssd-autofs.socket",
+      "sssd-nss.socket",
+      "sssd-pac.socket",
+      "sssd-pam-priv.socket",
+      "sssd-pam.socket",
+      "sssd-ssh.socket",
+      "sssd-sudo.socket",
+      "systemd-boot-check-no-failures.service",
+      "systemd-network-generator.service",
+      "systemd-networkd-wait-online.service",
+      "systemd-networkd.service",
+      "systemd-networkd.socket",
+      "systemd-pstore.service",
+      "systemd-sysext.service",
+      "systemd-time-wait-sync.service",
+      "systemd-timesyncd.service",
+      "tcsd.service"
+    ],
+    "services-enabled": [
+      "NetworkManager-dispatcher.service",
+      "NetworkManager-wait-online.service",
+      "NetworkManager.service",
+      "auditd.service",
+      "autovt@.service",
+      "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
+      "ctrl-alt-del.target",
+      "dbus-broker.service",
+      "dbus-org.freedesktop.home1.service",
+      "dbus-org.freedesktop.nm-dispatcher.service",
+      "dbus-org.freedesktop.oom1.service",
+      "dbus-org.freedesktop.resolve1.service",
+      "dbus.service",
+      "dbus.socket",
+      "dnf-makecache.timer",
+      "fstrim.timer",
+      "getty@.service",
+      "import-state.service",
+      "reboot.target",
+      "remote-fs.target",
+      "rpmdb-rebuild.service",
+      "runlevel6.target",
+      "selinux-autorelabel-mark.service",
+      "sshd.service",
+      "sshd.socket",
+      "sssd-kcm.socket",
+      "sssd.service",
+      "systemd-homed-activate.service",
+      "systemd-homed.service",
+      "systemd-oomd.service",
+      "systemd-resolved.service",
+      "systemd-userdbd.socket",
+      "unbound-anchor.timer"
+    ],
+    "sudoers": {
+      "/etc/sudoers": [
+        "Defaults   !visiblepw",
+        "Defaults    always_set_home",
+        "Defaults    match_group_by_gid",
+        "Defaults    always_query_group_plugin",
+        "Defaults    env_reset",
+        "Defaults    env_keep =  \"COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS\"",
+        "Defaults    env_keep += \"MAIL QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE\"",
+        "Defaults    env_keep += \"LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES\"",
+        "Defaults    env_keep += \"LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE\"",
+        "Defaults    env_keep += \"LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY\"",
+        "Defaults    secure_path = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+        "root\tALL=(ALL) \tALL",
+        "%wheel\tALL=(ALL)\tALL"
+      ]
+    },
+    "sysctl.d": {
+      "/usr/lib/sysctl.d": {
+        "10-default-yama-scope.conf": [
+          "kernel.yama.ptrace_scope = 0"
+        ],
+        "50-coredump.conf": [
+          "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h",
+          "kernel.core_pipe_limit=16",
+          "fs.suid_dumpable=2"
+        ],
+        "50-default.conf": [
+          "kernel.sysrq = 16",
+          "kernel.core_uses_pid = 1",
+          "net.ipv4.conf.default.rp_filter = 2",
+          "net.ipv4.conf.*.rp_filter = 2",
+          "-net.ipv4.conf.all.rp_filter",
+          "net.ipv4.conf.default.accept_source_route = 0",
+          "net.ipv4.conf.*.accept_source_route = 0",
+          "-net.ipv4.conf.all.accept_source_route",
+          "net.ipv4.conf.default.promote_secondaries = 1",
+          "net.ipv4.conf.*.promote_secondaries = 1",
+          "-net.ipv4.conf.all.promote_secondaries",
+          "-net.ipv4.ping_group_range = 0 2147483647",
+          "-net.core.default_qdisc = fq_codel",
+          "fs.protected_hardlinks = 1",
+          "fs.protected_symlinks = 1",
+          "fs.protected_regular = 1",
+          "fs.protected_fifos = 1"
+        ],
+        "50-libkcapi-optmem_max.conf": [
+          "net.core.optmem_max = 81920"
+        ],
+        "50-pid-max.conf": [
+          "kernel.pid_max = 4194304"
+        ]
+      }
+    },
+    "systemd-service-dropins": {
+      "/usr/lib/systemd/system": {
+        "systemd-hostnamed.service.d": {
+          "Service": {
+            "PrivateDevices": "no"
+          }
+        },
+        "systemd-logind.service.d": {
+          "Service": {
+            "Environment": "SYSTEMD_REBOOT_TO_BOOT_LOADER_MENU=true"
+          }
+        },
+        "systemd-udev-trigger.service.d": {
+          "Unit": {
+            "RefuseManualStop": "true"
+          }
+        },
+        "user@.service.d": {
+          "Service": {
+            "ManagedOOMMemoryPressure": "kill",
+            "ManagedOOMMemoryPressureLimit": "50%"
+          }
+        }
+      }
+    },
+    "timezone": "London",
+    "tmpfiles.d": {
+      "/usr/lib/tmpfiles.d": {
+        "cloud-init.conf": [
+          "d /run/cloud-init 0700 root root - -"
+        ],
+        "console-login-helper-messages-issuegen.conf": [
+          "r /etc/issue.d/*_clhm_*.issue - - - - -"
+        ],
+        "console-login-helper-messages-motdgen.conf": [
+          "d /run/motd.d - - - - -"
+        ],
+        "console-login-helper-messages-profile.conf": [
+          "L /etc/profile.d/console-login-helper-messages-profile.sh - - - - ../../usr/share/console-login-helper-messages/profile.sh"
+        ],
+        "console-login-helper-messages.conf": [
+          "d /run/console-login-helper-messages - - - - -"
+        ],
+        "cryptsetup.conf": [
+          "d /run/cryptsetup 0700 root root -"
+        ],
+        "dnf.conf": [
+          "R /var/tmp/dnf*/locks/*",
+          "r /var/cache/dnf/download_lock.pid",
+          "r /var/cache/dnf/metadata_lock.pid",
+          "r /var/lib/dnf/rpmdb_lock.pid",
+          "r /var/log/log_lock.pid"
+        ],
+        "etc.conf": [
+          "L /etc/os-release - - - - ../usr/lib/os-release",
+          "L+ /etc/mtab - - - - ../proc/self/mounts",
+          "L! /etc/resolv.conf - - - - ../run/systemd/resolve/stub-resolv.conf",
+          "C! /etc/nsswitch.conf - - - -",
+          "C! /etc/pam.d - - - -",
+          "C! /etc/issue - - - -"
+        ],
+        "home.conf": [
+          "Q /home 0755 - - -",
+          "q /srv 0755 - - -"
+        ],
+        "journal-nocow.conf": [
+          "h /var/log/journal - - - - +C",
+          "h /var/log/journal/%m - - - - +C",
+          "h /var/log/journal/remote - - - - +C"
+        ],
+        "legacy.conf": [
+          "d /run/lock 0755 root root -",
+          "L /var/lock - - - - ../run/lock",
+          "d /run/lock/subsys 0755 root root -",
+          "r! /forcefsck",
+          "r! /fastboot",
+          "r! /forcequotacheck"
+        ],
+        "libselinux.conf": [
+          "d /run/setrans 0755 root root"
+        ],
+        "man-db.conf": [
+          "d /var/cache/man 0755 root root 1w"
+        ],
+        "pam.conf": [
+          "d /run/console 0755 root root -",
+          "d /run/faillock 0755 root root -",
+          "d /run/sepermit 0755 root root -",
+          "d /run/motd.d 0755 root root -",
+          "f /var/log/tallylog 0600 root root -"
+        ],
+        "portables.conf": [
+          "Q /var/lib/portables 0700"
+        ],
+        "selinux-policy.conf": [
+          "z /sys/devices/system/cpu/online - - -",
+          "Z /sys/class/net - - -",
+          "z /sys/kernel/uevent_helper - - -",
+          "w /sys/fs/selinux/checkreqprot - - - - 0"
+        ],
+        "setup.conf": [
+          "f /run/motd 0644 root root -",
+          "d /run/motd.d 0755 root root -"
+        ],
+        "static-nodes-permissions.conf": [
+          "z /dev/snd/seq      0660 - audio -",
+          "z /dev/snd/timer    0660 - audio -",
+          "z /dev/loop-control 0660 - disk  -",
+          "z /dev/net/tun      0666 - -     -",
+          "z /dev/fuse         0666 - -     -",
+          "z /dev/kvm          0666 - kvm -",
+          "z /dev/vhost-net    0666 - kvm -",
+          "z /dev/vhost-vsock  0666 - kvm -"
+        ],
+        "sudo.conf": [
+          "d /run/sudo 0711 root root",
+          "D /run/sudo/ts 0700 root root"
+        ],
+        "systemd-nologin.conf": [
+          "F! /run/nologin 0644 - - - \"System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8).\""
+        ],
+        "systemd-pstore.conf": [
+          "d /var/lib/systemd/pstore 0755 root root 14d"
+        ],
+        "systemd-tmp.conf": [
+          "x /tmp/systemd-private-%b-*",
+          "X /tmp/systemd-private-%b-*/tmp",
+          "x /var/tmp/systemd-private-%b-*",
+          "X /var/tmp/systemd-private-%b-*/tmp",
+          "R! /tmp/systemd-private-*",
+          "R! /var/tmp/systemd-private-*",
+          "x  /var/lib/systemd/coredump/.#core*.%b*",
+          "r! /var/lib/systemd/coredump/.#*"
+        ],
+        "systemd.conf": [
+          "d /run/user 0755 root root -",
+          "F! /run/utmp 0664 root utmp -",
+          "d /run/systemd/ask-password 0755 root root -",
+          "d /run/systemd/seats 0755 root root -",
+          "d /run/systemd/sessions 0755 root root -",
+          "d /run/systemd/users 0755 root root -",
+          "d /run/systemd/machines 0755 root root -",
+          "d /run/systemd/shutdown 0755 root root -",
+          "d /run/systemd/netif 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/links 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/leases 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/lldp 0755 systemd-network systemd-network -",
+          "d /run/log 0755 root root -",
+          "z /run/log/journal 2755 root systemd-journal - -",
+          "Z /run/log/journal/%m ~2750 root systemd-journal - -",
+          "a+ /run/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m/*.journal* - - - - group:adm:r--,group:wheel:r--",
+          "z /var/log/journal 2755 root systemd-journal - -",
+          "z /var/log/journal/%m 2755 root systemd-journal - -",
+          "z /var/log/journal/%m/system.journal 0640 root systemd-journal - -",
+          "a+ /var/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m/system.journal - - - - group:adm:r--,group:wheel:r--",
+          "d /var/lib/systemd 0755 root root -",
+          "d /var/lib/systemd/coredump 0755 root root 3d",
+          "d /var/lib/private 0700 root root -",
+          "d /var/log/private 0700 root root -",
+          "d /var/cache/private 0700 root root -"
+        ],
+        "tmp.conf": [
+          "q /tmp 1777 root root 10d",
+          "q /var/tmp 1777 root root 30d"
+        ],
+        "tpm2-tss-fapi.conf": [
+          "d       /var/lib/tpm2-tss/system/keystore   2775 tss  tss   -           -",
+          "a+      /var/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx",
+          "d       /run/tpm2-tss/eventlog                2775 tss  tss   -           -",
+          "a+      /run/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx"
+        ],
+        "var.conf": [
+          "q /var 0755 - - -",
+          "L /var/run - - - - ../run",
+          "d /var/log 0755 - - -",
+          "f /var/log/wtmp 0664 root utmp -",
+          "f /var/log/btmp 0660 root utmp -",
+          "f /var/log/lastlog 0664 root utmp -",
+          "d /var/cache 0755 - - -",
+          "d /var/lib 0755 - - -",
+          "d /var/spool 0755 - - -"
+        ],
+        "x11.conf": [
+          "D! /tmp/.X11-unix 1777 root root 10d",
+          "D! /tmp/.ICE-unix 1777 root root 10d",
+          "D! /tmp/.XIM-unix 1777 root root 10d",
+          "D! /tmp/.font-unix 1777 root root 10d",
+          "D! /tmp/.Test-unix 1777 root root 10d",
+          "r! /tmp/.X[0-9]*-lock"
+        ]
+      }
+    }
+  }
+}

--- a/test/data/manifests/fedora_34-x86_64-oci-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-oci-boot.json
@@ -1,0 +1,10199 @@
+{
+  "compose-request": {
+    "distro": "fedora-34",
+    "arch": "x86_64",
+    "image-type": "oci",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-modular-20210512/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-modular-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      }
+    ],
+    "filename": "disk.qcow2",
+    "blueprint": {}
+  },
+  "manifest": {
+    "sources": {
+      "org.osbuild.files": {
+        "urls": {
+          "sha256:0041b41276afd2846199a020fa769b7a3b504fae34b83cbad92f217b1d55e481": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-cryptography-3.4.6-1.fc34.x86_64.rpm"
+          },
+          "sha256:00df260cd7acacb1e122f460046816e12f39566951ab39ccbc61c33b1c912aee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libtextstyle-0.21-4.fc34.x86_64.rpm"
+          },
+          "sha256:019c0bdb989459f7aed88f534cf96af8e720cb5a0ffa7d514f6b8de5e62eb9e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/trousers-0.3.15-2.fc34.x86_64.rpm"
+          },
+          "sha256:01c9d525eb77975631ff44b67e3ee65492445a3f1861f4f04a25be48218634a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libsepol-3.2-2.fc34.x86_64.rpm"
+          },
+          "sha256:0214ae16ef6a92843a4973aeda93db85584ad7840b1dd6e225bc57b594f58961": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/m/memstrack-0.2.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:0359a21c768977e0f589ee424690a905ea2f13dd0caf410ac1602d8807f77709": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/o/os-prober-1.77-7.fc34.x86_64.rpm"
+          },
+          "sha256:039719fc5f330260fc2cdac9f77618841a2aa1a35d6fd417a47312d4eb5bedd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/policycoreutils-3.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:039f11c0333b49318e60b1fa8e5621f16363fe77fb76602eccc085d0897fbdb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-1.fc34.x86_64.rpm"
+          },
+          "sha256:05606b38ea83db0d4f5fea924caeda9a1b90eb9bd5fa7858278e90c3661bf26e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/psmisc-23.4-1.fc34.x86_64.rpm"
+          },
+          "sha256:0586d4ad14181d8cca2979449ebec2d4ce1fde826c77feaa91ab47902055abdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.x86_64.rpm"
+          },
+          "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:066af2860b14cfc346263dc85c2d320e38d81d078bf3fd88130494a7717b282f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/kmod-29-2.fc34.x86_64.rpm"
+          },
+          "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-pip-21.0.1-4.fc34.noarch.rpm"
+          },
+          "sha256:09a0a4702e0f716caaf6f8e75dc478d3d70bf3fbd074a76fb4d6f8492af7c138": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-pyyaml-5.4.1-2.fc34.x86_64.rpm"
+          },
+          "sha256:0c37bbf98383679eb0f1cab44d20d3c0ca5e981a887152b64d1078c7734643e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libblkid-2.36.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:0c679ac467bc08e857adf5d1d8228e5a176fc06e74a3f30dbd5dab4843751163": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/j/jansson-2.13.1-2.fc34.x86_64.rpm"
+          },
+          "sha256:0c9434feed1a753e13e76a5cce78ffbef99e8dbce74edd23d73af3627b8cd928": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/m/mtools-4.0.36-1.fc34.x86_64.rpm"
+          },
+          "sha256:0e43c033af22ac108085cafbd1de5032a3642162abe06c0fc8fff1a10e61f629": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libnghttp2-1.43.0-2.fc34.x86_64.rpm"
+          },
+          "sha256:0e4fe80ef8c8799a3210290687f039b1c35de7f8c9c6644b3faf323946e38df0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gmp-6.2.0-6.fc34.x86_64.rpm"
+          },
+          "sha256:0ebb518a40590402136a181c5c0ec8d0c73d3074817bf94bd7a3937eb38ad107": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libidn2-2.3.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:0ebe43a9bef7ec2dc4cb98350fbde2e55dae886f905e2d9cea837da3fb613c87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/z/zlib-1.2.11-26.fc34.x86_64.rpm"
+          },
+          "sha256:0f4616a09f18ba7902f87ef22024a6692379272df2b66bb3c9d4d12771533fff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/keyutils-libs-1.6.1-2.fc34.x86_64.rpm"
+          },
+          "sha256:10d3680b3b99f8585bf95ffb53e14e1d2956acd2c2d0f892c8cbf93a9861af12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/syslinux-extlinux-6.04-0.17.fc34.x86_64.rpm"
+          },
+          "sha256:11079b8f071c61c3a2a8556e3c9e406b188378969fa34f5bc0ce67b88c8e3799": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/initscripts-10.09-1.fc34.x86_64.rpm"
+          },
+          "sha256:11253fdc73fbf71f3c5ff7d2b58d9967fc7525cf9a131f8ed0f69212e60f8bc1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libini_config-1.3.1-47.fc34.x86_64.rpm"
+          },
+          "sha256:11cd6fae157eb9e4800163633b57bcce21d59a1df4b86a99ba03707b6cee0cfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dhcp-common-4.4.2-11.b1.fc34.noarch.rpm"
+          },
+          "sha256:11f35d539334ee51f49c19be2ef596082e818511638070a9d41a4681fa61d279": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/sssd-common-2.5.2-2.fc34.x86_64.rpm"
+          },
+          "sha256:12e04c0e335343ce1c87f4a13f22faa3fc8305ad0cc74fa6d755997ddd82ba3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libtevent-0.11.0-0.fc34.x86_64.rpm"
+          },
+          "sha256:131adc47f044c9f600f5295ded0f5431cda57fa7276100c3ec81c9d1ce3fa6f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-jwt-1.7.1-11.fc34.noarch.rpm"
+          },
+          "sha256:1480de09d5016b10258a24571534f4cdbbd644efb0799c40842f390f0cf65e91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/gnutls-3.7.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:15a654d32efaa75b5df3e2481939d0393fe1746696cc858ca094ccf8b76073cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/a/alternatives-1.15-2.fc34.x86_64.rpm"
+          },
+          "sha256:164e1c0e3e8c89aeda4f272b3158932649a69b16aea058105117a64d3cdef517": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rootfiles-8.1-29.fc34.noarch.rpm"
+          },
+          "sha256:1816bd5b8dee276e7174ec06256bcc5f699b8a1c2203995bf84210590c52b0ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/f/fuse-libs-2.9.9-11.fc34.x86_64.rpm"
+          },
+          "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.x86_64.rpm"
+          },
+          "sha256:1877af369228dd661ae1adfc43bbb8d53d3464d59ead0f5bcf6c2be88f8e8685": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/console-login-helper-messages-0.21.2-1.fc34.noarch.rpm"
+          },
+          "sha256:193bae5dffa4c82249bfbbf3de479f048955a788a00e9c37c7667b820f36eb91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libnfnetlink-1.0.1-19.fc34.x86_64.rpm"
+          },
+          "sha256:1a3c32056482e59ce2e6ef29270f6abb0567bcd0345b3d7fe76ff2b4e4bd8f7c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/syslinux-6.04-0.17.fc34.x86_64.rpm"
+          },
+          "sha256:1b13e55eb2a2e9b7a01031e26f04655eec54a453831c9d68db25932d20e58453": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/openssh-8.6p1-5.fc34.x86_64.rpm"
+          },
+          "sha256:1b1af6b54050ec223c3289b107a9695a686c9d46d17a80ec9cd5d0201ec5d544": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-jsonpointer-2.0-2.fc34.noarch.rpm"
+          },
+          "sha256:1eead3a3a0b0ff0a9776309d838e0b154f6ad64f1e4a59dc773f3159c118dff0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/coreutils-8.32-30.fc34.x86_64.rpm"
+          },
+          "sha256:1f445df6b58ea1c9eb76d8cc2c9ec2eba81c45f00603c2b9e84eb86e038d4f89": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/krb5-libs-1.19.2-2.fc34.x86_64.rpm"
+          },
+          "sha256:1feb6a045cb3e95e3c8e0112ecb4b8ffeb9986a503b52c5497fefce217846b90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc34.noarch.rpm"
+          },
+          "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm"
+          },
+          "sha256:22ecb93be24849e734db3546e01dac762d152f22113b593b635544e256b98b52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc34.x86_64.rpm"
+          },
+          "sha256:231740a6624ac820b99bdc0084b4aab99d0d3466a7f0b828cc5451f3ccd251ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-100.fc34.x86_64.rpm"
+          },
+          "sha256:237a8756303db7712e91d2b52c428464b401b3295c6c50c5d23a2ebef2f88beb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/x/xz-5.2.5-5.fc34.x86_64.rpm"
+          },
+          "sha256:23a58f476dd47e7d92378060efa995a7c96c521b9d1532509e91460da73181f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libuuid-2.36.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:23e3ed871799a9209915359f71660babf451b0b44902e3ed488b7b22aff37718": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-ply-3.11-11.fc34.noarch.rpm"
+          },
+          "sha256:2414cb7345bc193f7ff7983c020c8b0e706aab013ee30af5d457d35c4de4a698": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-jinja2-2.11.3-1.fc34.noarch.rpm"
+          },
+          "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/w/whois-nls-5.5.10-1.fc34.noarch.rpm"
+          },
+          "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.x86_64.rpm"
+          },
+          "sha256:2595a15421c2de026658c7a4ed3eb46706bb16d2df63986eca4574fd87d72fb2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/p11-kit-0.23.22-3.fc34.x86_64.rpm"
+          },
+          "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm"
+          },
+          "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.x86_64.rpm"
+          },
+          "sha256:26abfb8ae9df36d7daab0590f40bbb794a495943fc317e9f2073fe8301058c72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.x86_64.rpm"
+          },
+          "sha256:29d944588a122ae56cc35c310dd202601e39e26964a7bf22d04819a5409c07ed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/kmod-libs-29-2.fc34.x86_64.rpm"
+          },
+          "sha256:2a63d1e893c95961c1d608bdbcf2acbdd51b045c74fa4827808a491ad424e929": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/groff-base-1.22.4-7.fc34.x86_64.rpm"
+          },
+          "sha256:2acde8d21a1d5c88823fd667bbaac59a4af3f8ad47a9e833276f86e8cfcc2275": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-1.fc34.x86_64.rpm"
+          },
+          "sha256:2b5bfefcbf88c3c22670ed52b39a075ed2ac5beaaedd9b16c22004897f5186e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/net-tools-2.0-0.59.20160912git.fc34.x86_64.rpm"
+          },
+          "sha256:2b9ff5e4d35b7ede55110ead06f4f2aa326e6a45040ea2638eb03d30d1fe113a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dhcp-client-4.4.2-11.b1.fc34.x86_64.rpm"
+          },
+          "sha256:2d98ce375c70ac4038d9e69be1ef562197e8f966cc1e805f06c266131d478562": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libdhash-0.5.0-47.fc34.x86_64.rpm"
+          },
+          "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/selinux-policy-targeted-34.23-1.fc34.noarch.rpm"
+          },
+          "sha256:2e2ee3306a607ffc6ab2bd0e398e7a176f45c55ede9c55462632cbf7d100723a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libfdisk-2.36.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.x86_64.rpm"
+          },
+          "sha256:30bc3583e503e0f459e323b27551f7b9a8ab784de15437b5b29f447b31f8d9cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/y/yum-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:32220dc513a6ebcd4994e7140ecb5859108baf44d12fe6b1f0c0459dbefc54e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-pycparser-2.20-3.fc34.noarch.rpm"
+          },
+          "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/crypto-policies-20210213-1.git5c710c0.fc34.noarch.rpm"
+          },
+          "sha256:344b1cc4edb49b7ac10f0d401fde43a2b67a61867652381825a24124d4af4d75": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/n/NetworkManager-1.30.6-1.fc34.x86_64.rpm"
+          },
+          "sha256:34bfb7bc369a50204f70d5a7f538f543a4ef053d36d48b74be62bb1ea8fa8187": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/grep-3.6-2.fc34.x86_64.rpm"
+          },
+          "sha256:364583b4cc9a12e344dadc1e3e734ab92882c4bf8d6731ffa0df752f36258834": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libgpg-error-1.42-1.fc34.x86_64.rpm"
+          },
+          "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.x86_64.rpm"
+          },
+          "sha256:3714a372bb59bcc89ba5d971cbf6eb025b3ff964825309f04fbc7d6366df8cf8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/inih-49-3.fc34.x86_64.rpm"
+          },
+          "sha256:377d141bf5e1dca120216e9cc478c31fceace604f0ba2b2bc51497efbf00b7df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.x86_64.rpm"
+          },
+          "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python-setuptools-wheel-53.0.0-2.fc34.noarch.rpm"
+          },
+          "sha256:37ccd5908e2e2c6a0ded948ffb7cb232f87515fa917bf1651226f6a5cf48b5ed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libldb-2.3.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:38731e49cb0ee6a0d98f736ec1ee5605ed3a12cf3c119bb3f140ccf42500d6b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-libs-4.16.1.3-1.fc34.x86_64.rpm"
+          },
+          "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.0.1-4.fc34.noarch.rpm"
+          },
+          "sha256:3b5f5b2129930d6eff8abcdadf70287fe92480c8deb9b622d1b31d7178e84e2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-248.9-1.fc34.x86_64.rpm"
+          },
+          "sha256:3b7916a277cd7dac44e861b56c0915977f36396d5b4f5007508bf7c90f93e7bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc34.x86_64.rpm"
+          },
+          "sha256:3d6181aa04e1bd81bc2f6d8eb2e5ddf5b18cd1ee8567815ecbf5932393a09f45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/i/ipcalc-1.0.1-1.fc34.x86_64.rpm"
+          },
+          "sha256:3d7c3cbf81fc044d098692a1a9989d36120405a46f7f7b595091aa10cf687d84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libref_array-0.1.5-47.fc34.x86_64.rpm"
+          },
+          "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/setup-2.13.7-3.fc34.noarch.rpm"
+          },
+          "sha256:3e69e8412d5914ec01c5e82264833698e92a1b88a7c7b5ed9b1f0351fc91f5d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-release-34-39.noarch.rpm"
+          },
+          "sha256:3f7bde703045c2651fbd4142131ea1e303a565269388a08e2312af0eb83307a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/console-login-helper-messages-issuegen-0.21.2-1.fc34.noarch.rpm"
+          },
+          "sha256:3fb05067cbd7fcf3283f2ab306c2dae668d818d3a69422e729c2ef62974810a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/f/fonts-filesystem-2.0.5-5.fc34.noarch.rpm"
+          },
+          "sha256:424f73b97c7d7541d35685108bdcddb03100cd0f3d6e0fd9def576462ca65b59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/console-login-helper-messages-profile-0.21.2-1.fc34.noarch.rpm"
+          },
+          "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.9.9-2.fc34.noarch.rpm"
+          },
+          "sha256:442415a2b11394c551e9d3496a325e0365b726543981d98a12e5910eced08115": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.x86_64.rpm"
+          },
+          "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.x86_64.rpm"
+          },
+          "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.x86_64.rpm"
+          },
+          "sha256:45ee87897faec4ad216eb111f76ecde2e7f6b864e63bdff4daf10efc97447eee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/n/nettle-3.7.3-1.fc34.x86_64.rpm"
+          },
+          "sha256:46022a4e7d40f858d01fabd50bf2b22705022103d2708805e44ada62ed7ccfe2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libssh-0.9.6-1.fc34.x86_64.rpm"
+          },
+          "sha256:4a2ce807ef248c703b78d6f298a7e7eb64b08528aab890de5608c09e34d54f6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.x86_64.rpm"
+          },
+          "sha256:4a74ae08a713e9b4e74ff27bfaf57374312370402f90e2796e66c504557ae189": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-pysocks-1.7.1-8.fc34.noarch.rpm"
+          },
+          "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.x86_64.rpm"
+          },
+          "sha256:4efbc2de7c8d2fcd78f542bf3e92a2d65084a08fff0a56f323c35ca0d4b98eb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/chrony-4.1-1.fc34.x86_64.rpm"
+          },
+          "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-common-1.12.20-3.fc34.noarch.rpm"
+          },
+          "sha256:509a2067a88eb29ddc4b66078401bbbe6c938c968b876bcb2d74c469e7327fcb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:50d06e862f369b217b1051c5e826bfdb15c795494bfc17283ab621804c1dba1d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-cffi-1.14.5-1.fc34.x86_64.rpm"
+          },
+          "sha256:5311161abf68dee473cd5b868a7a35aef1e98c017b29d9269c71d598143d301b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libnl3-3.5.0-6.fc34.x86_64.rpm"
+          },
+          "sha256:54616250eab59e08603e591ff38c1b4929d7799996b4834225ed2920e73bb379": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/a/audit-3.0.6-1.fc34.x86_64.rpm"
+          },
+          "sha256:547588862120dc0431fa1687ca22b8723114b68aa5c21b95f28055ed556faf2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/kernel-5.15.13-100.fc34.x86_64.rpm"
+          },
+          "sha256:5514af0678342f195a77718fdbf0a0ffddb3a66d5457c6e2f590f8236238ee95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/checkpolicy-3.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.x86_64.rpm"
+          },
+          "sha256:55819abd7651c8f0e7449967933909fa2c6a0f939e90c6074d4831b633cc6adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libpcap-1.10.1-1.fc34.x86_64.rpm"
+          },
+          "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.x86_64.rpm"
+          },
+          "sha256:581e6c46abab18afc9725f561894b0a41b9f3c15e778588a1874efb2324ef144": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-setools-4.4.0-1.fc34.x86_64.rpm"
+          },
+          "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.x86_64.rpm"
+          },
+          "sha256:59cc4d563ecb4c8b517f5dd7505f1cda297f950f32fc700344aa7789b69ca99c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-babel-2.9.1-1.fc34.noarch.rpm"
+          },
+          "sha256:59cfafb5b96fdb1d219743aaf3dfc72de9f2da527efc9c9db3c87815cade7517": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.x86_64.rpm"
+          },
+          "sha256:5a4b0cc50d9929ef558617fecd879f80a459379047ec77bcc238e5b305258bf5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-9.fc34.x86_64.rpm"
+          },
+          "sha256:5afd3d5069dec788145b4fc51d2445d2c9ac021414b4821e99147dd66928d2cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/syslinux-extlinux-nonlinux-6.04-0.17.fc34.noarch.rpm"
+          },
+          "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.x86_64.rpm"
+          },
+          "sha256:5cdb39c3cd9ddffe4e363ab60e64838858751547bc547f2cbf9d35c4a36febd4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libnfsidmap-2.5.4-2.rc3.fc34.x86_64.rpm"
+          },
+          "sha256:5d2c28837f0573ae2647b8fbba85f7c502f9c3da0a3eab1c9ba121de4a1a6cee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-dateutil-2.8.1-3.fc34.noarch.rpm"
+          },
+          "sha256:5e5e72cd1b7c708282657917de6f8aea198d308e30e42c9126994b7b4ccc3a64": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/h/hostname-3.23-4.fc34.x86_64.rpm"
+          },
+          "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.x86_64.rpm"
+          },
+          "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm"
+          },
+          "sha256:5fb88eb681e996ab2199251a68c79b2797fa03d31a36dae698de393b85e1f89e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/device-mapper-1.02.175-1.fc34.x86_64.rpm"
+          },
+          "sha256:60c79833b164f6dad8f7e0f330b993e9602a2357612f3157f31df8ebfa833d11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:6297d7eee103c679a0f1ea411568d3940af3fe8f38e19388a1544df70bda8b3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-requests-2.25.1-1.fc34.noarch.rpm"
+          },
+          "sha256:6351c0b6cb6af4444e033c0558727e92298695eda47492af65a678e13a6ee1f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc34.x86_64.rpm"
+          },
+          "sha256:6492193577a35112cac513566a71ee3d4cc40c7c2fb84a83a73698b320c2972f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dbus-1.2.18-1.fc34.x86_64.rpm"
+          },
+          "sha256:66f820e1083c42d6a6b29a880720fd03a79edc66f32f8bc94e44461feafb02bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.5.2-2.fc34.x86_64.rpm"
+          },
+          "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/selinux-policy-34.23-1.fc34.noarch.rpm"
+          },
+          "sha256:68e068283ebde084fc71d7adbfd29e519f37416fb8bcf746f89693d1ce90d0f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/cracklib-dicts-2.9.6-27.fc34.x86_64.rpm"
+          },
+          "sha256:68fa66fc992597c906349a67b60969f81c9548173e1eeb3e20bc3a2b20da626f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libcollection-0.7.0-47.fc34.x86_64.rpm"
+          },
+          "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.x86_64.rpm"
+          },
+          "sha256:69773821114b06ee0e5720178f33323d32434ee67ada19a3535d7cc6cc84aaaf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-pyrsistent-0.17.3-6.fc34.x86_64.rpm"
+          },
+          "sha256:6a5f21dd77a32eb484b0573e6bb4fe1da9fc26c02d53a564fe41130c080b16cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/parted-3.4-2.fc34.x86_64.rpm"
+          },
+          "sha256:6a84fac2aa4beec617e596818b06a5f154f678e666f1c4601c972828e22aa22a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.x86_64.rpm"
+          },
+          "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-repos-34-2.noarch.rpm"
+          },
+          "sha256:6c5db6a0eb030c42b41b8e533c559ef81967dbb513d539754ff79b6c407d80d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/a/audit-libs-3.0.6-1.fc34.x86_64.rpm"
+          },
+          "sha256:6d01dc580d599af1fd761172c6aa9a602502f782179828586774b199e329ed16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/pam-1.5.1-7.fc34.x86_64.rpm"
+          },
+          "sha256:6d1b00e8e758af552fcad8be95fa8250d561fbfaa727f8790ea06d72005444b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-9.fc34.x86_64.rpm"
+          },
+          "sha256:6d1b95e06ec98f6d65c64e18fec693d379b98128a3e94b4dec8929321354c549": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/cloud-utils-growpart-0.31-8.fc34.noarch.rpm"
+          },
+          "sha256:6d1c024b295c423746b44f120cf36ceb0fd898f8ce5a276813d7c78a3c8ece52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-34-39.noarch.rpm"
+          },
+          "sha256:6ddbf894c0a7542ecc5a641bde06659c5a80cd954fcfd2f9e558885e81724d60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/cyrus-sasl-lib-2.1.27-8.fc34.x86_64.rpm"
+          },
+          "sha256:6e72ff4bf990a5da1251ff8578c67f44afa361aa844f51eeabf1a82fc2221c59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsemanage-3.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:701c7d913f25cbc506cc04cfca52d91287dec9c35066ba04eda7efafd1a8c0e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/passwd-0.80-10.fc34.x86_64.rpm"
+          },
+          "sha256:70a90c6c682016e91fb4745eedbd23f28e150a38b01d18f85ce4e50fb4e0ca6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-pyserial-3.4-10.fc34.noarch.rpm"
+          },
+          "sha256:713e64ea709d4b34ab814a3466babebb3985648a5b6b87c327f50f6d1aefb7f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.x86_64.rpm"
+          },
+          "sha256:7151baf126a07d4f20f91309433005b3552175a1adc03f907d772db9f374b6bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libcbor-0.7.0-3.fc34.x86_64.rpm"
+          },
+          "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libssh-config-0.9.6-1.fc34.noarch.rpm"
+          },
+          "sha256:72539a2021ed64458eef5a82c1ea0fea965e9a21d2455aac7a501f932fe006c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libpsl-0.21.1-3.fc34.x86_64.rpm"
+          },
+          "sha256:72b1000c285aa522fde63196bdeb3b32e1cff5859d345b753081cdad3cbd76d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libgcrypt-1.9.3-3.fc34.x86_64.rpm"
+          },
+          "sha256:732d4e5a9eab39a0310aaf317c76445e9579c7b0b913a3dc1eccd0bb8454be83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libattr-2.5.1-1.fc34.x86_64.rpm"
+          },
+          "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.x86_64.rpm"
+          },
+          "sha256:79834af7f95c0d1e5dcf85b794819bd854197a52d2966594abdb3c3de0fcceb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dejavu-sans-fonts-2.37-16.fc34.noarch.rpm"
+          },
+          "sha256:7aab572608f77cf21be095a49046ab43dcacce130973e947707614d8aff55278": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/pcre-8.44-3.fc34.1.x86_64.rpm"
+          },
+          "sha256:7af59d2a7a1885369a75b0038fe2ee16743f68db1925572b440b5b1c354e8412": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:7b28a2f43e2f7f08930073e2fe4792e059cbe9a40b8996f90346f4989706dc19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/tar-1.34-1.fc34.x86_64.rpm"
+          },
+          "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-9.fc34.noarch.rpm"
+          },
+          "sha256:7d59ff94c9fa323e68c6f9d5b0ccc06075847d77775211f4acbee8f54d8975ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sudo-1.9.5p2-1.fc34.x86_64.rpm"
+          },
+          "sha256:7d73ab186606e96644c34135f5e48e9407aff309d63f720b2d68aafc6797dfdd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/procps-ng-3.3.17-1.fc34.1.x86_64.rpm"
+          },
+          "sha256:7dc85c364a4be27e065db7ef90a3049e37e8d4c03d5b46ad88d3c9b255070b44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/pcre2-10.36-4.fc34.x86_64.rpm"
+          },
+          "sha256:7e130c0f39168b8d442e8bf9ca17046f7ca6210bda0d5526a2b6b34ccfa22816": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gettext-libs-0.21-4.fc34.x86_64.rpm"
+          },
+          "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm"
+          },
+          "sha256:7f2e8cf1b8b1ae6c1e9cbfa60cc6083ba88aca1f42d1639b52c3fabf7ab68185": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/m/man-db-2.9.3-3.fc34.x86_64.rpm"
+          },
+          "sha256:7f2ee88a233ab8860662b45ec5eb853171bad68703715ad4e8aa2ac8f00ee45f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libnsl2-1.3.0-2.fc34.x86_64.rpm"
+          },
+          "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-release-common-34-39.noarch.rpm"
+          },
+          "sha256:80044e9d36ea73df2b3f3a947384a93182c0dd81a724741c24ae2b967338c384": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/c-ares-1.17.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch.rpm"
+          },
+          "sha256:81778d572983ef362a31c301ad8c7ac191a1fff2e65177918b85b67fc46c51cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.x86_64.rpm"
+          },
+          "sha256:820fee96d610178c7c7b8ce2b115bd02063d2f6dfcae5da4bf5d411de0b575f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-attrs-20.3.0-2.fc34.noarch.rpm"
+          },
+          "sha256:8242972295a6a3d2426ed7756eabb0fb2eabe871894399375a54271ddec56d14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/u/util-linux-2.36.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:82473998562b047466a8082308e0e268f665e7a1bac3f7c74e124f2c37d80628": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/m/mkpasswd-5.5.10-1.fc34.x86_64.rpm"
+          },
+          "sha256:82b51ca6bec551d74a6d8c43194b0fd4e8bfdf19d1d68b58c1787723edd88bd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/langpacks-en-3.0-14.fc34.noarch.rpm"
+          },
+          "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm"
+          },
+          "sha256:82cbc5e0339e832d2fc0160541c30f3dee59b3d28d83907ae7b55e22d5092c51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/langpacks-core-font-en-3.0-14.fc34.noarch.rpm"
+          },
+          "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm"
+          },
+          "sha256:84e5dd6e3ef3d1a8447fd8c5e71e7c5baca25d96b85440ef0c8e73a2209560c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sudo-python-plugin-1.9.5p2-1.fc34.x86_64.rpm"
+          },
+          "sha256:862eaaa6e3a3cee2baf0bf4027c85d513d1a16edb8cdf7814208e0b4f0c66db0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-oomd-defaults-248.9-1.fc34.x86_64.rpm"
+          },
+          "sha256:867da92a40eadf047aa6c4127cd0858b514ecb372c4fcdcb63bba87473c99fd8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/w/which-2.21-26.fc34.x86_64.rpm"
+          },
+          "sha256:87a1e286ad30c1c123e44ef180d1f857896459fd685c66e80316a51b4687d44e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libndp-1.7-7.fc34.x86_64.rpm"
+          },
+          "sha256:8857513982b0c12e02eb0593baa9dc7cf570f2761a6bb4996fc8cf7d98402444": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-4.16.1.3-1.fc34.x86_64.rpm"
+          },
+          "sha256:8a27704e62c90406df6793be2c8e2cb1fa4919f761795bef604843f8894ab639": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-libselinux-3.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:8ab032e2a86f300d978e521ab030db1e7bb7eeccca205a5d2a4d68b51566f43f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc34.noarch.rpm"
+          },
+          "sha256:8b11a97c1d2e28518505364fb1f8bf940e2a5203e80ea6f0cde11cfc420e0a3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libsss_autofs-2.5.2-2.fc34.x86_64.rpm"
+          },
+          "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.x86_64.rpm"
+          },
+          "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.x86_64.rpm"
+          },
+          "sha256:8d171fb436059f8ae1ba31f762c35e3ff96304b0e48e59842502d697bc04cdd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.30.6-1.fc34.x86_64.rpm"
+          },
+          "sha256:8d75d66318cdf547cf7f141e149abd7fbaddf33eea71156e32f5b68edcfa81ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/cracklib-2.9.6-27.fc34.x86_64.rpm"
+          },
+          "sha256:8e9ab9dc0035e220a6e470553ce4d2fdba896a6630c8e70abee00659e0d8fc75": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-common-2.33-20.fc34.x86_64.rpm"
+          },
+          "sha256:8f08844eec04f5765bdf73b02625fb360c5a2051d66752fec9b6446105ee018a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.x86_64.rpm"
+          },
+          "sha256:90008dbecc37d3e4b9f495a2e2d92478094b6be272fb849017f8e3f51541e08f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-pam-248.9-1.fc34.x86_64.rpm"
+          },
+          "sha256:91cdce1b6c90021c8174afd1ab36afab4fab67cb9a8f5df7516fa81c40061015": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libsss_sudo-2.5.2-2.fc34.x86_64.rpm"
+          },
+          "sha256:923316dcae9e2da6a7ca355e9c26242cdc8bf21cd09a58934b3de297f6f12eba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-langpack-en-2.33-20.fc34.x86_64.rpm"
+          },
+          "sha256:9256f1e9d9e996de69764019fe5e9e11b89f5db854aff3a8cb4a82a4a34eddfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/p11-kit-trust-0.23.22-3.fc34.x86_64.rpm"
+          },
+          "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.x86_64.rpm"
+          },
+          "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/b/basesystem-11-11.fc34.noarch.rpm"
+          },
+          "sha256:983a18e776aab5b2ae41f0cfa6a7da303de275f65f9d8c318b6ba99d19d3590f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc34.x86_64.rpm"
+          },
+          "sha256:98cb29680e00e102bd8e6ba1e8b079291823fd64a0e4adaf7631710e690bd27d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/o/openssl-pkcs11-0.4.11-2.fc34.x86_64.rpm"
+          },
+          "sha256:98f64ee7318237900c77a4dbf078e3a9dfda7fe907bc9eab9a45e27b2a2d0222": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/kernel-core-5.15.13-100.fc34.x86_64.rpm"
+          },
+          "sha256:99bc964d8f2fc46e9ccdc567b159163b72a628432643bdd159464224a9d612c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc34.x86_64.rpm"
+          },
+          "sha256:9a698a5991a08e23e87b4bce2f3e447eafdc7fd4d84a49d91c65c6045ead1e8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/b/bzip2-libs-1.0.8-6.fc34.x86_64.rpm"
+          },
+          "sha256:9bff70d51ecec129854ef62d82204db3e01706c444b966cb048bc7fd8ec8b524": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/cpio-2.13-10.fc34.x86_64.rpm"
+          },
+          "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.x86_64.rpm"
+          },
+          "sha256:9cc240ac305a862146e85d8dcc4ad981f5233a58b6901ecfac691d0b39966b49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-jwt+crypto-1.7.1-11.fc34.noarch.rpm"
+          },
+          "sha256:9ce3f0c0904ac22ab5769babebf43e7dcdb488b0ef999b2e9e88a5b5eb424e51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-chardet-4.0.0-1.fc34.noarch.rpm"
+          },
+          "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm"
+          },
+          "sha256:9e879df34e32ec5085e9863adb1221d2cb6b1cea1b4bd7d2345d7bfe91f66897": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/v/vim-minimal-8.2.3755-1.fc34.x86_64.rpm"
+          },
+          "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/kbd-misc-2.4.0-2.fc34.noarch.rpm"
+          },
+          "sha256:a04bd8e79ca9948ef5ec386bf78edd60c367d487f82832902de6dcb7ce2b5ed1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libcap-ng-0.8.2-4.fc34.x86_64.rpm"
+          },
+          "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.x86_64.rpm"
+          },
+          "sha256:a0b294cdc4585a0ac04fdc6f84a4fdc08f10afcaebe28ec60370622d43bfe33d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sed-4.8-7.fc34.x86_64.rpm"
+          },
+          "sha256:a0ec96e637f6acb65409eb32f90fc9bccfd7fbfb494ded90106eb70eaf7cdd0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-libsemanage-3.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:a196fc793d1578d7c4b423ec49bdf6ef0f792cb0f505fe8c708815315ac29d81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/openldap-2.4.57-6.fc34.x86_64.rpm"
+          },
+          "sha256:a2052ecaa71b5dae58df3b651ba3437b098a2a804e55336b819e95a5a49f23f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libtirpc-1.3.2-0.fc34.x86_64.rpm"
+          },
+          "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc34.noarch.rpm"
+          },
+          "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-gpg-keys-34-2.noarch.rpm"
+          },
+          "sha256:a67d8e75329c0f5ab18a0b2a102351a09d2476f0479dea57d2dbb352245a7a03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/m/mpfr-4.1.0-7.fc34.x86_64.rpm"
+          },
+          "sha256:a7dd48e65cd9bc6254c71d51aa473f0e1a5d99baf1f8ea077652884098969e2c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc34.x86_64.rpm"
+          },
+          "sha256:a823a3f73c688a0a0bd9f049ece18574d15f361e0f4cbc5b66d1fa953b33b659": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-6.2-4.20200222.fc34.x86_64.rpm"
+          },
+          "sha256:a858b65eb278c40507abdccb587bdc0c6edb2960ec51f5bfe3d774900079694c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gettext-0.21-4.fc34.x86_64.rpm"
+          },
+          "sha256:aa59709bb1397e17d4f202baad4a28ae872e40fc50b5bee5b400b2a06095d3cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libcap-2.48-2.fc34.x86_64.rpm"
+          },
+          "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.x86_64.rpm"
+          },
+          "sha256:ac474501243d1a59ad02fdea585eaf523cd3d1aefeceead4f697fc92e3c30632": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/sssd-kcm-2.5.2-2.fc34.x86_64.rpm"
+          },
+          "sha256:ac6dbb4d55388f795b15f0339116978bca4fc0231eaa7fa7faaddc77bb9aa74a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.x86_64.rpm"
+          },
+          "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:adcd36cb0e582f5fb2d0465cf88bb813ffac17d25d6ec8aa608b647d008bebc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/v/vim-data-8.2.3755-1.fc34.noarch.rpm"
+          },
+          "sha256:ae8410b779aaa5a5ed108d6b95fd7c2b1fb13f92a06d7c28383f233dcb1c47c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-audit-3.0.6-1.fc34.x86_64.rpm"
+          },
+          "sha256:af1a24d15612b0b750cd24b74a1cb38131dcf09049187c283e244a5d3a64e789": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libtasn1-4.16.0-4.fc34.x86_64.rpm"
+          },
+          "sha256:af603a6e5e4696cfb1e7a4583940a46c5ef42de39778d55e08a7cde62bc14786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.x86_64.rpm"
+          },
+          "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64.rpm"
+          },
+          "sha256:b017639e7e7602a981baa2a0d3b99bb484d2299a3b5a907cb6856ac80a31a359": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/iproute-5.10.0-2.fc34.x86_64.rpm"
+          },
+          "sha256:b0d3b898968868b627f62a2f1b18257dc89f4e04c5c3adc8c25baa36c6cf5fa6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.x86_64.rpm"
+          },
+          "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.x86_64.rpm"
+          },
+          "sha256:b1db042b9b66ec1f24b59cac5fbb7acced19ae474399862406bc6737b434a9de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.x86_64.rpm"
+          },
+          "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.x86_64.rpm"
+          },
+          "sha256:b30db4e3d9605e7263387ff91f91508667693d28e8b8835a2b7fcefd64f24388": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-oauthlib+signedtoken-3.0.2-9.fc34.noarch.rpm"
+          },
+          "sha256:b3200e9726d4a0def9df15d6cef100a27f928aa198609940c3889f33ee635557": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libsss_idmap-2.5.2-2.fc34.x86_64.rpm"
+          },
+          "sha256:b34c767bab93fb626c993b98e10547779fa5bec98865b9a66b914e45b4b14f6e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/readline-8.1-2.fc34.x86_64.rpm"
+          },
+          "sha256:b37452649da277bc6f1e80f8c2250a16aa877444e1dcbba0d3546eef7d6fcda3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/popt-1.18-4.fc34.x86_64.rpm"
+          },
+          "sha256:b4e47421cbc842d53d14fb00b31bdb10bdddd1571dcaffbe258fa3a8c5be0500": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-1.12.20-3.fc34.x86_64.rpm"
+          },
+          "sha256:b53a61b34e0bc3cc693bcb82e1e494d201098db149dd38106cb97b6923ec3093": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/trousers-lib-0.3.15-2.fc34.x86_64.rpm"
+          },
+          "sha256:b554175a1dea7562b6d2810eb7bf41b11c01beb430479764401318785e6f85cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/f/filesystem-3.14-5.fc34.x86_64.rpm"
+          },
+          "sha256:b58e6fd55e8018e6632ddddc0564201f5cffc314a521f28c9e923c86d760a648": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.0-1.fc34.x86_64.rpm"
+          },
+          "sha256:b5d5e7255c85c3aa9d63598ef140de35843ab2485adf1cb9a9130be80aa0297f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-six-1.15.0-5.fc34.noarch.rpm"
+          },
+          "sha256:b7dac3f2d8feaffb21a6ec0503559448ad99096b50ff0d33a8a2107dbb23a8f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.x86_64.rpm"
+          },
+          "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.x86_64.rpm"
+          },
+          "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/npth-1.6-6.fc34.x86_64.rpm"
+          },
+          "sha256:b9ca1ddf049221d91a9b74baf7964ce09259a87b778b8427a7a35d3646e128db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/linux-atm-libs-2.5.1-28.fc34.x86_64.rpm"
+          },
+          "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.x86_64.rpm"
+          },
+          "sha256:ba877062b6d0746be4c66b6ff85e2b5265124532ae962d491ffed9d61bbde7bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libtalloc-2.3.2-2.fc34.x86_64.rpm"
+          },
+          "sha256:baa55f06cacd3b30db59ebc42f4967d3d15dcd20fab4cb269913c0f991078220": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.x86_64.rpm"
+          },
+          "sha256:bab19da8b6f553325decae00748f88fc0924b918136f065ab8995e1ebf5bde5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc34.noarch.rpm"
+          },
+          "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm"
+          },
+          "sha256:bc67ce199727a497116c32ad260bf75c90ffeab9fa45960c2f7d8f725ffc87c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/sssd-client-2.5.2-2.fc34.x86_64.rpm"
+          },
+          "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm"
+          },
+          "sha256:bccfdce40119616d620fa9ddc61876a471ce2cf6f558d226910454f5b289d5b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc34.x86_64.rpm"
+          },
+          "sha256:bcd3d68e3e86e62ac4f241cb3aebb35afd58c96558afabe5915a301291b90869": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/openssh-server-8.6p1-5.fc34.x86_64.rpm"
+          },
+          "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.x86_64.rpm"
+          },
+          "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/pcre2-syntax-10.36-4.fc34.noarch.rpm"
+          },
+          "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.x86_64.rpm"
+          },
+          "sha256:c060ffeb6d268d4ab20449af1a40c18f3eacb1aab5ef225f91e0c0bd08d65205": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libpath_utils-0.2.1-47.fc34.x86_64.rpm"
+          },
+          "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-rpm-macros-248.9-1.fc34.noarch.rpm"
+          },
+          "sha256:c14d10994b488aa8f6b78f2aa3850fc4dbf8d791868d08aef8e929780d5012d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.x86_64.rpm"
+          },
+          "sha256:c1f4a6f3bda5087a680c2a940fae2e02f0199c95a949dddc227390336681a405": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.8.1-10.fc34.x86_64.rpm"
+          },
+          "sha256:c20caffb4d2a500416dab0e8418a24ae5e25c02c831ae02ee10f97a0dcc80374": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/langpacks-core-en-3.0-14.fc34.noarch.rpm"
+          },
+          "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.x86_64.rpm"
+          },
+          "sha256:c44e6efc9a521ad24b919d7fab92e8864913a2ea994a2134492720648150699f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-3.9.9-2.fc34.x86_64.rpm"
+          },
+          "sha256:c5084b5bf90349032858699526d1c75606ab3d848bd4f90d320126f2e22b1957": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/grubby-8.40-51.fc34.x86_64.rpm"
+          },
+          "sha256:c540ca8c5e21ba5f063286c94a088af2aac0b15bc40df6fd562d40154c10f4a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/a/acl-2.3.1-1.fc34.x86_64.rpm"
+          },
+          "sha256:c555acae201eda07e7f97a6d0c9d8e6d71065dca7efe3fb131f3b29fe1b080ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libibverbs-37.0-1.fc34.x86_64.rpm"
+          },
+          "sha256:c568c7d0939faa7f3321d95d16ad6c84fb1e81e3c5b14b40bccc61fc3574bbc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/coreutils-common-8.32-30.fc34.x86_64.rpm"
+          },
+          "sha256:c58752e2529cf0ea4aabb0476ef53ca7748091aa936513affc1245928ae5b1b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.x86_64.rpm"
+          },
+          "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:c70d5e913bea41a0a4795ce6a43dd3d9849009649035cc111227ccc007cf18da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libbasicobjects-0.1.1-47.fc34.x86_64.rpm"
+          },
+          "sha256:c7b9527ce55677974b88c44bb541dc471512fcc3915665818b05b11c1cb7f119": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.33-20.fc34.x86_64.rpm"
+          },
+          "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.x86_64.rpm"
+          },
+          "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.x86_64.rpm"
+          },
+          "sha256:c8e0cdf3260afc4ce9c115f30df68182faaa02944cdaeeb5c20161430f82c8e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/x/xz-libs-5.2.5-5.fc34.x86_64.rpm"
+          },
+          "sha256:caa41935dc130081a607caccac5db4bc5b1963c781ba4ea43aa525b5aaf0f51e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/b/bash-5.1.0-2.fc34.x86_64.rpm"
+          },
+          "sha256:cbcd2e59caa454c8dc7a91c807189fad07a5ad6b4097e9a8c66eb169f911f127": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.5.2-2.fc34.x86_64.rpm"
+          },
+          "sha256:cc4401d1e292b28d771a2038081b929b342ffa3b60358aed91697fdbc668546a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-prettytable-0.7.2-25.fc34.noarch.rpm"
+          },
+          "sha256:cd33d7742606c567f01e0c2125121cc4fde549ed8789778a7f10ce58bd528aea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libs-3.9.9-2.fc34.x86_64.rpm"
+          },
+          "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc34.noarch.rpm"
+          },
+          "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm"
+          },
+          "sha256:cefa4197ff8c8664bbc28408953c223320cd448a2a120e22aec93c8baf39a954": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/lmdb-libs-0.9.29-1.fc34.x86_64.rpm"
+          },
+          "sha256:cf126ae271b434f9427b6e5531b3d5013688c6464740b9025f4a4548a6c69b14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/iproute-tc-5.10.0-2.fc34.x86_64.rpm"
+          },
+          "sha256:d2bac91a1969f555ea2641b161bb23fa0aaaffaba3284d9973ad696594b73f18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/console-login-helper-messages-motdgen-0.21.2-1.fc34.noarch.rpm"
+          },
+          "sha256:d3494b25cf8bac271fe6b58b149c424e1a438583ffa0808f0750d8e662b305a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libuser-0.63-4.fc34.x86_64.rpm"
+          },
+          "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm"
+          },
+          "sha256:d4b8f6fcbb1e1d0aca4d44bfd93f72e238b7ff35466c3f332d17a1354b6826c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.x86_64.rpm"
+          },
+          "sha256:d54b628e6d0b7813ec0b4cc0beb1b8f3f8510ffbaff8ae1d9c4b9993095e4edf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-release-cloud-34-39.noarch.rpm"
+          },
+          "sha256:d564ebb4b69df5f5b757808844038c0876afd4c9a4f573092f1731c10ac9d63e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.x86_64.rpm"
+          },
+          "sha256:d58e0ddac3c208aba6f507ea5df678dab7125dc3f741880cf831b1a76b0072de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libxml2-2.9.12-4.fc34.x86_64.rpm"
+          },
+          "sha256:d5f486b818d86d5f79a5dd619b24abc039496801fb3d54134322715a9c6b489f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/file-5.39-7.fc34.x86_64.rpm"
+          },
+          "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.x86_64.rpm"
+          },
+          "sha256:d6810c97f24d93cd54a61bb288ada8591a94e4083b5165e0719915bceb637504": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-jsonschema-3.2.0-9.fc34.noarch.rpm"
+          },
+          "sha256:d737d05827d680cece3b0e6bb32a64f73562d99cfcba16d09ee765134d9a0826": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/openssh-clients-8.6p1-5.fc34.x86_64.rpm"
+          },
+          "sha256:d8dde242a8be009e1e0ce8ad0a513397d90b734181f0f6491245c327c81f5a4e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libtdb-1.4.3-6.fc34.x86_64.rpm"
+          },
+          "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-9.fc34.x86_64.rpm"
+          },
+          "sha256:d9bc0ebdccb79160632bc50abca0ec13fec191dd3cfe8ed032d07e91c8314851": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-markupsafe-1.1.1-10.fc34.x86_64.rpm"
+          },
+          "sha256:da676955f475492f17c573bc526d47c37e34919d2a6ed33ec4573a4de0cab2a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/lz4-libs-1.9.3-2.fc34.x86_64.rpm"
+          },
+          "sha256:de675241db34363c2f99d4434ea342cdd8c1178a30d51b2a55ce1666b0ac426a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gawk-all-langpacks-5.1.0-3.fc34.x86_64.rpm"
+          },
+          "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.x86_64.rpm"
+          },
+          "sha256:decef5a0fec1ae8589088a1ff822f6a1f3290208d516de675dbed955414249db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/pigz-2.5-1.fc34.x86_64.rpm"
+          },
+          "sha256:df22e432aaecb2059b714760bf075922af83e21e0ed5fdbca3185c4871d83c04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/openssl-libs-1.1.1l-2.fc34.x86_64.rpm"
+          },
+          "sha256:df6e40a2f87fb634126d1a97d19b6f45a3623cf108a2dd1653608891e1d12deb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rsync-3.2.3-5.fc34.x86_64.rpm"
+          },
+          "sha256:df8f70b98e21e38a9b6449436d1ab3663fd1a7602a1be4c4d32bffba3a2831b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libfido2-1.6.0-2.fc34.x86_64.rpm"
+          },
+          "sha256:e035a5041c721ea40e47cbbc19eb1b91c520183f85137ee1dd3ed3b42a47c180": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-cloud-34-39.noarch.rpm"
+          },
+          "sha256:e0b9fbbfc90d70bff8c64adc104a46b2bc4d9705720d2955468309c9a6d84610": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/i/iptables-legacy-libs-1.8.7-8.fc34.x86_64.rpm"
+          },
+          "sha256:e0dffa204780c20c16357a51b992351aa1cf9f9cdda6182939ecd0cd7ab2c2bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-jsonpatch-1.21-14.fc34.noarch.rpm"
+          },
+          "sha256:e3f0e950f5c8b2039821cd589f3d3fb9a01f0a8da953f05f77fd3c548fe4f2ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libnetfilter_conntrack-1.0.8-2.fc34.x86_64.rpm"
+          },
+          "sha256:e43f96ba7bae364527936f5c55f9d3949a97ecf37f57b3cc80b7d9bf93a17cb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/less-590-2.fc34.x86_64.rpm"
+          },
+          "sha256:e530795e5c9bc27de609fcbbacdc43c226026fee95e47a1f783f1c03ba5d48ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-distro-1.5.0-5.fc34.noarch.rpm"
+          },
+          "sha256:e5a2f667e1bf1be38b54b5bac3fca499b8992de7a66d678a25d3e0128e3f1587": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.x86_64.rpm"
+          },
+          "sha256:e5cbfb4aca5f7a97f08fc86b83c5ec57423a32a39de6d4909ce0126ed15f4cd4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libkcapi-1.2.1-1.fc34.x86_64.rpm"
+          },
+          "sha256:e61dc56977e3d8e506174f9959ea3b41ae987aeb515e8695fa9fb22f7f5c3d12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/x/xfsprogs-5.10.0-2.fc34.x86_64.rpm"
+          },
+          "sha256:e61e911fa03cd3436b05bdb4abcf48c5c78396419d161fe13b39dcd16e3abced": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gdbm-libs-1.19-2.fc34.x86_64.rpm"
+          },
+          "sha256:e76f1401d9e119eae4cc461c8b68e9eae075d4b69f61870cb5c19ba7d69cf1a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-policycoreutils-3.2-1.fc34.noarch.rpm"
+          },
+          "sha256:e7d1d0b85ac49d8b0c9dd3fce4613e6229ac8720cfb74c80a496b9f0beaa7a22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/cloud-init-20.4-2.fc34.noarch.rpm"
+          },
+          "sha256:ea89f3a15fdd80587a928ec156bdbdb1321c01c4c753e4eca036584e575e7e2f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/curl-7.76.1-12.fc34.x86_64.rpm"
+          },
+          "sha256:ea9851b961b645165a931d3953ec4f0c6d35eb917ac7a982fd52fa847768fc31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.x86_64.rpm"
+          },
+          "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.x86_64.rpm"
+          },
+          "sha256:eb88e660b9fd02e695a90c0266831b79e513c2f65ba5d6353e82726af96e9752": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-repos-modular-34-2.noarch.rpm"
+          },
+          "sha256:ecb6266488947b43138644864dc54c81bc0e10ea55fbde7100e699da45dfeb29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libbrotli-1.0.9-4.fc34.x86_64.rpm"
+          },
+          "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm"
+          },
+          "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.x86_64.rpm"
+          },
+          "sha256:eecc86b828ad436a9f397d2f7acdf5705bfd36bcad3edd2da73f3acc94363411": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc34.noarch.rpm"
+          },
+          "sha256:ef22650f127e4109d16f6bb795277f4bee328eaaaac39ec7c43aa2053f5f770f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/syslinux-nonlinux-6.04-0.17.fc34.noarch.rpm"
+          },
+          "sha256:ef9a875e12eb5f50864325121e648a54165aeec9a2b7da12e1630a57c2c33c22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libxkbcommon-1.3.0-1.fc34.x86_64.rpm"
+          },
+          "sha256:f1f078ebde340cb37f7049555e78906b54e42ce22703e878305783a4b91e0477": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc34.x86_64.rpm"
+          },
+          "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-urllib3-1.25.10-5.fc34.noarch.rpm"
+          },
+          "sha256:f43356bc92e900004026937f9af3b350f7298b5040ec30fefd4e260bcaea6540": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-networkd-248.9-1.fc34.x86_64.rpm"
+          },
+          "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-doc-2.33-20.fc34.noarch.rpm"
+          },
+          "sha256:f534a9f0cea9cbfbc580083a80b7965a642ca6299d990edee23f7e49079314c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libselinux-3.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:f53686de3cd500fb010b54f69f7220e4c313453ca5a9aa6c3bbe94566725e838": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-2.33-20.fc34.x86_64.rpm"
+          },
+          "sha256:f5630307e59bd28ac9f87ff56ebaf1752a7b3b79d655771b4a98bbe701573e38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libedit-3.1-38.20210714cvs.fc34.x86_64.rpm"
+          },
+          "sha256:f58b4687fec5132064c12041f9356a2713c94b31c70c5afdc384e76992d13234": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/i/iptables-libs-1.8.7-8.fc34.x86_64.rpm"
+          },
+          "sha256:f5c0b6b252acb19f9b7e3b066be252e6bc9812642fe2e76009ffed365140e236": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libsss_certmap-2.5.2-2.fc34.x86_64.rpm"
+          },
+          "sha256:f5f5c988604aa5c870eee7efff6d40f26acb908cf82991d762ade18c8b46aff6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/device-mapper-libs-1.02.175-1.fc34.x86_64.rpm"
+          },
+          "sha256:f61173014cf0d8423088cd705352faed48e83a1b13fc33d8af0bfc12dd04f240": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc34.x86_64.rpm"
+          },
+          "sha256:f6829710ec06b6df70e98f39d197e66c3b42bf53443a83929651ef366f2aea14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/j/json-c-0.14-8.fc34.x86_64.rpm"
+          },
+          "sha256:f68c93c0461c149bb17282dededf421cbc1fbfa5ac133b59bd362526f59e0d57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-idna-2.10-3.fc34.noarch.rpm"
+          },
+          "sha256:f792d09a27deb8c45c2f0887351a3bea684b79ccb6127f8c59512f8866016daa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.3.6-1.fc34.x86_64.rpm"
+          },
+          "sha256:f7f8832ccaedd7ddad064956309478b9bf366f0576517356ee68481e196236cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-configobj-5.0.6-23.fc34.noarch.rpm"
+          },
+          "sha256:f83c97898b9c7fd3d2593faf8ac86e25648dab37057fafd822f1f2c04580c1c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libpipeline-1.5.3-2.fc34.x86_64.rpm"
+          },
+          "sha256:f85364e3d8b5896793728102ff59107a78fbe916da3b7ce5146ff97bc68e0c01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/f/findutils-4.8.0-2.fc34.x86_64.rpm"
+          },
+          "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm"
+          },
+          "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm"
+          },
+          "sha256:f8bf13c71c043e381a419b8e3fe45f6708b798db9e93ff04f261fcb0d690b46c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/iputils-20210202-2.fc34.x86_64.rpm"
+          },
+          "sha256:f9677c1a279cc002d15383edefb3fcdd6355076729ff337a5ca49436ab653cd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libutempter-1.2.1-4.fc34.x86_64.rpm"
+          },
+          "sha256:f9b2e7232d0b2d33bf52993c31b43b31520601f52f44fe792acd6dee4d84afc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-oauthlib-3.0.2-9.fc34.noarch.rpm"
+          },
+          "sha256:fd9453e9740feb7aa070fffc2b83ebddedca4d42c9f886843197b626ab4ba131": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libmaxminddb-1.5.2-1.fc34.x86_64.rpm"
+          },
+          "sha256:ff16ef3ab82ad4c43f743e4f2569988b4ca2fcd8018cf048d856847687c3a16a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libmnl-1.0.4-13.fc34.x86_64.rpm"
+          },
+          "sha256:ff4a45abbcd1f1720a1dd0f46328ff987f7cc75474395db90967a3de50022605": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsigsegv-2.13-2.fc34.x86_64.rpm"
+          }
+        }
+      }
+    },
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.rpm",
+              "options": {
+                "gpgkeys": [
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n"
+                ],
+                "packages": [
+                  {
+                    "checksum": "sha256:c540ca8c5e21ba5f063286c94a088af2aac0b15bc40df6fd562d40154c10f4a1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:15a654d32efaa75b5df3e2481939d0393fe1746696cc858ca094ccf8b76073cd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:caa41935dc130081a607caccac5db4bc5b1963c781ba4ea43aa525b5aaf0f51e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9a698a5991a08e23e87b4bce2f3e447eafdc7fd4d84a49d91c65c6045ead1e8e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9bff70d51ecec129854ef62d82204db3e01706c444b966cb048bc7fd8ec8b524",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6ddbf894c0a7542ecc5a641bde06659c5a80cd954fcfd2f9e558885e81724d60",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b4e47421cbc842d53d14fb00b31bdb10bdddd1571dcaffbe258fa3a8c5be0500",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5fb88eb681e996ab2199251a68c79b2797fa03d31a36dae698de393b85e1f89e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f5f5c988604aa5c870eee7efff6d40f26acb908cf82991d762ade18c8b46aff6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c58752e2529cf0ea4aabb0476ef53ca7748091aa936513affc1245928ae5b1b8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:509a2067a88eb29ddc4b66078401bbbe6c938c968b876bcb2d74c469e7327fcb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:377d141bf5e1dca120216e9cc478c31fceace604f0ba2b2bc51497efbf00b7df",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b7dac3f2d8feaffb21a6ec0503559448ad99096b50ff0d33a8a2107dbb23a8f2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b554175a1dea7562b6d2810eb7bf41b11c01beb430479764401318785e6f85cc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f85364e3d8b5896793728102ff59107a78fbe916da3b7ce5146ff97bc68e0c01",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1816bd5b8dee276e7174ec06256bcc5f699b8a1c2203995bf84210590c52b0ad",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:baa55f06cacd3b30db59ebc42f4967d3d15dcd20fab4cb269913c0f991078220",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:de675241db34363c2f99d4434ea342cdd8c1178a30d51b2a55ce1666b0ac426a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e61e911fa03cd3436b05bdb4abcf48c5c78396419d161fe13b39dcd16e3abced",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a858b65eb278c40507abdccb587bdc0c6edb2960ec51f5bfe3d774900079694c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7e130c0f39168b8d442e8bf9ca17046f7ca6210bda0d5526a2b6b34ccfa22816",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e4fe80ef8c8799a3210290687f039b1c35de7f8c9c6644b3faf323946e38df0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:34bfb7bc369a50204f70d5a7f538f543a4ef053d36d48b74be62bb1ea8fa8187",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c5084b5bf90349032858699526d1c75606ab3d848bd4f90d320126f2e22b1957",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f6829710ec06b6df70e98f39d197e66c3b42bf53443a83929651ef366f2aea14",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e5a2f667e1bf1be38b54b5bac3fca499b8992de7a66d678a25d3e0128e3f1587",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0f4616a09f18ba7902f87ef22024a6692379272df2b66bb3c9d4d12771533fff",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:26abfb8ae9df36d7daab0590f40bbb794a495943fc317e9f2073fe8301058c72",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:81778d572983ef362a31c301ad8c7ac191a1fff2e65177918b85b67fc46c51cd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:713e64ea709d4b34ab814a3466babebb3985648a5b6b87c327f50f6d1aefb7f6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:732d4e5a9eab39a0310aaf317c76445e9579c7b0b913a3dc1eccd0bb8454be83",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0c37bbf98383679eb0f1cab44d20d3c0ca5e981a887152b64d1078c7734643e3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ecb6266488947b43138644864dc54c81bc0e10ea55fbde7100e699da45dfeb29",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:aa59709bb1397e17d4f202baad4a28ae872e40fc50b5bee5b400b2a06095d3cb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a04bd8e79ca9948ef5ec386bf78edd60c367d487f82832902de6dcb7ce2b5ed1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6a84fac2aa4beec617e596818b06a5f154f678e666f1c4601c972828e22aa22a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2e2ee3306a607ffc6ab2bd0e398e7a176f45c55ede9c55462632cbf7d100723a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ac6dbb4d55388f795b15f0339116978bca4fc0231eaa7fa7faaddc77bb9aa74a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:364583b4cc9a12e344dadc1e3e734ab92882c4bf8d6731ffa0df752f36258834",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e5cbfb4aca5f7a97f08fc86b83c5ec57423a32a39de6d4909ce0126ed15f4cd4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7b28a2f43e2f7f08930073e2fe4792e059cbe9a40b8996f90346f4989706dc19",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e43c033af22ac108085cafbd1de5032a3642162abe06c0fc8fff1a10e61f629",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5311161abf68dee473cd5b868a7a35aef1e98c017b29d9269c71d598143d301b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7f2ee88a233ab8860662b45ec5eb853171bad68703715ad4e8aa2ac8f00ee45f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:72539a2021ed64458eef5a82c1ea0fea965e9a21d2455aac7a501f932fe006c6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f534a9f0cea9cbfbc580083a80b7965a642ca6299d990edee23f7e49079314c0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7af59d2a7a1885369a75b0038fe2ee16743f68db1925572b440b5b1c354e8412",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6e72ff4bf990a5da1251ff8578c67f44afa361aa844f51eeabf1a82fc2221c59",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ff4a45abbcd1f1720a1dd0f46328ff987f7cc75474395db90967a3de50022605",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:60c79833b164f6dad8f7e0f330b993e9602a2357612f3157f31df8ebfa833d11",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8f08844eec04f5765bdf73b02625fb360c5a2051d66752fec9b6446105ee018a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:af1a24d15612b0b750cd24b74a1cb38131dcf09049187c283e244a5d3a64e789",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:00df260cd7acacb1e122f460046816e12f39566951ab39ccbc61c33b1c912aee",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d564ebb4b69df5f5b757808844038c0876afd4c9a4f573092f1731c10ac9d63e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f9677c1a279cc002d15383edefb3fcdd6355076729ff337a5ca49436ab653cd7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:23a58f476dd47e7d92378060efa995a7c96c521b9d1532509e91460da73181f8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:da676955f475492f17c573bc526d47c37e34919d2a6ed33ec4573a4de0cab2a7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0214ae16ef6a92843a4973aeda93db85584ad7840b1dd6e225bc57b594f58961",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a823a3f73c688a0a0bd9f049ece18574d15f361e0f4cbc5b66d1fa953b33b659",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:98cb29680e00e102bd8e6ba1e8b079291823fd64a0e4adaf7631710e690bd27d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0359a21c768977e0f589ee424690a905ea2f13dd0caf410ac1602d8807f77709",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2595a15421c2de026658c7a4ed3eb46706bb16d2df63986eca4574fd87d72fb2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9256f1e9d9e996de69764019fe5e9e11b89f5db854aff3a8cb4a82a4a34eddfc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7aab572608f77cf21be095a49046ab43dcacce130973e947707614d8aff55278",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7dc85c364a4be27e065db7ef90a3049e37e8d4c03d5b46ad88d3c9b255070b44",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:decef5a0fec1ae8589088a1ff822f6a1f3290208d516de675dbed955414249db",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:039719fc5f330260fc2cdac9f77618841a2aa1a35d6fd417a47312d4eb5bedd3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b37452649da277bc6f1e80f8c2250a16aa877444e1dcbba0d3546eef7d6fcda3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b34c767bab93fb626c993b98e10547779fa5bec98865b9a66b914e45b4b14f6e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8857513982b0c12e02eb0593baa9dc7cf570f2761a6bb4996fc8cf7d98402444",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:38731e49cb0ee6a0d98f736ec1ee5605ed3a12cf3c119bb3f140ccf42500d6b3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a0b294cdc4585a0ac04fdc6f84a4fdc08f10afcaebe28ec60370622d43bfe33d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ea9851b961b645165a931d3953ec4f0c6d35eb917ac7a982fd52fa847768fc31",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:019c0bdb989459f7aed88f534cf96af8e720cb5a0ffa7d514f6b8de5e62eb9e3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b53a61b34e0bc3cc693bcb82e1e494d201098db149dd38106cb97b6923ec3093",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8242972295a6a3d2426ed7756eabb0fb2eabe871894399375a54271ddec56d14",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:237a8756303db7712e91d2b52c428464b401b3295c6c50c5d23a2ebef2f88beb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c8e0cdf3260afc4ce9c115f30df68182faaa02944cdaeeb5c20161430f82c8e5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0ebe43a9bef7ec2dc4cb98350fbde2e55dae886f905e2d9cea837da3fb613c87",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6c5db6a0eb030c42b41b8e533c559ef81967dbb513d539754ff79b6c407d80d9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1eead3a3a0b0ff0a9776309d838e0b154f6ad64f1e4a59dc773f3159c118dff0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c568c7d0939faa7f3321d95d16ad6c84fb1e81e3c5b14b40bccc61fc3574bbc4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8d75d66318cdf547cf7f141e149abd7fbaddf33eea71156e32f5b68edcfa81ec",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f792d09a27deb8c45c2f0887351a3bea684b79ccb6127f8c59512f8866016daa",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ea89f3a15fdd80587a928ec156bdbdb1321c01c4c753e4eca036584e575e7e2f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bccfdce40119616d620fa9ddc61876a471ce2cf6f558d226910454f5b289d5b7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6351c0b6cb6af4444e033c0558727e92298695eda47492af65a678e13a6ee1f2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f1f078ebde340cb37f7049555e78906b54e42ce22703e878305783a4b91e0477",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3b7916a277cd7dac44e861b56c0915977f36396d5b4f5007508bf7c90f93e7bf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:59cfafb5b96fdb1d219743aaf3dfc72de9f2da527efc9c9db3c87815cade7517",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3e69e8412d5914ec01c5e82264833698e92a1b88a7c7b5ed9b1f0351fc91f5d2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6d1c024b295c423746b44f120cf36ceb0fd898f8ce5a276813d7c78a3c8ece52",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d5f486b818d86d5f79a5dd619b24abc039496801fb3d54134322715a9c6b489f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:442415a2b11394c551e9d3496a325e0365b726543981d98a12e5910eced08115",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c14d10994b488aa8f6b78f2aa3850fc4dbf8d791868d08aef8e929780d5012d4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f53686de3cd500fb010b54f69f7220e4c313453ca5a9aa6c3bbe94566725e838",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e9ab9dc0035e220a6e470553ce4d2fdba896a6630c8e70abee00659e0d8fc75",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c7b9527ce55677974b88c44bb541dc471512fcc3915665818b05b11c1cb7f119",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1480de09d5016b10258a24571534f4cdbbd644efb0799c40842f390f0cf65e91",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5a4b0cc50d9929ef558617fecd879f80a459379047ec77bcc238e5b305258bf5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6d1b00e8e758af552fcad8be95fa8250d561fbfaa727f8790ea06d72005444b1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e0b9fbbfc90d70bff8c64adc104a46b2bc4d9705720d2955468309c9a6d84610",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:066af2860b14cfc346263dc85c2d320e38d81d078bf3fd88130494a7717b282f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:29d944588a122ae56cc35c310dd202601e39e26964a7bf22d04819a5409c07ed",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1f445df6b58ea1c9eb76d8cc2c9ec2eba81c45f00603c2b9e84eb86e038d4f89",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0586d4ad14181d8cca2979449ebec2d4ce1fde826c77feaa91ab47902055abdf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d4b8f6fcbb1e1d0aca4d44bfd93f72e238b7ff35466c3f332d17a1354b6826c9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:af603a6e5e4696cfb1e7a4583940a46c5ef42de39778d55e08a7cde62bc14786",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:72b1000c285aa522fde63196bdeb3b32e1cff5859d345b753081cdad3cbd76d5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2acde8d21a1d5c88823fd667bbaac59a4af3f8ad47a9e833276f86e8cfcc2275",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c555acae201eda07e7f97a6d0c9d8e6d71065dca7efe3fb131f3b29fe1b080ce",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0ebb518a40590402136a181c5c0ec8d0c73d3074817bf94bd7a3937eb38ad107",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:55819abd7651c8f0e7449967933909fa2c6a0f939e90c6074d4831b633cc6adc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a7dd48e65cd9bc6254c71d51aa473f0e1a5d99baf1f8ea077652884098969e2c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:01c9d525eb77975631ff44b67e3ee65492445a3f1861f4f04a25be48218634a2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:46022a4e7d40f858d01fabd50bf2b22705022103d2708805e44ada62ed7ccfe2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:039f11c0333b49318e60b1fa8e5621f16363fe77fb76602eccc085d0897fbdb1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a2052ecaa71b5dae58df3b651ba3437b098a2a804e55336b819e95a5a49f23f5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f61173014cf0d8423088cd705352faed48e83a1b13fc33d8af0bfc12dd04f240",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:99bc964d8f2fc46e9ccdc567b159163b72a628432643bdd159464224a9d612c3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ef9a875e12eb5f50864325121e648a54165aeec9a2b7da12e1630a57c2c33c22",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d58e0ddac3c208aba6f507ea5df678dab7125dc3f741880cf831b1a76b0072de",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b58e6fd55e8018e6632ddddc0564201f5cffc314a521f28c9e923c86d760a648",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4a2ce807ef248c703b78d6f298a7e7eb64b08528aab890de5608c09e34d54f6c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:82473998562b047466a8082308e0e268f665e7a1bac3f7c74e124f2c37d80628",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a67d8e75329c0f5ab18a0b2a102351a09d2476f0479dea57d2dbb352245a7a03",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:45ee87897faec4ad216eb111f76ecde2e7f6b864e63bdff4daf10efc97447eee",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a196fc793d1578d7c4b423ec49bdf6ef0f792cb0f505fe8c708815315ac29d81",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:df22e432aaecb2059b714760bf075922af83e21e0ed5fdbca3185c4871d83c04",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6d01dc580d599af1fd761172c6aa9a602502f782179828586774b199e329ed16",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7d73ab186606e96644c34135f5e48e9407aff309d63f720b2d68aafc6797dfdd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c44e6efc9a521ad24b919d7fab92e8864913a2ea994a2134492720648150699f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cd33d7742606c567f01e0c2125121cc4fde549ed8789778a7f10ce58bd528aea",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:983a18e776aab5b2ae41f0cfa6a7da303de275f65f9d8c318b6ba99d19d3590f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c1f4a6f3bda5087a680c2a940fae2e02f0199c95a949dddc227390336681a405",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3b5f5b2129930d6eff8abcdadf70287fe92480c8deb9b622d1b31d7178e84e2d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b0d3b898968868b627f62a2f1b18257dc89f4e04c5c3adc8c25baa36c6cf5fa6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f43356bc92e900004026937f9af3b350f7298b5040ec30fefd4e260bcaea6540",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:90008dbecc37d3e4b9f495a2e2d92478094b6be272fb849017f8e3f51541e08f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1db042b9b66ec1f24b59cac5fbb7acced19ae474399862406bc6737b434a9de",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:867da92a40eadf047aa6c4127cd0858b514ecb372c4fcdcb63bba87473c99fd8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
+                    "check_gpg": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "org.osbuild.selinux",
+              "options": {
+                "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+                "labels": {
+                  "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+                }
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.fedora33"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8"
+          }
+        },
+        {
+          "name": "org.osbuild.rpm",
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF8sAZIBEADKYvLg/5FdLXcVryAFd7Q8qrJq23R7ebxUT1u48Dc8xrsfYJZq\naMcna/xw47wZNyek4Z6YpzqfmnjR7H8yRH/1hAPi/ixYnA6DVL7O3eGE5lYGJzN3\nE2ILTzBOI9o/pavvtOqW9N5WIus8cqSdA921v8YPzr3/BTKgGqC9biOrMA+3sNoe\nU4T+dztLg20SyBTr/rBH0eui2p/ipvIRuJvHLTKTubR+yG804yupI69M6qFBDebT\nrm+CBmwVyj/DY/92LgvCgYqV/TL5FU4qvtyB6jd8JkEeaz/G7UmDRB5JqzKEu6TB\nN3SY7nwLiRpIaXet1TWVW/8UKSB2JvYt1LbZyEO82/QOIXxqvV6h3kuBI21RvURz\nVxEjRlvPRGHMZ80OoAQqNPkLnVTcX1eLj2ClbwoXCmXFSm72cCCt1SzcAmlaWh8E\nrXSUZfs7XqkBrbphXHZ1e6Vxjt/RyKC5doklfOhbuF8gJ31CPo/kuOjFrHGzOwgi\nLlec+GHGMfI/cUOu59qo3W85GHsntvEMk83QLkKjBInEYjZSAajp/lS4QF+SD4pl\nQj6Vc1mMCmci61cXX5CcIl1YxNJZzUfZEZNbUjDajqGzkYJoG9n2yJB0w4OiqsAe\nZCirmUIeDUNeI082epc4RFuV33hByGYY9kRWSyM+aCF6PYVISj4l1o9KcQARAQAB\ntDFGZWRvcmEgKDM0KSA8ZmVkb3JhLTM0LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEjFummQvbJuGfKhqAEWGuaUVxmjkFAl8sAZICGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQEWGuaUVxmjlVuA//QnMA02tydqwpM7r4\nWZ4OvlVqFWHhn3oDaBSwBvn6R1oC0MWbr79nnFDn3tpSkZDUdb7wyArmaF8kG8tI\nwit5xD/JAzqRBVa9z2hY3n1SFafU/hp3DwbGIL4vLUv3fRayCgWsGhGp0tZvDC9q\nPSvQZ675XpRG4pt/TGJB5gGXw7Jxoae/ffaJeblLLRDlSV/bKJt9sYpdu5InDG2i\nyIUHfamtYQtnENKL/bN6w7tU/IEgCHqxPmPRiJ0gTUAi5Yabp1+JHqskE85Hm2QF\nxMonX595Ry1yZzCjPGhCPAknJ4BhisXV+E/iV3Jyh8vxbJCo1//ygd1Xz8SkCuu/\nI0xPtFcVSIP2ikYpJwR2nwwQlLbQYIGCw/S1LV725oEYm/Z1xQ5zha2hBB+fxSwz\n7MHsD2XIHrP8NNwt3ywG3NV/BSSkvSSStGUNcQyGRi3O/x/BEIRtWRxgoNO9o3jE\nxtWFq3G5+gKY+wfYz/cTGlsWPDG7Fzx4lNisIGATKtLNqdedl7LASPK93z0XDdnS\nkfKF0HrT9rdzIKRu4xWatUVIq/65Gv7nsavdsRAQL/Y0jl6sjjQac/Te5J0fByHY\n6tGG1W0UWTd0rzFWitEZI/64/Bs83rGhjJNLqWXItZ5VqLe0TWzuxvRFLfM7oX8r\nn5Si4l7NpIJubWPqjPoCoP5lsS8=\n=V2FG\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "packages": [
+              {
+                "checksum": "sha256:c540ca8c5e21ba5f063286c94a088af2aac0b15bc40df6fd562d40154c10f4a1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:15a654d32efaa75b5df3e2481939d0393fe1746696cc858ca094ccf8b76073cd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:caa41935dc130081a607caccac5db4bc5b1963c781ba4ea43aa525b5aaf0f51e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9a698a5991a08e23e87b4bce2f3e447eafdc7fd4d84a49d91c65c6045ead1e8e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5514af0678342f195a77718fdbf0a0ffddb3a66d5457c6e2f590f8236238ee95",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e7d1d0b85ac49d8b0c9dd3fce4613e6229ac8720cfb74c80a496b9f0beaa7a22",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6d1b95e06ec98f6d65c64e18fec693d379b98128a3e94b4dec8929321354c549",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1877af369228dd661ae1adfc43bbb8d53d3464d59ead0f5bcf6c2be88f8e8685",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3f7bde703045c2651fbd4142131ea1e303a565269388a08e2312af0eb83307a4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d2bac91a1969f555ea2641b161bb23fa0aaaffaba3284d9973ad696594b73f18",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:424f73b97c7d7541d35685108bdcddb03100cd0f3d6e0fd9def576462ca65b59",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9bff70d51ecec129854ef62d82204db3e01706c444b966cb048bc7fd8ec8b524",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6ddbf894c0a7542ecc5a641bde06659c5a80cd954fcfd2f9e558885e81724d60",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b4e47421cbc842d53d14fb00b31bdb10bdddd1571dcaffbe258fa3a8c5be0500",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:79834af7f95c0d1e5dcf85b794819bd854197a52d2966594abdb3c3de0fcceb6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5fb88eb681e996ab2199251a68c79b2797fa03d31a36dae698de393b85e1f89e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f5f5c988604aa5c870eee7efff6d40f26acb908cf82991d762ade18c8b46aff6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c58752e2529cf0ea4aabb0476ef53ca7748091aa936513affc1245928ae5b1b8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:377d141bf5e1dca120216e9cc478c31fceace604f0ba2b2bc51497efbf00b7df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b7dac3f2d8feaffb21a6ec0503559448ad99096b50ff0d33a8a2107dbb23a8f2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b554175a1dea7562b6d2810eb7bf41b11c01beb430479764401318785e6f85cc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f85364e3d8b5896793728102ff59107a78fbe916da3b7ce5146ff97bc68e0c01",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3fb05067cbd7fcf3283f2ab306c2dae668d818d3a69422e729c2ef62974810a5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1816bd5b8dee276e7174ec06256bcc5f699b8a1c2203995bf84210590c52b0ad",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:baa55f06cacd3b30db59ebc42f4967d3d15dcd20fab4cb269913c0f991078220",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:de675241db34363c2f99d4434ea342cdd8c1178a30d51b2a55ce1666b0ac426a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e61e911fa03cd3436b05bdb4abcf48c5c78396419d161fe13b39dcd16e3abced",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a858b65eb278c40507abdccb587bdc0c6edb2960ec51f5bfe3d774900079694c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7e130c0f39168b8d442e8bf9ca17046f7ca6210bda0d5526a2b6b34ccfa22816",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e4fe80ef8c8799a3210290687f039b1c35de7f8c9c6644b3faf323946e38df0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:34bfb7bc369a50204f70d5a7f538f543a4ef053d36d48b74be62bb1ea8fa8187",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2a63d1e893c95961c1d608bdbcf2acbdd51b045c74fa4827808a491ad424e929",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c5084b5bf90349032858699526d1c75606ab3d848bd4f90d320126f2e22b1957",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5e5e72cd1b7c708282657917de6f8aea198d308e30e42c9126994b7b4ccc3a64",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3714a372bb59bcc89ba5d971cbf6eb025b3ff964825309f04fbc7d6366df8cf8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11079b8f071c61c3a2a8556e3c9e406b188378969fa34f5bc0ce67b88c8e3799",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b017639e7e7602a981baa2a0d3b99bb484d2299a3b5a907cb6856ac80a31a359",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cf126ae271b434f9427b6e5531b3d5013688c6464740b9025f4a4548a6c69b14",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f8bf13c71c043e381a419b8e3fe45f6708b798db9e93ff04f261fcb0d690b46c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0c679ac467bc08e857adf5d1d8228e5a176fc06e74a3f30dbd5dab4843751163",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f6829710ec06b6df70e98f39d197e66c3b42bf53443a83929651ef366f2aea14",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5a2f667e1bf1be38b54b5bac3fca499b8992de7a66d678a25d3e0128e3f1587",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0f4616a09f18ba7902f87ef22024a6692379272df2b66bb3c9d4d12771533fff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:26abfb8ae9df36d7daab0590f40bbb794a495943fc317e9f2073fe8301058c72",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c20caffb4d2a500416dab0e8418a24ae5e25c02c831ae02ee10f97a0dcc80374",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:82cbc5e0339e832d2fc0160541c30f3dee59b3d28d83907ae7b55e22d5092c51",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:82b51ca6bec551d74a6d8c43194b0fd4e8bfdf19d1d68b58c1787723edd88bd0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:81778d572983ef362a31c301ad8c7ac191a1fff2e65177918b85b67fc46c51cd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:713e64ea709d4b34ab814a3466babebb3985648a5b6b87c327f50f6d1aefb7f6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:732d4e5a9eab39a0310aaf317c76445e9579c7b0b913a3dc1eccd0bb8454be83",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c70d5e913bea41a0a4795ce6a43dd3d9849009649035cc111227ccc007cf18da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0c37bbf98383679eb0f1cab44d20d3c0ca5e981a887152b64d1078c7734643e3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ecb6266488947b43138644864dc54c81bc0e10ea55fbde7100e699da45dfeb29",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aa59709bb1397e17d4f202baad4a28ae872e40fc50b5bee5b400b2a06095d3cb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a04bd8e79ca9948ef5ec386bf78edd60c367d487f82832902de6dcb7ce2b5ed1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7151baf126a07d4f20f91309433005b3552175a1adc03f907d772db9f374b6bc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68fa66fc992597c906349a67b60969f81c9548173e1eeb3e20bc3a2b20da626f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6a84fac2aa4beec617e596818b06a5f154f678e666f1c4601c972828e22aa22a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2d98ce375c70ac4038d9e69be1ef562197e8f966cc1e805f06c266131d478562",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2e2ee3306a607ffc6ab2bd0e398e7a176f45c55ede9c55462632cbf7d100723a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac6dbb4d55388f795b15f0339116978bca4fc0231eaa7fa7faaddc77bb9aa74a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:df8f70b98e21e38a9b6449436d1ab3663fd1a7602a1be4c4d32bffba3a2831b9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:364583b4cc9a12e344dadc1e3e734ab92882c4bf8d6731ffa0df752f36258834",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11253fdc73fbf71f3c5ff7d2b58d9967fc7525cf9a131f8ed0f69212e60f8bc1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5cbfb4aca5f7a97f08fc86b83c5ec57423a32a39de6d4909ce0126ed15f4cd4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fd9453e9740feb7aa070fffc2b83ebddedca4d42c9f886843197b626ab4ba131",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ff16ef3ab82ad4c43f743e4f2569988b4ca2fcd8018cf048d856847687c3a16a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7b28a2f43e2f7f08930073e2fe4792e059cbe9a40b8996f90346f4989706dc19",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:87a1e286ad30c1c123e44ef180d1f857896459fd685c66e80316a51b4687d44e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e3f0e950f5c8b2039821cd589f3d3fb9a01f0a8da953f05f77fd3c548fe4f2ac",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:193bae5dffa4c82249bfbbf3de479f048955a788a00e9c37c7667b820f36eb91",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e43c033af22ac108085cafbd1de5032a3642162abe06c0fc8fff1a10e61f629",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5311161abf68dee473cd5b868a7a35aef1e98c017b29d9269c71d598143d301b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7f2ee88a233ab8860662b45ec5eb853171bad68703715ad4e8aa2ac8f00ee45f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c060ffeb6d268d4ab20449af1a40c18f3eacb1aab5ef225f91e0c0bd08d65205",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f83c97898b9c7fd3d2593faf8ac86e25648dab37057fafd822f1f2c04580c1c8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:72539a2021ed64458eef5a82c1ea0fea965e9a21d2455aac7a501f932fe006c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3d7c3cbf81fc044d098692a1a9989d36120405a46f7f7b595091aa10cf687d84",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f534a9f0cea9cbfbc580083a80b7965a642ca6299d990edee23f7e49079314c0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7af59d2a7a1885369a75b0038fe2ee16743f68db1925572b440b5b1c354e8412",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6e72ff4bf990a5da1251ff8578c67f44afa361aa844f51eeabf1a82fc2221c59",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ff4a45abbcd1f1720a1dd0f46328ff987f7cc75474395db90967a3de50022605",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:60c79833b164f6dad8f7e0f330b993e9602a2357612f3157f31df8ebfa833d11",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8f08844eec04f5765bdf73b02625fb360c5a2051d66752fec9b6446105ee018a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ba877062b6d0746be4c66b6ff85e2b5265124532ae962d491ffed9d61bbde7bf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:af1a24d15612b0b750cd24b74a1cb38131dcf09049187c283e244a5d3a64e789",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d8dde242a8be009e1e0ce8ad0a513397d90b734181f0f6491245c327c81f5a4e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:00df260cd7acacb1e122f460046816e12f39566951ab39ccbc61c33b1c912aee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d564ebb4b69df5f5b757808844038c0876afd4c9a4f573092f1731c10ac9d63e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f9677c1a279cc002d15383edefb3fcdd6355076729ff337a5ca49436ab653cd7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:23a58f476dd47e7d92378060efa995a7c96c521b9d1532509e91460da73181f8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b9ca1ddf049221d91a9b74baf7964ce09259a87b778b8427a7a35d3646e128db",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cefa4197ff8c8664bbc28408953c223320cd448a2a120e22aec93c8baf39a954",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:da676955f475492f17c573bc526d47c37e34919d2a6ed33ec4573a4de0cab2a7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7f2e8cf1b8b1ae6c1e9cbfa60cc6083ba88aca1f42d1639b52c3fabf7ab68185",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0214ae16ef6a92843a4973aeda93db85584ad7840b1dd6e225bc57b594f58961",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a823a3f73c688a0a0bd9f049ece18574d15f361e0f4cbc5b66d1fa953b33b659",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2b5bfefcbf88c3c22670ed52b39a075ed2ac5beaaedd9b16c22004897f5186e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:98cb29680e00e102bd8e6ba1e8b079291823fd64a0e4adaf7631710e690bd27d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0359a21c768977e0f589ee424690a905ea2f13dd0caf410ac1602d8807f77709",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2595a15421c2de026658c7a4ed3eb46706bb16d2df63986eca4574fd87d72fb2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9256f1e9d9e996de69764019fe5e9e11b89f5db854aff3a8cb4a82a4a34eddfc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6a5f21dd77a32eb484b0573e6bb4fe1da9fc26c02d53a564fe41130c080b16cd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:701c7d913f25cbc506cc04cfca52d91287dec9c35066ba04eda7efafd1a8c0e4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7aab572608f77cf21be095a49046ab43dcacce130973e947707614d8aff55278",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7dc85c364a4be27e065db7ef90a3049e37e8d4c03d5b46ad88d3c9b255070b44",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:decef5a0fec1ae8589088a1ff822f6a1f3290208d516de675dbed955414249db",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:039719fc5f330260fc2cdac9f77618841a2aa1a35d6fd417a47312d4eb5bedd3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b37452649da277bc6f1e80f8c2250a16aa877444e1dcbba0d3546eef7d6fcda3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:05606b38ea83db0d4f5fea924caeda9a1b90eb9bd5fa7858278e90c3661bf26e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:820fee96d610178c7c7b8ce2b115bd02063d2f6dfcae5da4bf5d411de0b575f7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:50d06e862f369b217b1051c5e826bfdb15c795494bfc17283ab621804c1dba1d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9ce3f0c0904ac22ab5769babebf43e7dcdb488b0ef999b2e9e88a5b5eb424e51",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f7f8832ccaedd7ddad064956309478b9bf366f0576517356ee68481e196236cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0041b41276afd2846199a020fa769b7a3b504fae34b83cbad92f217b1d55e481",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d2c28837f0573ae2647b8fbba85f7c502f9c3da0a3eab1c9ba121de4a1a6cee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e530795e5c9bc27de609fcbbacdc43c226026fee95e47a1f783f1c03ba5d48ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f68c93c0461c149bb17282dededf421cbc1fbfa5ac133b59bd362526f59e0d57",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2414cb7345bc193f7ff7983c020c8b0e706aab013ee30af5d457d35c4de4a698",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e0dffa204780c20c16357a51b992351aa1cf9f9cdda6182939ecd0cd7ab2c2bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1b1af6b54050ec223c3289b107a9695a686c9d46d17a80ec9cd5d0201ec5d544",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d6810c97f24d93cd54a61bb288ada8591a94e4083b5165e0719915bceb637504",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9cc240ac305a862146e85d8dcc4ad981f5233a58b6901ecfac691d0b39966b49",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:131adc47f044c9f600f5295ded0f5431cda57fa7276100c3ec81c9d1ce3fa6f7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a27704e62c90406df6793be2c8e2cb1fa4919f761795bef604843f8894ab639",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a0ec96e637f6acb65409eb32f90fc9bccfd7fbfb494ded90106eb70eaf7cdd0b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d9bc0ebdccb79160632bc50abca0ec13fec191dd3cfe8ed032d07e91c8314851",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b30db4e3d9605e7263387ff91f91508667693d28e8b8835a2b7fcefd64f24388",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f9b2e7232d0b2d33bf52993c31b43b31520601f52f44fe792acd6dee4d84afc8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:23e3ed871799a9209915359f71660babf451b0b44902e3ed488b7b22aff37718",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e76f1401d9e119eae4cc461c8b68e9eae075d4b69f61870cb5c19ba7d69cf1a3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cc4401d1e292b28d771a2038081b929b342ffa3b60358aed91697fdbc668546a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:32220dc513a6ebcd4994e7140ecb5859108baf44d12fe6b1f0c0459dbefc54e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:70a90c6c682016e91fb4745eedbd23f28e150a38b01d18f85ce4e50fb4e0ca6c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4a74ae08a713e9b4e74ff27bfaf57374312370402f90e2796e66c504557ae189",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09a0a4702e0f716caaf6f8e75dc478d3d70bf3fbd074a76fb4d6f8492af7c138",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6297d7eee103c679a0f1ea411568d3940af3fe8f38e19388a1544df70bda8b3c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:581e6c46abab18afc9725f561894b0a41b9f3c15e778588a1874efb2324ef144",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5d5e7255c85c3aa9d63598ef140de35843ab2485adf1cb9a9130be80aa0297f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b34c767bab93fb626c993b98e10547779fa5bec98865b9a66b914e45b4b14f6e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:164e1c0e3e8c89aeda4f272b3158932649a69b16aea058105117a64d3cdef517",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8857513982b0c12e02eb0593baa9dc7cf570f2761a6bb4996fc8cf7d98402444",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:38731e49cb0ee6a0d98f736ec1ee5605ed3a12cf3c119bb3f140ccf42500d6b3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:df6e40a2f87fb634126d1a97d19b6f45a3623cf108a2dd1653608891e1d12deb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a0b294cdc4585a0ac04fdc6f84a4fdc08f10afcaebe28ec60370622d43bfe33d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ea9851b961b645165a931d3953ec4f0c6d35eb917ac7a982fd52fa847768fc31",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7d59ff94c9fa323e68c6f9d5b0ccc06075847d77775211f4acbee8f54d8975ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:84e5dd6e3ef3d1a8447fd8c5e71e7c5baca25d96b85440ef0c8e73a2209560c4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1a3c32056482e59ce2e6ef29270f6abb0567bcd0345b3d7fe76ff2b4e4bd8f7c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:10d3680b3b99f8585bf95ffb53e14e1d2956acd2c2d0f892c8cbf93a9861af12",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5afd3d5069dec788145b4fc51d2445d2c9ac021414b4821e99147dd66928d2cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ef22650f127e4109d16f6bb795277f4bee328eaaaac39ec7c43aa2053f5f770f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:019c0bdb989459f7aed88f534cf96af8e720cb5a0ffa7d514f6b8de5e62eb9e3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b53a61b34e0bc3cc693bcb82e1e494d201098db149dd38106cb97b6923ec3093",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8242972295a6a3d2426ed7756eabb0fb2eabe871894399375a54271ddec56d14",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e61dc56977e3d8e506174f9959ea3b41ae987aeb515e8695fa9fb22f7f5c3d12",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:237a8756303db7712e91d2b52c428464b401b3295c6c50c5d23a2ebef2f88beb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c8e0cdf3260afc4ce9c115f30df68182faaa02944cdaeeb5c20161430f82c8e5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0ebe43a9bef7ec2dc4cb98350fbde2e55dae886f905e2d9cea837da3fb613c87",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:344b1cc4edb49b7ac10f0d401fde43a2b67a61867652381825a24124d4af4d75",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8d171fb436059f8ae1ba31f762c35e3ff96304b0e48e59842502d697bc04cdd3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:54616250eab59e08603e591ff38c1b4929d7799996b4834225ed2920e73bb379",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6c5db6a0eb030c42b41b8e533c559ef81967dbb513d539754ff79b6c407d80d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:80044e9d36ea73df2b3f3a947384a93182c0dd81a724741c24ae2b967338c384",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4efbc2de7c8d2fcd78f542bf3e92a2d65084a08fff0a56f323c35ca0d4b98eb1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1eead3a3a0b0ff0a9776309d838e0b154f6ad64f1e4a59dc773f3159c118dff0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c568c7d0939faa7f3321d95d16ad6c84fb1e81e3c5b14b40bccc61fc3574bbc4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8d75d66318cdf547cf7f141e149abd7fbaddf33eea71156e32f5b68edcfa81ec",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68e068283ebde084fc71d7adbfd29e519f37416fb8bcf746f89693d1ce90d0f3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f792d09a27deb8c45c2f0887351a3bea684b79ccb6127f8c59512f8866016daa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ea89f3a15fdd80587a928ec156bdbdb1321c01c4c753e4eca036584e575e7e2f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2b9ff5e4d35b7ede55110ead06f4f2aa326e6a45040ea2638eb03d30d1fe113a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11cd6fae157eb9e4800163633b57bcce21d59a1df4b86a99ba03707b6cee0cfc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1feb6a045cb3e95e3c8e0112ecb4b8ffeb9986a503b52c5497fefce217846b90",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bccfdce40119616d620fa9ddc61876a471ce2cf6f558d226910454f5b289d5b7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:22ecb93be24849e734db3546e01dac762d152f22113b593b635544e256b98b52",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6351c0b6cb6af4444e033c0558727e92298695eda47492af65a678e13a6ee1f2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f1f078ebde340cb37f7049555e78906b54e42ce22703e878305783a4b91e0477",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b7916a277cd7dac44e861b56c0915977f36396d5b4f5007508bf7c90f93e7bf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59cfafb5b96fdb1d219743aaf3dfc72de9f2da527efc9c9db3c87815cade7517",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d54b628e6d0b7813ec0b4cc0beb1b8f3f8510ffbaff8ae1d9c4b9993095e4edf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e035a5041c721ea40e47cbbc19eb1b91c520183f85137ee1dd3ed3b42a47c180",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eb88e660b9fd02e695a90c0266831b79e513c2f65ba5d6353e82726af96e9752",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d5f486b818d86d5f79a5dd619b24abc039496801fb3d54134322715a9c6b489f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:442415a2b11394c551e9d3496a325e0365b726543981d98a12e5910eced08115",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c14d10994b488aa8f6b78f2aa3850fc4dbf8d791868d08aef8e929780d5012d4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f53686de3cd500fb010b54f69f7220e4c313453ca5a9aa6c3bbe94566725e838",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e9ab9dc0035e220a6e470553ce4d2fdba896a6630c8e70abee00659e0d8fc75",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:923316dcae9e2da6a7ca355e9c26242cdc8bf21cd09a58934b3de297f6f12eba",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1480de09d5016b10258a24571534f4cdbbd644efb0799c40842f390f0cf65e91",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5a4b0cc50d9929ef558617fecd879f80a459379047ec77bcc238e5b305258bf5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6d1b00e8e758af552fcad8be95fa8250d561fbfaa727f8790ea06d72005444b1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3d6181aa04e1bd81bc2f6d8eb2e5ddf5b18cd1ee8567815ecbf5932393a09f45",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e0b9fbbfc90d70bff8c64adc104a46b2bc4d9705720d2955468309c9a6d84610",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f58b4687fec5132064c12041f9356a2713c94b31c70c5afdc384e76992d13234",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:547588862120dc0431fa1687ca22b8723114b68aa5c21b95f28055ed556faf2a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:98f64ee7318237900c77a4dbf078e3a9dfda7fe907bc9eab9a45e27b2a2d0222",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:231740a6624ac820b99bdc0084b4aab99d0d3466a7f0b828cc5451f3ccd251ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:066af2860b14cfc346263dc85c2d320e38d81d078bf3fd88130494a7717b282f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:29d944588a122ae56cc35c310dd202601e39e26964a7bf22d04819a5409c07ed",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1f445df6b58ea1c9eb76d8cc2c9ec2eba81c45f00603c2b9e84eb86e038d4f89",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e43f96ba7bae364527936f5c55f9d3949a97ecf37f57b3cc80b7d9bf93a17cb9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0586d4ad14181d8cca2979449ebec2d4ce1fde826c77feaa91ab47902055abdf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d4b8f6fcbb1e1d0aca4d44bfd93f72e238b7ff35466c3f332d17a1354b6826c9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f5630307e59bd28ac9f87ff56ebaf1752a7b3b79d655771b4a98bbe701573e38",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:af603a6e5e4696cfb1e7a4583940a46c5ef42de39778d55e08a7cde62bc14786",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:72b1000c285aa522fde63196bdeb3b32e1cff5859d345b753081cdad3cbd76d5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2acde8d21a1d5c88823fd667bbaac59a4af3f8ad47a9e833276f86e8cfcc2275",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c555acae201eda07e7f97a6d0c9d8e6d71065dca7efe3fb131f3b29fe1b080ce",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0ebb518a40590402136a181c5c0ec8d0c73d3074817bf94bd7a3937eb38ad107",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:37ccd5908e2e2c6a0ded948ffb7cb232f87515fa917bf1651226f6a5cf48b5ed",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5cdb39c3cd9ddffe4e363ab60e64838858751547bc547f2cbf9d35c4a36febd4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:55819abd7651c8f0e7449967933909fa2c6a0f939e90c6074d4831b633cc6adc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7dd48e65cd9bc6254c71d51aa473f0e1a5d99baf1f8ea077652884098969e2c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:01c9d525eb77975631ff44b67e3ee65492445a3f1861f4f04a25be48218634a2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:46022a4e7d40f858d01fabd50bf2b22705022103d2708805e44ada62ed7ccfe2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8b11a97c1d2e28518505364fb1f8bf940e2a5203e80ea6f0cde11cfc420e0a3e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f5c0b6b252acb19f9b7e3b066be252e6bc9812642fe2e76009ffed365140e236",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b3200e9726d4a0def9df15d6cef100a27f928aa198609940c3889f33ee635557",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cbcd2e59caa454c8dc7a91c807189fad07a5ad6b4097e9a8c66eb169f911f127",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:91cdce1b6c90021c8174afd1ab36afab4fab67cb9a8f5df7516fa81c40061015",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:039f11c0333b49318e60b1fa8e5621f16363fe77fb76602eccc085d0897fbdb1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:12e04c0e335343ce1c87f4a13f22faa3fc8305ad0cc74fa6d755997ddd82ba3a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a2052ecaa71b5dae58df3b651ba3437b098a2a804e55336b819e95a5a49f23f5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d3494b25cf8bac271fe6b58b149c424e1a438583ffa0808f0750d8e662b305a8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f61173014cf0d8423088cd705352faed48e83a1b13fc33d8af0bfc12dd04f240",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:99bc964d8f2fc46e9ccdc567b159163b72a628432643bdd159464224a9d612c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ef9a875e12eb5f50864325121e648a54165aeec9a2b7da12e1630a57c2c33c22",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d58e0ddac3c208aba6f507ea5df678dab7125dc3f741880cf831b1a76b0072de",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b58e6fd55e8018e6632ddddc0564201f5cffc314a521f28c9e923c86d760a648",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8ab032e2a86f300d978e521ab030db1e7bb7eeccca205a5d2a4d68b51566f43f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4a2ce807ef248c703b78d6f298a7e7eb64b08528aab890de5608c09e34d54f6c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:82473998562b047466a8082308e0e268f665e7a1bac3f7c74e124f2c37d80628",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a67d8e75329c0f5ab18a0b2a102351a09d2476f0479dea57d2dbb352245a7a03",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0c9434feed1a753e13e76a5cce78ffbef99e8dbce74edd23d73af3627b8cd928",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:45ee87897faec4ad216eb111f76ecde2e7f6b864e63bdff4daf10efc97447eee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a196fc793d1578d7c4b423ec49bdf6ef0f792cb0f505fe8c708815315ac29d81",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1b13e55eb2a2e9b7a01031e26f04655eec54a453831c9d68db25932d20e58453",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d737d05827d680cece3b0e6bb32a64f73562d99cfcba16d09ee765134d9a0826",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bcd3d68e3e86e62ac4f241cb3aebb35afd58c96558afabe5915a301291b90869",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:df22e432aaecb2059b714760bf075922af83e21e0ed5fdbca3185c4871d83c04",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6d01dc580d599af1fd761172c6aa9a602502f782179828586774b199e329ed16",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7d73ab186606e96644c34135f5e48e9407aff309d63f720b2d68aafc6797dfdd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c44e6efc9a521ad24b919d7fab92e8864913a2ea994a2134492720648150699f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ae8410b779aaa5a5ed108d6b95fd7c2b1fb13f92a06d7c28383f233dcb1c47c7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59cc4d563ecb4c8b517f5dd7505f1cda297f950f32fc700344aa7789b69ca99c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6492193577a35112cac513566a71ee3d4cc40c7c2fb84a83a73698b320c2972f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bab19da8b6f553325decae00748f88fc0924b918136f065ab8995e1ebf5bde5b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cd33d7742606c567f01e0c2125121cc4fde549ed8789778a7f10ce58bd528aea",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:69773821114b06ee0e5720178f33323d32434ee67ada19a3535d7cc6cc84aaaf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eecc86b828ad436a9f397d2f7acdf5705bfd36bcad3edd2da73f3acc94363411",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:983a18e776aab5b2ae41f0cfa6a7da303de275f65f9d8c318b6ba99d19d3590f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c1f4a6f3bda5087a680c2a940fae2e02f0199c95a949dddc227390336681a405",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bc67ce199727a497116c32ad260bf75c90ffeab9fa45960c2f7d8f725ffc87c0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11f35d539334ee51f49c19be2ef596082e818511638070a9d41a4681fa61d279",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac474501243d1a59ad02fdea585eaf523cd3d1aefeceead4f697fc92e3c30632",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:66f820e1083c42d6a6b29a880720fd03a79edc66f32f8bc94e44461feafb02bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b5f5b2129930d6eff8abcdadf70287fe92480c8deb9b622d1b31d7178e84e2d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b0d3b898968868b627f62a2f1b18257dc89f4e04c5c3adc8c25baa36c6cf5fa6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f43356bc92e900004026937f9af3b350f7298b5040ec30fefd4e260bcaea6540",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:862eaaa6e3a3cee2baf0bf4027c85d513d1a16edb8cdf7814208e0b4f0c66db0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:90008dbecc37d3e4b9f495a2e2d92478094b6be272fb849017f8e3f51541e08f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1db042b9b66ec1f24b59cac5fbb7acced19ae474399862406bc6737b434a9de",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:adcd36cb0e582f5fb2d0465cf88bb813ffac17d25d6ec8aa608b647d008bebc3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9e879df34e32ec5085e9863adb1221d2cb6b1cea1b4bd7d2345d7bfe91f66897",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:867da92a40eadf047aa6c4127cd0858b514ecb372c4fcdcb63bba87473c99fd8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30bc3583e503e0f459e323b27551f7b9a8ab784de15437b5b29f447b31f8d9cd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
+                "check_gpg": true
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.hostname",
+          "options": {
+            "hostname": "localhost.localdomain"
+          }
+        },
+        {
+          "name": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "legacy": "i386-pc"
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
+        "options": {
+          "format": "qcow2",
+          "filename": "disk.qcow2",
+          "size": 2147483648,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
+            {
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build-packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/a/acl-2.3.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:c540ca8c5e21ba5f063286c94a088af2aac0b15bc40df6fd562d40154c10f4a1",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/a/alternatives-1.15-2.fc34.x86_64.rpm",
+        "checksum": "sha256:15a654d32efaa75b5df3e2481939d0393fe1746696cc858ca094ccf8b76073cd",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/b/basesystem-11-11.fc34.noarch.rpm",
+        "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/b/bash-5.1.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:caa41935dc130081a607caccac5db4bc5b1963c781ba4ea43aa525b5aaf0f51e",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/b/bzip2-libs-1.0.8-6.fc34.x86_64.rpm",
+        "checksum": "sha256:9a698a5991a08e23e87b4bce2f3e447eafdc7fd4d84a49d91c65c6045ead1e8e",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "10.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/cpio-2.13-10.fc34.x86_64.rpm",
+        "checksum": "sha256:9bff70d51ecec129854ef62d82204db3e01706c444b966cb048bc7fd8ec8b524",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/crypto-policies-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "8.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/cyrus-sasl-lib-2.1.27-8.fc34.x86_64.rpm",
+        "checksum": "sha256:6ddbf894c0a7542ecc5a641bde06659c5a80cd954fcfd2f9e558885e81724d60",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-1.12.20-3.fc34.x86_64.rpm",
+        "checksum": "sha256:b4e47421cbc842d53d14fb00b31bdb10bdddd1571dcaffbe258fa3a8c5be0500",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-common-1.12.20-3.fc34.noarch.rpm",
+        "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.x86_64.rpm",
+        "checksum": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "8.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm",
+        "checksum": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/device-mapper-1.02.175-1.fc34.x86_64.rpm",
+        "checksum": "sha256:5fb88eb681e996ab2199251a68c79b2797fa03d31a36dae698de393b85e1f89e",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/device-mapper-libs-1.02.175-1.fc34.x86_64.rpm",
+        "checksum": "sha256:f5f5c988604aa5c870eee7efff6d40f26acb908cf82991d762ade18c8b46aff6",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "8.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.x86_64.rpm",
+        "checksum": "sha256:c58752e2529cf0ea4aabb0476ef53ca7748091aa936513affc1245928ae5b1b8",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dosfstools-4.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:509a2067a88eb29ddc4b66078401bbbe6c938c968b876bcb2d74c469e7327fcb",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.x86_64.rpm",
+        "checksum": "sha256:377d141bf5e1dca120216e9cc478c31fceace604f0ba2b2bc51497efbf00b7df",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.x86_64.rpm",
+        "checksum": "sha256:b7dac3f2d8feaffb21a6ec0503559448ad99096b50ff0d33a8a2107dbb23a8f2",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/f/filesystem-3.14-5.fc34.x86_64.rpm",
+        "checksum": "sha256:b554175a1dea7562b6d2810eb7bf41b11c01beb430479764401318785e6f85cc",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/f/findutils-4.8.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:f85364e3d8b5896793728102ff59107a78fbe916da3b7ce5146ff97bc68e0c01",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "11.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/f/fuse-libs-2.9.9-11.fc34.x86_64.rpm",
+        "checksum": "sha256:1816bd5b8dee276e7174ec06256bcc5f699b8a1c2203995bf84210590c52b0ad",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.x86_64.rpm",
+        "checksum": "sha256:baa55f06cacd3b30db59ebc42f4967d3d15dcd20fab4cb269913c0f991078220",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gawk-all-langpacks-5.1.0-3.fc34.x86_64.rpm",
+        "checksum": "sha256:de675241db34363c2f99d4434ea342cdd8c1178a30d51b2a55ce1666b0ac426a",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.19",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gdbm-libs-1.19-2.fc34.x86_64.rpm",
+        "checksum": "sha256:e61e911fa03cd3436b05bdb4abcf48c5c78396419d161fe13b39dcd16e3abced",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gettext-0.21-4.fc34.x86_64.rpm",
+        "checksum": "sha256:a858b65eb278c40507abdccb587bdc0c6edb2960ec51f5bfe3d774900079694c",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gettext-libs-0.21-4.fc34.x86_64.rpm",
+        "checksum": "sha256:7e130c0f39168b8d442e8bf9ca17046f7ca6210bda0d5526a2b6b34ccfa22816",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gmp-6.2.0-6.fc34.x86_64.rpm",
+        "checksum": "sha256:0e4fe80ef8c8799a3210290687f039b1c35de7f8c9c6644b3faf323946e38df0",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.x86_64.rpm",
+        "checksum": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.x86_64.rpm",
+        "checksum": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.x86_64.rpm",
+        "checksum": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/grep-3.6-2.fc34.x86_64.rpm",
+        "checksum": "sha256:34bfb7bc369a50204f70d5a7f538f543a4ef053d36d48b74be62bb1ea8fa8187",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "51.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/grubby-8.40-51.fc34.x86_64.rpm",
+        "checksum": "sha256:c5084b5bf90349032858699526d1c75606ab3d848bd4f90d320126f2e22b1957",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.x86_64.rpm",
+        "checksum": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.14",
+        "release": "8.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/j/json-c-0.14-8.fc34.x86_64.rpm",
+        "checksum": "sha256:f6829710ec06b6df70e98f39d197e66c3b42bf53443a83929651ef366f2aea14",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:e5a2f667e1bf1be38b54b5bac3fca499b8992de7a66d678a25d3e0128e3f1587",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/kbd-misc-2.4.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/keyutils-libs-1.6.1-2.fc34.x86_64.rpm",
+        "checksum": "sha256:0f4616a09f18ba7902f87ef22024a6692379272df2b66bb3c9d4d12771533fff",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.5",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.x86_64.rpm",
+        "checksum": "sha256:26abfb8ae9df36d7daab0590f40bbb794a495943fc317e9f2073fe8301058c72",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:81778d572983ef362a31c301ad8c7ac191a1fff2e65177918b85b67fc46c51cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "11.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libaio-0.3.111-11.fc34.x86_64.rpm",
+        "checksum": "sha256:2508758a3bbf79e979bf95226223f04b018264e97fa6fab29019020056b5d203",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.x86_64.rpm",
+        "checksum": "sha256:713e64ea709d4b34ab814a3466babebb3985648a5b6b87c327f50f6d1aefb7f6",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.x86_64.rpm",
+        "checksum": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libattr-2.5.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:732d4e5a9eab39a0310aaf317c76445e9579c7b0b913a3dc1eccd0bb8454be83",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libblkid-2.36.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:0c37bbf98383679eb0f1cab44d20d3c0ca5e981a887152b64d1078c7734643e3",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libbrotli-1.0.9-4.fc34.x86_64.rpm",
+        "checksum": "sha256:ecb6266488947b43138644864dc54c81bc0e10ea55fbde7100e699da45dfeb29",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libcap-2.48-2.fc34.x86_64.rpm",
+        "checksum": "sha256:aa59709bb1397e17d4f202baad4a28ae872e40fc50b5bee5b400b2a06095d3cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libcap-ng-0.8.2-4.fc34.x86_64.rpm",
+        "checksum": "sha256:a04bd8e79ca9948ef5ec386bf78edd60c367d487f82832902de6dcb7ce2b5ed1",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.x86_64.rpm",
+        "checksum": "sha256:6a84fac2aa4beec617e596818b06a5f154f678e666f1c4601c972828e22aa22a",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm",
+        "checksum": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libfdisk-2.36.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:2e2ee3306a607ffc6ab2bd0e398e7a176f45c55ede9c55462632cbf7d100723a",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "28.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.x86_64.rpm",
+        "checksum": "sha256:ac6dbb4d55388f795b15f0339116978bca4fc0231eaa7fa7faaddc77bb9aa74a",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.42",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libgpg-error-1.42-1.fc34.x86_64.rpm",
+        "checksum": "sha256:364583b4cc9a12e344dadc1e3e734ab92882c4bf8d6731ffa0df752f36258834",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libkcapi-1.2.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:e5cbfb4aca5f7a97f08fc86b83c5ec57423a32a39de6d4909ce0126ed15f4cd4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:7b28a2f43e2f7f08930073e2fe4792e059cbe9a40b8996f90346f4989706dc19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.43.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libnghttp2-1.43.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:0e43c033af22ac108085cafbd1de5032a3642162abe06c0fc8fff1a10e61f629",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libnl3-3.5.0-6.fc34.x86_64.rpm",
+        "checksum": "sha256:5311161abf68dee473cd5b868a7a35aef1e98c017b29d9269c71d598143d301b",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libnsl2-1.3.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:7f2ee88a233ab8860662b45ec5eb853171bad68703715ad4e8aa2ac8f00ee45f",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libpsl-0.21.1-3.fc34.x86_64.rpm",
+        "checksum": "sha256:72539a2021ed64458eef5a82c1ea0fea965e9a21d2455aac7a501f932fe006c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.x86_64.rpm",
+        "checksum": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libselinux-3.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:f534a9f0cea9cbfbc580083a80b7965a642ca6299d990edee23f7e49079314c0",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:7af59d2a7a1885369a75b0038fe2ee16743f68db1925572b440b5b1c354e8412",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsemanage-3.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:6e72ff4bf990a5da1251ff8578c67f44afa361aa844f51eeabf1a82fc2221c59",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsigsegv-2.13-2.fc34.x86_64.rpm",
+        "checksum": "sha256:ff4a45abbcd1f1720a1dd0f46328ff987f7cc75474395db90967a3de50022605",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:60c79833b164f6dad8f7e0f330b993e9602a2357612f3157f31df8ebfa833d11",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.17",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.x86_64.rpm",
+        "checksum": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.x86_64.rpm",
+        "checksum": "sha256:8f08844eec04f5765bdf73b02625fb360c5a2051d66752fec9b6446105ee018a",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libtasn1-4.16.0-4.fc34.x86_64.rpm",
+        "checksum": "sha256:af1a24d15612b0b750cd24b74a1cb38131dcf09049187c283e244a5d3a64e789",
+        "check_gpg": true
+      },
+      {
+        "name": "libtextstyle",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libtextstyle-0.21-4.fc34.x86_64.rpm",
+        "checksum": "sha256:00df260cd7acacb1e122f460046816e12f39566951ab39ccbc61c33b1c912aee",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "10.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.x86_64.rpm",
+        "checksum": "sha256:d564ebb4b69df5f5b757808844038c0876afd4c9a4f573092f1731c10ac9d63e",
+        "check_gpg": true
+      },
+      {
+        "name": "liburing",
+        "epoch": 0,
+        "version": "0.7",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/liburing-0.7-4.fc34.x86_64.rpm",
+        "checksum": "sha256:c846fbce750dd7a8bb51b9b5a0a6687743c1575514bbd2cf742f27ba160f3429",
+        "check_gpg": true
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.x86_64.rpm",
+        "checksum": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libutempter-1.2.1-4.fc34.x86_64.rpm",
+        "checksum": "sha256:f9677c1a279cc002d15383edefb3fcdd6355076729ff337a5ca49436ab653cd7",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libuuid-2.36.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:23a58f476dd47e7d92378060efa995a7c96c521b9d1532509e91460da73181f8",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.x86_64.rpm",
+        "checksum": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/lz4-libs-1.9.3-2.fc34.x86_64.rpm",
+        "checksum": "sha256:da676955f475492f17c573bc526d47c37e34919d2a6ed33ec4573a4de0cab2a7",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/m/memstrack-0.2.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:0214ae16ef6a92843a4973aeda93db85584ad7840b1dd6e225bc57b594f58961",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-6.2-4.20200222.fc34.x86_64.rpm",
+        "checksum": "sha256:a823a3f73c688a0a0bd9f049ece18574d15f361e0f4cbc5b66d1fa953b33b659",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm",
+        "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.x86_64.rpm",
+        "checksum": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/npth-1.6-6.fc34.x86_64.rpm",
+        "checksum": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/o/openssl-pkcs11-0.4.11-2.fc34.x86_64.rpm",
+        "checksum": "sha256:98cb29680e00e102bd8e6ba1e8b079291823fd64a0e4adaf7631710e690bd27d",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "7.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/o/os-prober-1.77-7.fc34.x86_64.rpm",
+        "checksum": "sha256:0359a21c768977e0f589ee424690a905ea2f13dd0caf410ac1602d8807f77709",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/p11-kit-0.23.22-3.fc34.x86_64.rpm",
+        "checksum": "sha256:2595a15421c2de026658c7a4ed3eb46706bb16d2df63986eca4574fd87d72fb2",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/p11-kit-trust-0.23.22-3.fc34.x86_64.rpm",
+        "checksum": "sha256:9256f1e9d9e996de69764019fe5e9e11b89f5db854aff3a8cb4a82a4a34eddfc",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.44",
+        "release": "3.fc34.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/pcre-8.44-3.fc34.1.x86_64.rpm",
+        "checksum": "sha256:7aab572608f77cf21be095a49046ab43dcacce130973e947707614d8aff55278",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/pcre2-10.36-4.fc34.x86_64.rpm",
+        "checksum": "sha256:7dc85c364a4be27e065db7ef90a3049e37e8d4c03d5b46ad88d3c9b255070b44",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/pcre2-syntax-10.36-4.fc34.noarch.rpm",
+        "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/pigz-2.5-1.fc34.x86_64.rpm",
+        "checksum": "sha256:decef5a0fec1ae8589088a1ff822f6a1f3290208d516de675dbed955414249db",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/policycoreutils-3.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:039719fc5f330260fc2cdac9f77618841a2aa1a35d6fd417a47312d4eb5bedd3",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/popt-1.18-4.fc34.x86_64.rpm",
+        "checksum": "sha256:b37452649da277bc6f1e80f8c2250a16aa877444e1dcbba0d3546eef7d6fcda3",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "7.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.x86_64.rpm",
+        "checksum": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20190417",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
+        "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.x86_64.rpm",
+        "checksum": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/readline-8.1-2.fc34.x86_64.rpm",
+        "checksum": "sha256:b34c767bab93fb626c993b98e10547779fa5bec98865b9a66b914e45b4b14f6e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-4.16.1.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:8857513982b0c12e02eb0593baa9dc7cf570f2761a6bb4996fc8cf7d98402444",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-libs-4.16.1.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:38731e49cb0ee6a0d98f736ec1ee5605ed3a12cf3c119bb3f140ccf42500d6b3",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "7.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sed-4.8-7.fc34.x86_64.rpm",
+        "checksum": "sha256:a0b294cdc4585a0ac04fdc6f84a4fdc08f10afcaebe28ec60370622d43bfe33d",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.7",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/setup-2.13.7-3.fc34.noarch.rpm",
+        "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.1",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.x86_64.rpm",
+        "checksum": "sha256:ea9851b961b645165a931d3953ec4f0c6d35eb917ac7a982fd52fa847768fc31",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.34.1",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.x86_64.rpm",
+        "checksum": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/tar-1.34-1.fc34.x86_64.rpm",
+        "checksum": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/trousers-0.3.15-2.fc34.x86_64.rpm",
+        "checksum": "sha256:019c0bdb989459f7aed88f534cf96af8e720cb5a0ffa7d514f6b8de5e62eb9e3",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/trousers-lib-0.3.15-2.fc34.x86_64.rpm",
+        "checksum": "sha256:b53a61b34e0bc3cc693bcb82e1e494d201098db149dd38106cb97b6923ec3093",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/u/util-linux-2.36.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:8242972295a6a3d2426ed7756eabb0fb2eabe871894399375a54271ddec56d14",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/x/xz-5.2.5-5.fc34.x86_64.rpm",
+        "checksum": "sha256:237a8756303db7712e91d2b52c428464b401b3295c6c50c5d23a2ebef2f88beb",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/x/xz-libs-5.2.5-5.fc34.x86_64.rpm",
+        "checksum": "sha256:c8e0cdf3260afc4ce9c115f30df68182faaa02944cdaeeb5c20161430f82c8e5",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "26.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/z/zlib-1.2.11-26.fc34.x86_64.rpm",
+        "checksum": "sha256:0ebe43a9bef7ec2dc4cb98350fbde2e55dae886f905e2d9cea837da3fb613c87",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/a/audit-libs-3.0.6-1.fc34.x86_64.rpm",
+        "checksum": "sha256:6c5db6a0eb030c42b41b8e533c559ef81967dbb513d539754ff79b6c407d80d9",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm",
+        "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/coreutils-8.32-30.fc34.x86_64.rpm",
+        "checksum": "sha256:1eead3a3a0b0ff0a9776309d838e0b154f6ad64f1e4a59dc773f3159c118dff0",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/coreutils-common-8.32-30.fc34.x86_64.rpm",
+        "checksum": "sha256:c568c7d0939faa7f3321d95d16ad6c84fb1e81e3c5b14b40bccc61fc3574bbc4",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/cracklib-2.9.6-27.fc34.x86_64.rpm",
+        "checksum": "sha256:8d75d66318cdf547cf7f141e149abd7fbaddf33eea71156e32f5b68edcfa81ec",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.3.6-1.fc34.x86_64.rpm",
+        "checksum": "sha256:f792d09a27deb8c45c2f0887351a3bea684b79ccb6127f8c59512f8866016daa",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/curl-7.76.1-12.fc34.x86_64.rpm",
+        "checksum": "sha256:ea89f3a15fdd80587a928ec156bdbdb1321c01c4c753e4eca036584e575e7e2f",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.x86_64.rpm",
+        "checksum": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc34.x86_64.rpm",
+        "checksum": "sha256:bccfdce40119616d620fa9ddc61876a471ce2cf6f558d226910454f5b289d5b7",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc34.x86_64.rpm",
+        "checksum": "sha256:6351c0b6cb6af4444e033c0558727e92298695eda47492af65a678e13a6ee1f2",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc34.noarch.rpm",
+        "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc34.x86_64.rpm",
+        "checksum": "sha256:f1f078ebde340cb37f7049555e78906b54e42ce22703e878305783a4b91e0477",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc34.x86_64.rpm",
+        "checksum": "sha256:3b7916a277cd7dac44e861b56c0915977f36396d5b4f5007508bf7c90f93e7bf",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:59cfafb5b96fdb1d219743aaf3dfc72de9f2da527efc9c9db3c87815cade7517",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-gpg-keys-34-2.noarch.rpm",
+        "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-release-34-39.noarch.rpm",
+        "checksum": "sha256:3e69e8412d5914ec01c5e82264833698e92a1b88a7c7b5ed9b1f0351fc91f5d2",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-release-common-34-39.noarch.rpm",
+        "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-34-39.noarch.rpm",
+        "checksum": "sha256:6d1c024b295c423746b44f120cf36ceb0fd898f8ce5a276813d7c78a3c8ece52",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-repos-34-2.noarch.rpm",
+        "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/file-5.39-7.fc34.x86_64.rpm",
+        "checksum": "sha256:d5f486b818d86d5f79a5dd619b24abc039496801fb3d54134322715a9c6b489f",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.x86_64.rpm",
+        "checksum": "sha256:442415a2b11394c551e9d3496a325e0365b726543981d98a12e5910eced08115",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.68.4",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.x86_64.rpm",
+        "checksum": "sha256:c14d10994b488aa8f6b78f2aa3850fc4dbf8d791868d08aef8e929780d5012d4",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-2.33-20.fc34.x86_64.rpm",
+        "checksum": "sha256:f53686de3cd500fb010b54f69f7220e4c313453ca5a9aa6c3bbe94566725e838",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-common-2.33-20.fc34.x86_64.rpm",
+        "checksum": "sha256:8e9ab9dc0035e220a6e470553ce4d2fdba896a6630c8e70abee00659e0d8fc75",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-doc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-doc-2.33-20.fc34.noarch.rpm",
+        "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.33-20.fc34.x86_64.rpm",
+        "checksum": "sha256:c7b9527ce55677974b88c44bb541dc471512fcc3915665818b05b11c1cb7f119",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/gnutls-3.7.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:1480de09d5016b10258a24571534f4cdbbd644efb0799c40842f390f0cf65e91",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm",
+        "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-9.fc34.x86_64.rpm",
+        "checksum": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-9.fc34.noarch.rpm",
+        "checksum": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-9.fc34.x86_64.rpm",
+        "checksum": "sha256:5a4b0cc50d9929ef558617fecd879f80a459379047ec77bcc238e5b305258bf5",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-9.fc34.x86_64.rpm",
+        "checksum": "sha256:6d1b00e8e758af552fcad8be95fa8250d561fbfaa727f8790ea06d72005444b1",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "8.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/i/iptables-legacy-libs-1.8.7-8.fc34.x86_64.rpm",
+        "checksum": "sha256:e0b9fbbfc90d70bff8c64adc104a46b2bc4d9705720d2955468309c9a6d84610",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/kmod-29-2.fc34.x86_64.rpm",
+        "checksum": "sha256:066af2860b14cfc346263dc85c2d320e38d81d078bf3fd88130494a7717b282f",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/kmod-libs-29-2.fc34.x86_64.rpm",
+        "checksum": "sha256:29d944588a122ae56cc35c310dd202601e39e26964a7bf22d04819a5409c07ed",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/krb5-libs-1.19.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:1f445df6b58ea1c9eb76d8cc2c9ec2eba81c45f00603c2b9e84eb86e038d4f89",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:0586d4ad14181d8cca2979449ebec2d4ce1fde826c77feaa91ab47902055abdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.x86_64.rpm",
+        "checksum": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.x86_64.rpm",
+        "checksum": "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "49.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.x86_64.rpm",
+        "checksum": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:d4b8f6fcbb1e1d0aca4d44bfd93f72e238b7ff35466c3f332d17a1354b6826c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:af603a6e5e4696cfb1e7a4583940a46c5ef42de39778d55e08a7cde62bc14786",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libgcrypt-1.9.3-3.fc34.x86_64.rpm",
+        "checksum": "sha256:72b1000c285aa522fde63196bdeb3b32e1cff5859d345b753081cdad3cbd76d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:2acde8d21a1d5c88823fd667bbaac59a4af3f8ad47a9e833276f86e8cfcc2275",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "37.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libibverbs-37.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:c555acae201eda07e7f97a6d0c9d8e6d71065dca7efe3fb131f3b29fe1b080ce",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libidn2-2.3.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:0ebb518a40590402136a181c5c0ec8d0c73d3074817bf94bd7a3937eb38ad107",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libpcap-1.10.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:55819abd7651c8f0e7449967933909fa2c6a0f939e90c6074d4831b633cc6adc",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.x86_64.rpm",
+        "checksum": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
+        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:a7dd48e65cd9bc6254c71d51aa473f0e1a5d99baf1f8ea077652884098969e2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libsepol-3.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:01c9d525eb77975631ff44b67e3ee65492445a3f1861f4f04a25be48218634a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libssh-0.9.6-1.fc34.x86_64.rpm",
+        "checksum": "sha256:46022a4e7d40f858d01fabd50bf2b22705022103d2708805e44ada62ed7ccfe2",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libssh-config-0.9.6-1.fc34.noarch.rpm",
+        "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:039f11c0333b49318e60b1fa8e5621f16363fe77fb76602eccc085d0897fbdb1",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "0.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libtirpc-1.3.2-0.fc34.x86_64.rpm",
+        "checksum": "sha256:a2052ecaa71b5dae58df3b651ba3437b098a2a804e55336b819e95a5a49f23f5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc34.x86_64.rpm",
+        "checksum": "sha256:f61173014cf0d8423088cd705352faed48e83a1b13fc33d8af0bfc12dd04f240",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc34.x86_64.rpm",
+        "checksum": "sha256:99bc964d8f2fc46e9ccdc567b159163b72a628432643bdd159464224a9d612c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libxkbcommon-1.3.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:ef9a875e12eb5f50864325121e648a54165aeec9a2b7da12e1630a57c2c33c22",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libxml2-2.9.12-4.fc34.x86_64.rpm",
+        "checksum": "sha256:d58e0ddac3c208aba6f507ea5df678dab7125dc3f741880cf831b1a76b0072de",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:b58e6fd55e8018e6632ddddc0564201f5cffc314a521f28c9e923c86d760a648",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:4a2ce807ef248c703b78d6f298a7e7eb64b08528aab890de5608c09e34d54f6c",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/m/mkpasswd-5.5.10-1.fc34.x86_64.rpm",
+        "checksum": "sha256:82473998562b047466a8082308e0e268f665e7a1bac3f7c74e124f2c37d80628",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "7.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/m/mpfr-4.1.0-7.fc34.x86_64.rpm",
+        "checksum": "sha256:a67d8e75329c0f5ab18a0b2a102351a09d2476f0479dea57d2dbb352245a7a03",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/n/nettle-3.7.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:45ee87897faec4ad216eb111f76ecde2e7f6b864e63bdff4daf10efc97447eee",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.57",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/openldap-2.4.57-6.fc34.x86_64.rpm",
+        "checksum": "sha256:a196fc793d1578d7c4b423ec49bdf6ef0f792cb0f505fe8c708815315ac29d81",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/openssl-libs-1.1.1l-2.fc34.x86_64.rpm",
+        "checksum": "sha256:df22e432aaecb2059b714760bf075922af83e21e0ed5fdbca3185c4871d83c04",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "7.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/pam-1.5.1-7.fc34.x86_64.rpm",
+        "checksum": "sha256:6d01dc580d599af1fd761172c6aa9a602502f782179828586774b199e329ed16",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "1.fc34.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/procps-ng-3.3.17-1.fc34.1.x86_64.rpm",
+        "checksum": "sha256:7d73ab186606e96644c34135f5e48e9407aff309d63f720b2d68aafc6797dfdd",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python-setuptools-wheel-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.9.9-2.fc34.noarch.rpm",
+        "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-3.9.9-2.fc34.x86_64.rpm",
+        "checksum": "sha256:c44e6efc9a521ad24b919d7fab92e8864913a2ea994a2134492720648150699f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.x86_64.rpm",
+        "checksum": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libs-3.9.9-2.fc34.x86_64.rpm",
+        "checksum": "sha256:cd33d7742606c567f01e0c2125121cc4fde549ed8789778a7f10ce58bd528aea",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-pip-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
+        "check_gpg": true
+      },
+      {
+        "name": "qemu-img",
+        "epoch": 2,
+        "version": "5.2.0",
+        "release": "8.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qemu-img-5.2.0-8.fc34.x86_64.rpm",
+        "checksum": "sha256:266c256daec0cb7d71718ef31f85a21d146e0f04d39ff8974ddcdceafbf3fab9",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:983a18e776aab5b2ae41f0cfa6a7da303de275f65f9d8c318b6ba99d19d3590f",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/selinux-policy-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/selinux-policy-targeted-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.8.1",
+        "release": "10.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.8.1-10.fc34.x86_64.rpm",
+        "checksum": "sha256:c1f4a6f3bda5087a680c2a940fae2e02f0199c95a949dddc227390336681a405",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-248.9-1.fc34.x86_64.rpm",
+        "checksum": "sha256:3b5f5b2129930d6eff8abcdadf70287fe92480c8deb9b622d1b31d7178e84e2d",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.x86_64.rpm",
+        "checksum": "sha256:b0d3b898968868b627f62a2f1b18257dc89f4e04c5c3adc8c25baa36c6cf5fa6",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-networkd-248.9-1.fc34.x86_64.rpm",
+        "checksum": "sha256:f43356bc92e900004026937f9af3b350f7298b5040ec30fefd4e260bcaea6540",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-pam-248.9-1.fc34.x86_64.rpm",
+        "checksum": "sha256:90008dbecc37d3e4b9f495a2e2d92478094b6be272fb849017f8e3f51541e08f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-rpm-macros",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-rpm-macros-248.9-1.fc34.noarch.rpm",
+        "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.x86_64.rpm",
+        "checksum": "sha256:b1db042b9b66ec1f24b59cac5fbb7acced19ae474399862406bc6737b434a9de",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
+        "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "26.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/w/which-2.21-26.fc34.x86_64.rpm",
+        "checksum": "sha256:867da92a40eadf047aa6c4127cd0858b514ecb372c4fcdcb63bba87473c99fd8",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/w/whois-nls-5.5.10-1.fc34.noarch.rpm",
+        "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
+        "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.x86_64.rpm",
+        "checksum": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
+        "check_gpg": true
+      }
+    ],
+    "packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/a/acl-2.3.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:c540ca8c5e21ba5f063286c94a088af2aac0b15bc40df6fd562d40154c10f4a1",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/a/alternatives-1.15-2.fc34.x86_64.rpm",
+        "checksum": "sha256:15a654d32efaa75b5df3e2481939d0393fe1746696cc858ca094ccf8b76073cd",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/b/basesystem-11-11.fc34.noarch.rpm",
+        "checksum": "sha256:97d2f9654b75965609874b6e8675ad4c737ae8b02468ea32e859b38d50e955f4",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/b/bash-5.1.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:caa41935dc130081a607caccac5db4bc5b1963c781ba4ea43aa525b5aaf0f51e",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/b/bzip2-libs-1.0.8-6.fc34.x86_64.rpm",
+        "checksum": "sha256:9a698a5991a08e23e87b4bce2f3e447eafdc7fd4d84a49d91c65c6045ead1e8e",
+        "check_gpg": true
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/checkpolicy-3.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:5514af0678342f195a77718fdbf0a0ffddb3a66d5457c6e2f590f8236238ee95",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "20.4",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/cloud-init-20.4-2.fc34.noarch.rpm",
+        "checksum": "sha256:e7d1d0b85ac49d8b0c9dd3fce4613e6229ac8720cfb74c80a496b9f0beaa7a22",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-utils-growpart",
+        "epoch": 0,
+        "version": "0.31",
+        "release": "8.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/cloud-utils-growpart-0.31-8.fc34.noarch.rpm",
+        "checksum": "sha256:6d1b95e06ec98f6d65c64e18fec693d379b98128a3e94b4dec8929321354c549",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/console-login-helper-messages-0.21.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:1877af369228dd661ae1adfc43bbb8d53d3464d59ead0f5bcf6c2be88f8e8685",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-issuegen",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/console-login-helper-messages-issuegen-0.21.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:3f7bde703045c2651fbd4142131ea1e303a565269388a08e2312af0eb83307a4",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-motdgen",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/console-login-helper-messages-motdgen-0.21.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:d2bac91a1969f555ea2641b161bb23fa0aaaffaba3284d9973ad696594b73f18",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-profile",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/console-login-helper-messages-profile-0.21.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:424f73b97c7d7541d35685108bdcddb03100cd0f3d6e0fd9def576462ca65b59",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "10.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/cpio-2.13-10.fc34.x86_64.rpm",
+        "checksum": "sha256:9bff70d51ecec129854ef62d82204db3e01706c444b966cb048bc7fd8ec8b524",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/crypto-policies-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:34441a7147eed87587bf5a6edbb6b495b3504db4b2438580dd353c97466b9534",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210213",
+        "release": "1.git5c710c0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch.rpm",
+        "checksum": "sha256:809a330873f918264d495039d98b21d329d4c7c6ca9d597642e76049121c427e",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "8.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/c/cyrus-sasl-lib-2.1.27-8.fc34.x86_64.rpm",
+        "checksum": "sha256:6ddbf894c0a7542ecc5a641bde06659c5a80cd954fcfd2f9e558885e81724d60",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-1.12.20-3.fc34.x86_64.rpm",
+        "checksum": "sha256:b4e47421cbc842d53d14fb00b31bdb10bdddd1571dcaffbe258fa3a8c5be0500",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-common-1.12.20-3.fc34.noarch.rpm",
+        "checksum": "sha256:4f9e4767af643db826108b4c95c5a7ca8f0317af3dcbd3505b9136e8fd7fcbaf",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dbus-libs-1.12.20-3.fc34.x86_64.rpm",
+        "checksum": "sha256:b2ffc9785842ccc76ca187d8b922fb3b91da2257341fb115ed6bdbfedb24c1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "dejavu-sans-fonts",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "16.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/dejavu-sans-fonts-2.37-16.fc34.noarch.rpm",
+        "checksum": "sha256:79834af7f95c0d1e5dcf85b794819bd854197a52d2966594abdb3c3de0fcceb6",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "8.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/deltarpm-3.6.2-8.fc34.x86_64.rpm",
+        "checksum": "sha256:f8b418b88b30d28c911d26f6f0b9c1ede8be00fa71d28c789328dfd7c58eea67",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/device-mapper-1.02.175-1.fc34.x86_64.rpm",
+        "checksum": "sha256:5fb88eb681e996ab2199251a68c79b2797fa03d31a36dae698de393b85e1f89e",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/device-mapper-libs-1.02.175-1.fc34.x86_64.rpm",
+        "checksum": "sha256:f5f5c988604aa5c870eee7efff6d40f26acb908cf82991d762ade18c8b46aff6",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "8.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/d/diffutils-3.7-8.fc34.x86_64.rpm",
+        "checksum": "sha256:c58752e2529cf0ea4aabb0476ef53ca7748091aa936513affc1245928ae5b1b8",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/e/e2fsprogs-1.45.6-5.fc34.x86_64.rpm",
+        "checksum": "sha256:377d141bf5e1dca120216e9cc478c31fceace604f0ba2b2bc51497efbf00b7df",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/e/e2fsprogs-libs-1.45.6-5.fc34.x86_64.rpm",
+        "checksum": "sha256:b7dac3f2d8feaffb21a6ec0503559448ad99096b50ff0d33a8a2107dbb23a8f2",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/f/filesystem-3.14-5.fc34.x86_64.rpm",
+        "checksum": "sha256:b554175a1dea7562b6d2810eb7bf41b11c01beb430479764401318785e6f85cc",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/f/findutils-4.8.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:f85364e3d8b5896793728102ff59107a78fbe916da3b7ce5146ff97bc68e0c01",
+        "check_gpg": true
+      },
+      {
+        "name": "fonts-filesystem",
+        "epoch": 1,
+        "version": "2.0.5",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/f/fonts-filesystem-2.0.5-5.fc34.noarch.rpm",
+        "checksum": "sha256:3fb05067cbd7fcf3283f2ab306c2dae668d818d3a69422e729c2ef62974810a5",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "11.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/f/fuse-libs-2.9.9-11.fc34.x86_64.rpm",
+        "checksum": "sha256:1816bd5b8dee276e7174ec06256bcc5f699b8a1c2203995bf84210590c52b0ad",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gawk-5.1.0-3.fc34.x86_64.rpm",
+        "checksum": "sha256:baa55f06cacd3b30db59ebc42f4967d3d15dcd20fab4cb269913c0f991078220",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gawk-all-langpacks-5.1.0-3.fc34.x86_64.rpm",
+        "checksum": "sha256:de675241db34363c2f99d4434ea342cdd8c1178a30d51b2a55ce1666b0ac426a",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.19",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gdbm-libs-1.19-2.fc34.x86_64.rpm",
+        "checksum": "sha256:e61e911fa03cd3436b05bdb4abcf48c5c78396419d161fe13b39dcd16e3abced",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gettext-0.21-4.fc34.x86_64.rpm",
+        "checksum": "sha256:a858b65eb278c40507abdccb587bdc0c6edb2960ec51f5bfe3d774900079694c",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gettext-libs-0.21-4.fc34.x86_64.rpm",
+        "checksum": "sha256:7e130c0f39168b8d442e8bf9ca17046f7ca6210bda0d5526a2b6b34ccfa22816",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gmp-6.2.0-6.fc34.x86_64.rpm",
+        "checksum": "sha256:0e4fe80ef8c8799a3210290687f039b1c35de7f8c9c6644b3faf323946e38df0",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-2.2.27-4.fc34.x86_64.rpm",
+        "checksum": "sha256:a0563c8de72ede011586c72df7a8e253cceebe1e603b2540e4e31c681ee8badc",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.2.27",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gnupg2-smime-2.2.27-4.fc34.x86_64.rpm",
+        "checksum": "sha256:ed84b25915a5aa35223f0a06f06c5911c68c269671dad61f0886297d5462a8bc",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gpgme-1.15.1-2.fc34.x86_64.rpm",
+        "checksum": "sha256:7798e0551fb9452d368b678e0f7f2ad6d3358abf39b46c42c26db7131d5e1a8f",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/grep-3.6-2.fc34.x86_64.rpm",
+        "checksum": "sha256:34bfb7bc369a50204f70d5a7f538f543a4ef053d36d48b74be62bb1ea8fa8187",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "7.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/groff-base-1.22.4-7.fc34.x86_64.rpm",
+        "checksum": "sha256:2a63d1e893c95961c1d608bdbcf2acbdd51b045c74fa4827808a491ad424e929",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "51.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/grubby-8.40-51.fc34.x86_64.rpm",
+        "checksum": "sha256:c5084b5bf90349032858699526d1c75606ab3d848bd4f90d320126f2e22b1957",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/g/gzip-1.10-4.fc34.x86_64.rpm",
+        "checksum": "sha256:c05122e77479c37f40666b49fb0451785b14c5b81c6cee23f6c176e33563931a",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/h/hostname-3.23-4.fc34.x86_64.rpm",
+        "checksum": "sha256:5e5e72cd1b7c708282657917de6f8aea198d308e30e42c9126994b7b4ccc3a64",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/ima-evm-utils-1.3.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:6964a3e499aa00923d841bc3eef5c05db7ba8184e256612c95502dd5adcb7f01",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "49",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/inih-49-3.fc34.x86_64.rpm",
+        "checksum": "sha256:3714a372bb59bcc89ba5d971cbf6eb025b3ff964825309f04fbc7d6366df8cf8",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.09",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/initscripts-10.09-1.fc34.x86_64.rpm",
+        "checksum": "sha256:11079b8f071c61c3a2a8556e3c9e406b188378969fa34f5bc0ce67b88c8e3799",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.10.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/iproute-5.10.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:b017639e7e7602a981baa2a0d3b99bb484d2299a3b5a907cb6856ac80a31a359",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute-tc",
+        "epoch": 0,
+        "version": "5.10.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/iproute-tc-5.10.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:cf126ae271b434f9427b6e5531b3d5013688c6464740b9025f4a4548a6c69b14",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20210202",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/i/iputils-20210202-2.fc34.x86_64.rpm",
+        "checksum": "sha256:f8bf13c71c043e381a419b8e3fe45f6708b798db9e93ff04f261fcb0d690b46c",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/j/jansson-2.13.1-2.fc34.x86_64.rpm",
+        "checksum": "sha256:0c679ac467bc08e857adf5d1d8228e5a176fc06e74a3f30dbd5dab4843751163",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.14",
+        "release": "8.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/j/json-c-0.14-8.fc34.x86_64.rpm",
+        "checksum": "sha256:f6829710ec06b6df70e98f39d197e66c3b42bf53443a83929651ef366f2aea14",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/kbd-2.4.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:e5a2f667e1bf1be38b54b5bac3fca499b8992de7a66d678a25d3e0128e3f1587",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/kbd-misc-2.4.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:9f40883055c549687b8d7ec1b80a6bda5a812484b7caf977c8ed0de56ac91a48",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/keyutils-libs-1.6.1-2.fc34.x86_64.rpm",
+        "checksum": "sha256:0f4616a09f18ba7902f87ef22024a6692379272df2b66bb3c9d4d12771533fff",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.5",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/k/kpartx-0.8.5-4.fc34.x86_64.rpm",
+        "checksum": "sha256:26abfb8ae9df36d7daab0590f40bbb794a495943fc317e9f2073fe8301058c72",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/langpacks-core-en-3.0-14.fc34.noarch.rpm",
+        "checksum": "sha256:c20caffb4d2a500416dab0e8418a24ae5e25c02c831ae02ee10f97a0dcc80374",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-font-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/langpacks-core-font-en-3.0-14.fc34.noarch.rpm",
+        "checksum": "sha256:82cbc5e0339e832d2fc0160541c30f3dee59b3d28d83907ae7b55e22d5092c51",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/langpacks-en-3.0-14.fc34.noarch.rpm",
+        "checksum": "sha256:82b51ca6bec551d74a6d8c43194b0fd4e8bfdf19d1d68b58c1787723edd88bd0",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libacl-2.3.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:81778d572983ef362a31c301ad8c7ac191a1fff2e65177918b85b67fc46c51cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libargon2-20171227-6.fc34.x86_64.rpm",
+        "checksum": "sha256:713e64ea709d4b34ab814a3466babebb3985648a5b6b87c327f50f6d1aefb7f6",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libassuan-2.5.5-1.fc34.x86_64.rpm",
+        "checksum": "sha256:30196b8258578403a726fabc612d701b95704a389d51b3a391d529c469b7b378",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libattr-2.5.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:732d4e5a9eab39a0310aaf317c76445e9579c7b0b913a3dc1eccd0bb8454be83",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "47.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libbasicobjects-0.1.1-47.fc34.x86_64.rpm",
+        "checksum": "sha256:c70d5e913bea41a0a4795ce6a43dd3d9849009649035cc111227ccc007cf18da",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libblkid-2.36.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:0c37bbf98383679eb0f1cab44d20d3c0ca5e981a887152b64d1078c7734643e3",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libbrotli-1.0.9-4.fc34.x86_64.rpm",
+        "checksum": "sha256:ecb6266488947b43138644864dc54c81bc0e10ea55fbde7100e699da45dfeb29",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libcap-2.48-2.fc34.x86_64.rpm",
+        "checksum": "sha256:aa59709bb1397e17d4f202baad4a28ae872e40fc50b5bee5b400b2a06095d3cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libcap-ng-0.8.2-4.fc34.x86_64.rpm",
+        "checksum": "sha256:a04bd8e79ca9948ef5ec386bf78edd60c367d487f82832902de6dcb7ce2b5ed1",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libcbor-0.7.0-3.fc34.x86_64.rpm",
+        "checksum": "sha256:7151baf126a07d4f20f91309433005b3552175a1adc03f907d772db9f374b6bc",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "47.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libcollection-0.7.0-47.fc34.x86_64.rpm",
+        "checksum": "sha256:68fa66fc992597c906349a67b60969f81c9548173e1eeb3e20bc3a2b20da626f",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libcom_err-1.45.6-5.fc34.x86_64.rpm",
+        "checksum": "sha256:6a84fac2aa4beec617e596818b06a5f154f678e666f1c4601c972828e22aa22a",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "47.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libdhash-0.5.0-47.fc34.x86_64.rpm",
+        "checksum": "sha256:2d98ce375c70ac4038d9e69be1ef562197e8f966cc1e805f06c266131d478562",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libevent-2.1.12-3.fc34.x86_64.rpm",
+        "checksum": "sha256:82c4712b0fc9591482113f7c70ef3977a8ef5cf7e6d28cbfa5efe80b125ecf53",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libfdisk-2.36.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:2e2ee3306a607ffc6ab2bd0e398e7a176f45c55ede9c55462632cbf7d100723a",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "28.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libffi-3.1-28.fc34.x86_64.rpm",
+        "checksum": "sha256:ac6dbb4d55388f795b15f0339116978bca4fc0231eaa7fa7faaddc77bb9aa74a",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libfido2-1.6.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:df8f70b98e21e38a9b6449436d1ab3663fd1a7602a1be4c4d32bffba3a2831b9",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.42",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libgpg-error-1.42-1.fc34.x86_64.rpm",
+        "checksum": "sha256:364583b4cc9a12e344dadc1e3e734ab92882c4bf8d6731ffa0df752f36258834",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "47.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libini_config-1.3.1-47.fc34.x86_64.rpm",
+        "checksum": "sha256:11253fdc73fbf71f3c5ff7d2b58d9967fc7525cf9a131f8ed0f69212e60f8bc1",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libkcapi-1.2.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:e5cbfb4aca5f7a97f08fc86b83c5ec57423a32a39de6d4909ce0126ed15f4cd4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libkcapi-hmaccalc-1.2.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:ab75c02d93cec64e749fc52ecf37c46f9a83f6fe1f64b421f8c8c2edd87b5644",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libksba-1.5.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:5730480584e64460dc3821e7e6b45a8d34c14d7361e851cf3ab7afabb104e2ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libmaxminddb-1.5.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:fd9453e9740feb7aa070fffc2b83ebddedca4d42c9f886843197b626ab4ba131",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "13.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libmnl-1.0.4-13.fc34.x86_64.rpm",
+        "checksum": "sha256:ff16ef3ab82ad4c43f743e4f2569988b4ca2fcd8018cf048d856847687c3a16a",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libmount-2.36.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:7b28a2f43e2f7f08930073e2fe4792e059cbe9a40b8996f90346f4989706dc19",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.7",
+        "release": "7.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libndp-1.7-7.fc34.x86_64.rpm",
+        "checksum": "sha256:87a1e286ad30c1c123e44ef180d1f857896459fd685c66e80316a51b4687d44e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libnetfilter_conntrack-1.0.8-2.fc34.x86_64.rpm",
+        "checksum": "sha256:e3f0e950f5c8b2039821cd589f3d3fb9a01f0a8da953f05f77fd3c548fe4f2ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "19.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libnfnetlink-1.0.1-19.fc34.x86_64.rpm",
+        "checksum": "sha256:193bae5dffa4c82249bfbbf3de479f048955a788a00e9c37c7667b820f36eb91",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.43.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libnghttp2-1.43.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:0e43c033af22ac108085cafbd1de5032a3642162abe06c0fc8fff1a10e61f629",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libnl3-3.5.0-6.fc34.x86_64.rpm",
+        "checksum": "sha256:5311161abf68dee473cd5b868a7a35aef1e98c017b29d9269c71d598143d301b",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libnsl2-1.3.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:7f2ee88a233ab8860662b45ec5eb853171bad68703715ad4e8aa2ac8f00ee45f",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "47.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libpath_utils-0.2.1-47.fc34.x86_64.rpm",
+        "checksum": "sha256:c060ffeb6d268d4ab20449af1a40c18f3eacb1aab5ef225f91e0c0bd08d65205",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libpipeline-1.5.3-2.fc34.x86_64.rpm",
+        "checksum": "sha256:f83c97898b9c7fd3d2593faf8ac86e25648dab37057fafd822f1f2c04580c1c8",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libpsl-0.21.1-3.fc34.x86_64.rpm",
+        "checksum": "sha256:72539a2021ed64458eef5a82c1ea0fea965e9a21d2455aac7a501f932fe006c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "47.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libref_array-0.1.5-47.fc34.x86_64.rpm",
+        "checksum": "sha256:3d7c3cbf81fc044d098692a1a9989d36120405a46f7f7b595091aa10cf687d84",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsecret-0.20.4-2.fc34.x86_64.rpm",
+        "checksum": "sha256:369c63ec6b1ec3a0f36625c7a2eb7d46195f9b9e9d542590ff058c5d870ff018",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libselinux-3.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:f534a9f0cea9cbfbc580083a80b7965a642ca6299d990edee23f7e49079314c0",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libselinux-utils-3.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:7af59d2a7a1885369a75b0038fe2ee16743f68db1925572b440b5b1c354e8412",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsemanage-3.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:6e72ff4bf990a5da1251ff8578c67f44afa361aa844f51eeabf1a82fc2221c59",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsigsegv-2.13-2.fc34.x86_64.rpm",
+        "checksum": "sha256:ff4a45abbcd1f1720a1dd0f46328ff987f7cc75474395db90967a3de50022605",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsmartcols-2.36.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:60c79833b164f6dad8f7e0f330b993e9602a2357612f3157f31df8ebfa833d11",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.17",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libsolv-0.7.17-3.fc34.x86_64.rpm",
+        "checksum": "sha256:d6762e1d533b1ca2ccc787d7394fd9ddeeb73845cdf55a5d1f93fbc53b716d8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.45.6",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libss-1.45.6-5.fc34.x86_64.rpm",
+        "checksum": "sha256:8f08844eec04f5765bdf73b02625fb360c5a2051d66752fec9b6446105ee018a",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libtalloc-2.3.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:ba877062b6d0746be4c66b6ff85e2b5265124532ae962d491ffed9d61bbde7bf",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libtasn1-4.16.0-4.fc34.x86_64.rpm",
+        "checksum": "sha256:af1a24d15612b0b750cd24b74a1cb38131dcf09049187c283e244a5d3a64e789",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.3",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libtdb-1.4.3-6.fc34.x86_64.rpm",
+        "checksum": "sha256:d8dde242a8be009e1e0ce8ad0a513397d90b734181f0f6491245c327c81f5a4e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtextstyle",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libtextstyle-0.21-4.fc34.x86_64.rpm",
+        "checksum": "sha256:00df260cd7acacb1e122f460046816e12f39566951ab39ccbc61c33b1c912aee",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "10.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libunistring-0.9.10-10.fc34.x86_64.rpm",
+        "checksum": "sha256:d564ebb4b69df5f5b757808844038c0876afd4c9a4f573092f1731c10ac9d63e",
+        "check_gpg": true
+      },
+      {
+        "name": "libusbx",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libusbx-1.0.24-2.fc34.x86_64.rpm",
+        "checksum": "sha256:55564201da6eed182ab7b5f32de3cec7083b0320fd78d14995c9d22cbbc35012",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libutempter-1.2.1-4.fc34.x86_64.rpm",
+        "checksum": "sha256:f9677c1a279cc002d15383edefb3fcdd6355076729ff337a5ca49436ab653cd7",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libuuid-2.36.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:23a58f476dd47e7d92378060efa995a7c96c521b9d1532509e91460da73181f8",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libverto-0.3.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:c6a93c82e2d982d569ffc5754d4164396317306dbd24587606fba87acd02f936",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/libyaml-0.2.5-5.fc34.x86_64.rpm",
+        "checksum": "sha256:95ca236992db01a158c9a637ca0aa33605712f21fce57d2ff4492edd9a3e3eb2",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-atm-libs",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "28.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/linux-atm-libs-2.5.1-28.fc34.x86_64.rpm",
+        "checksum": "sha256:b9ca1ddf049221d91a9b74baf7964ce09259a87b778b8427a7a35d3646e128db",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/lmdb-libs-0.9.29-1.fc34.x86_64.rpm",
+        "checksum": "sha256:cefa4197ff8c8664bbc28408953c223320cd448a2a120e22aec93c8baf39a954",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/l/lz4-libs-1.9.3-2.fc34.x86_64.rpm",
+        "checksum": "sha256:da676955f475492f17c573bc526d47c37e34919d2a6ed33ec4573a4de0cab2a7",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.9.3",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/m/man-db-2.9.3-3.fc34.x86_64.rpm",
+        "checksum": "sha256:7f2e8cf1b8b1ae6c1e9cbfa60cc6083ba88aca1f42d1639b52c3fabf7ab68185",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/m/memstrack-0.2.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:0214ae16ef6a92843a4973aeda93db85584ad7840b1dd6e225bc57b594f58961",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-6.2-4.20200222.fc34.x86_64.rpm",
+        "checksum": "sha256:a823a3f73c688a0a0bd9f049ece18574d15f361e0f4cbc5b66d1fa953b33b659",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-base-6.2-4.20200222.fc34.noarch.rpm",
+        "checksum": "sha256:f8940f08214a129c11bd8fd00090a2bd28dd52b4fc2bc69f66105ce34a06d2b3",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "4.20200222.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/ncurses-libs-6.2-4.20200222.fc34.x86_64.rpm",
+        "checksum": "sha256:8c9400c01548aa4d4dcfe464bf266ff2fdd31a14c2b5d2b06000084871b54db7",
+        "check_gpg": true
+      },
+      {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.59.20160912git.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/net-tools-2.0-0.59.20160912git.fc34.x86_64.rpm",
+        "checksum": "sha256:2b5bfefcbf88c3c22670ed52b39a075ed2ac5beaaedd9b16c22004897f5186e7",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/n/npth-1.6-6.fc34.x86_64.rpm",
+        "checksum": "sha256:b918d4670e1e519b18e2f5fc087e129581b496afe0cd987089183dba23a52406",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/o/openssl-pkcs11-0.4.11-2.fc34.x86_64.rpm",
+        "checksum": "sha256:98cb29680e00e102bd8e6ba1e8b079291823fd64a0e4adaf7631710e690bd27d",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "7.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/o/os-prober-1.77-7.fc34.x86_64.rpm",
+        "checksum": "sha256:0359a21c768977e0f589ee424690a905ea2f13dd0caf410ac1602d8807f77709",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/p11-kit-0.23.22-3.fc34.x86_64.rpm",
+        "checksum": "sha256:2595a15421c2de026658c7a4ed3eb46706bb16d2df63986eca4574fd87d72fb2",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/p11-kit-trust-0.23.22-3.fc34.x86_64.rpm",
+        "checksum": "sha256:9256f1e9d9e996de69764019fe5e9e11b89f5db854aff3a8cb4a82a4a34eddfc",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/parted-3.4-2.fc34.x86_64.rpm",
+        "checksum": "sha256:6a5f21dd77a32eb484b0573e6bb4fe1da9fc26c02d53a564fe41130c080b16cd",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "10.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/passwd-0.80-10.fc34.x86_64.rpm",
+        "checksum": "sha256:701c7d913f25cbc506cc04cfca52d91287dec9c35066ba04eda7efafd1a8c0e4",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.44",
+        "release": "3.fc34.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/pcre-8.44-3.fc34.1.x86_64.rpm",
+        "checksum": "sha256:7aab572608f77cf21be095a49046ab43dcacce130973e947707614d8aff55278",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/pcre2-10.36-4.fc34.x86_64.rpm",
+        "checksum": "sha256:7dc85c364a4be27e065db7ef90a3049e37e8d4c03d5b46ad88d3c9b255070b44",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.36",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/pcre2-syntax-10.36-4.fc34.noarch.rpm",
+        "checksum": "sha256:be529c72adcd9c1b07c2c54dbfdf25ec972b9d68eed5602984e4b7b14ad57dbc",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/pigz-2.5-1.fc34.x86_64.rpm",
+        "checksum": "sha256:decef5a0fec1ae8589088a1ff822f6a1f3290208d516de675dbed955414249db",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/policycoreutils-3.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:039719fc5f330260fc2cdac9f77618841a2aa1a35d6fd417a47312d4eb5bedd3",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/popt-1.18-4.fc34.x86_64.rpm",
+        "checksum": "sha256:b37452649da277bc6f1e80f8c2250a16aa877444e1dcbba0d3546eef7d6fcda3",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "7.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/protobuf-c-1.3.3-7.fc34.x86_64.rpm",
+        "checksum": "sha256:c2147331efdfe52db58aeba0a7e211fd7729b33827d16fdbf84da74331cf2e32",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/psmisc-23.4-1.fc34.x86_64.rpm",
+        "checksum": "sha256:05606b38ea83db0d4f5fea924caeda9a1b90eb9bd5fa7858278e90c3661bf26e",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20190417",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/publicsuffix-list-dafsa-20190417-5.fc34.noarch.rpm",
+        "checksum": "sha256:5f75cc1f7b0007d303d9ca5415de60ab359334d0cd179d3002b4faf4fdb73cbe",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-attrs",
+        "epoch": 0,
+        "version": "20.3.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-attrs-20.3.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:820fee96d610178c7c7b8ce2b115bd02063d2f6dfcae5da4bf5d411de0b575f7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cffi",
+        "epoch": 0,
+        "version": "1.14.5",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-cffi-1.14.5-1.fc34.x86_64.rpm",
+        "checksum": "sha256:50d06e862f369b217b1051c5e826bfdb15c795494bfc17283ab621804c1dba1d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-chardet-4.0.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:9ce3f0c0904ac22ab5769babebf43e7dcdb488b0ef999b2e9e88a5b5eb424e51",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-configobj",
+        "epoch": 0,
+        "version": "5.0.6",
+        "release": "23.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-configobj-5.0.6-23.fc34.noarch.rpm",
+        "checksum": "sha256:f7f8832ccaedd7ddad064956309478b9bf366f0576517356ee68481e196236cf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cryptography",
+        "epoch": 0,
+        "version": "3.4.6",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-cryptography-3.4.6-1.fc34.x86_64.rpm",
+        "checksum": "sha256:0041b41276afd2846199a020fa769b7a3b504fae34b83cbad92f217b1d55e481",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-dateutil-2.8.1-3.fc34.noarch.rpm",
+        "checksum": "sha256:5d2c28837f0573ae2647b8fbba85f7c502f9c3da0a3eab1c9ba121de4a1a6cee",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-distro-1.5.0-5.fc34.noarch.rpm",
+        "checksum": "sha256:e530795e5c9bc27de609fcbbacdc43c226026fee95e47a1f783f1c03ba5d48ae",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-gpg-1.15.1-2.fc34.x86_64.rpm",
+        "checksum": "sha256:59b2e0dcf99b49de75623a68ecb5e67831fd289e532c4eded0bc4914414db4e9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-idna-2.10-3.fc34.noarch.rpm",
+        "checksum": "sha256:f68c93c0461c149bb17282dededf421cbc1fbfa5ac133b59bd362526f59e0d57",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jinja2",
+        "epoch": 0,
+        "version": "2.11.3",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-jinja2-2.11.3-1.fc34.noarch.rpm",
+        "checksum": "sha256:2414cb7345bc193f7ff7983c020c8b0e706aab013ee30af5d457d35c4de4a698",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpatch",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "14.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-jsonpatch-1.21-14.fc34.noarch.rpm",
+        "checksum": "sha256:e0dffa204780c20c16357a51b992351aa1cf9f9cdda6182939ecd0cd7ab2c2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpointer",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-jsonpointer-2.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:1b1af6b54050ec223c3289b107a9695a686c9d46d17a80ec9cd5d0201ec5d544",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonschema",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-jsonschema-3.2.0-9.fc34.noarch.rpm",
+        "checksum": "sha256:d6810c97f24d93cd54a61bb288ada8591a94e4083b5165e0719915bceb637504",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt+crypto",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-jwt+crypto-1.7.1-11.fc34.noarch.rpm",
+        "checksum": "sha256:9cc240ac305a862146e85d8dcc4ad981f5233a58b6901ecfac691d0b39966b49",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-jwt-1.7.1-11.fc34.noarch.rpm",
+        "checksum": "sha256:131adc47f044c9f600f5295ded0f5431cda57fa7276100c3ec81c9d1ce3fa6f7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libselinux",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-libselinux-3.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:8a27704e62c90406df6793be2c8e2cb1fa4919f761795bef604843f8894ab639",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-libsemanage-3.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:a0ec96e637f6acb65409eb32f90fc9bccfd7fbfb494ded90106eb70eaf7cdd0b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "10.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-markupsafe-1.1.1-10.fc34.x86_64.rpm",
+        "checksum": "sha256:d9bc0ebdccb79160632bc50abca0ec13fec191dd3cfe8ed032d07e91c8314851",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib+signedtoken",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-oauthlib+signedtoken-3.0.2-9.fc34.noarch.rpm",
+        "checksum": "sha256:b30db4e3d9605e7263387ff91f91508667693d28e8b8835a2b7fcefd64f24388",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-oauthlib-3.0.2-9.fc34.noarch.rpm",
+        "checksum": "sha256:f9b2e7232d0b2d33bf52993c31b43b31520601f52f44fe792acd6dee4d84afc8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ply",
+        "epoch": 0,
+        "version": "3.11",
+        "release": "11.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-ply-3.11-11.fc34.noarch.rpm",
+        "checksum": "sha256:23e3ed871799a9209915359f71660babf451b0b44902e3ed488b7b22aff37718",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-policycoreutils-3.2-1.fc34.noarch.rpm",
+        "checksum": "sha256:e76f1401d9e119eae4cc461c8b68e9eae075d4b69f61870cb5c19ba7d69cf1a3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "25.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-prettytable-0.7.2-25.fc34.noarch.rpm",
+        "checksum": "sha256:cc4401d1e292b28d771a2038081b929b342ffa3b60358aed91697fdbc668546a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pycparser",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-pycparser-2.20-3.fc34.noarch.rpm",
+        "checksum": "sha256:32220dc513a6ebcd4994e7140ecb5859108baf44d12fe6b1f0c0459dbefc54e7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyserial",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "10.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-pyserial-3.4-10.fc34.noarch.rpm",
+        "checksum": "sha256:70a90c6c682016e91fb4745eedbd23f28e150a38b01d18f85ce4e50fb4e0ca6c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "8.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-pysocks-1.7.1-8.fc34.noarch.rpm",
+        "checksum": "sha256:4a74ae08a713e9b4e74ff27bfaf57374312370402f90e2796e66c504557ae189",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-pyyaml-5.4.1-2.fc34.x86_64.rpm",
+        "checksum": "sha256:09a0a4702e0f716caaf6f8e75dc478d3d70bf3fbd074a76fb4d6f8492af7c138",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-requests-2.25.1-1.fc34.noarch.rpm",
+        "checksum": "sha256:6297d7eee103c679a0f1ea411568d3940af3fe8f38e19388a1544df70bda8b3c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-rpm-4.16.1.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:45783e958a60d62115e29b961a4b374340a996784b6fc973d088e3e8020d4e24",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.4.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-setools-4.4.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:581e6c46abab18afc9725f561894b0a41b9f3c15e778588a1874efb2324ef144",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.15.0",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/p/python3-six-1.15.0-5.fc34.noarch.rpm",
+        "checksum": "sha256:b5d5e7255c85c3aa9d63598ef140de35843ab2485adf1cb9a9130be80aa0297f",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/readline-8.1-2.fc34.x86_64.rpm",
+        "checksum": "sha256:b34c767bab93fb626c993b98e10547779fa5bec98865b9a66b914e45b4b14f6e",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "29.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rootfiles-8.1-29.fc34.noarch.rpm",
+        "checksum": "sha256:164e1c0e3e8c89aeda4f272b3158932649a69b16aea058105117a64d3cdef517",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-4.16.1.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:8857513982b0c12e02eb0593baa9dc7cf570f2761a6bb4996fc8cf7d98402444",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-build-libs-4.16.1.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:ba8625030f89d7dbb04d8aff5d542f65637c4f65d89adf687f1127469fe3c51e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-libs-4.16.1.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:38731e49cb0ee6a0d98f736ec1ee5605ed3a12cf3c119bb3f140ccf42500d6b3",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-selinux-4.16.1.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:eb364f59cee096d59098939b2260db3f8cec8d3a5762b62a347e2c70db20d998",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:af7e6d438ee1773df790f32d12093e4e7ff94537ce556679145e58dcf345a4ae",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.16.1.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rpm-sign-libs-4.16.1.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:83dd0474d7e81226936f35ce59a27dc69d01060f052775216151b39f6d0f4365",
+        "check_gpg": true
+      },
+      {
+        "name": "rsync",
+        "epoch": 0,
+        "version": "3.2.3",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/r/rsync-3.2.3-5.fc34.x86_64.rpm",
+        "checksum": "sha256:df6e40a2f87fb634126d1a97d19b6f45a3623cf108a2dd1653608891e1d12deb",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "7.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sed-4.8-7.fc34.x86_64.rpm",
+        "checksum": "sha256:a0b294cdc4585a0ac04fdc6f84a4fdc08f10afcaebe28ec60370622d43bfe33d",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.7",
+        "release": "3.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/setup-2.13.7-3.fc34.noarch.rpm",
+        "checksum": "sha256:3dcf5a6091d96a71cb45ff0896d0520e798ab1a7df34cac040311dbb0bb81ab5",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.1",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/shared-mime-info-2.1-2.fc34.x86_64.rpm",
+        "checksum": "sha256:ea9851b961b645165a931d3953ec4f0c6d35eb917ac7a982fd52fa847768fc31",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.34.1",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sqlite-libs-3.34.1-2.fc34.x86_64.rpm",
+        "checksum": "sha256:b88ba4db01c7bdc41b3c6b85d0670d429d19a701c33d604e6da331a0a6fa523f",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.5p2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sudo-1.9.5p2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:7d59ff94c9fa323e68c6f9d5b0ccc06075847d77775211f4acbee8f54d8975ae",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.5p2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/sudo-python-plugin-1.9.5p2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:84e5dd6e3ef3d1a8447fd8c5e71e7c5baca25d96b85440ef0c8e73a2209560c4",
+        "check_gpg": true
+      },
+      {
+        "name": "syslinux",
+        "epoch": 0,
+        "version": "6.04",
+        "release": "0.17.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/syslinux-6.04-0.17.fc34.x86_64.rpm",
+        "checksum": "sha256:1a3c32056482e59ce2e6ef29270f6abb0567bcd0345b3d7fe76ff2b4e4bd8f7c",
+        "check_gpg": true
+      },
+      {
+        "name": "syslinux-extlinux",
+        "epoch": 0,
+        "version": "6.04",
+        "release": "0.17.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/syslinux-extlinux-6.04-0.17.fc34.x86_64.rpm",
+        "checksum": "sha256:10d3680b3b99f8585bf95ffb53e14e1d2956acd2c2d0f892c8cbf93a9861af12",
+        "check_gpg": true
+      },
+      {
+        "name": "syslinux-extlinux-nonlinux",
+        "epoch": 0,
+        "version": "6.04",
+        "release": "0.17.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/syslinux-extlinux-nonlinux-6.04-0.17.fc34.noarch.rpm",
+        "checksum": "sha256:5afd3d5069dec788145b4fc51d2445d2c9ac021414b4821e99147dd66928d2cf",
+        "check_gpg": true
+      },
+      {
+        "name": "syslinux-nonlinux",
+        "epoch": 0,
+        "version": "6.04",
+        "release": "0.17.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/s/syslinux-nonlinux-6.04-0.17.fc34.noarch.rpm",
+        "checksum": "sha256:ef22650f127e4109d16f6bb795277f4bee328eaaaac39ec7c43aa2053f5f770f",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/tar-1.34-1.fc34.x86_64.rpm",
+        "checksum": "sha256:7b574e38bfd9854f3a4411a73df63c32d65cd0511577461cc2596049501a3725",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/trousers-0.3.15-2.fc34.x86_64.rpm",
+        "checksum": "sha256:019c0bdb989459f7aed88f534cf96af8e720cb5a0ffa7d514f6b8de5e62eb9e3",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/t/trousers-lib-0.3.15-2.fc34.x86_64.rpm",
+        "checksum": "sha256:b53a61b34e0bc3cc693bcb82e1e494d201098db149dd38106cb97b6923ec3093",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.36.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/u/util-linux-2.36.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:8242972295a6a3d2426ed7756eabb0fb2eabe871894399375a54271ddec56d14",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.10.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/x/xfsprogs-5.10.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:e61dc56977e3d8e506174f9959ea3b41ae987aeb515e8695fa9fb22f7f5c3d12",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/x/xz-5.2.5-5.fc34.x86_64.rpm",
+        "checksum": "sha256:237a8756303db7712e91d2b52c428464b401b3295c6c50c5d23a2ebef2f88beb",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/x/xz-libs-5.2.5-5.fc34.x86_64.rpm",
+        "checksum": "sha256:c8e0cdf3260afc4ce9c115f30df68182faaa02944cdaeeb5c20161430f82c8e5",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "26.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/Packages/z/zlib-1.2.11-26.fc34.x86_64.rpm",
+        "checksum": "sha256:0ebe43a9bef7ec2dc4cb98350fbde2e55dae886f905e2d9cea837da3fb613c87",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.30.6",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/n/NetworkManager-1.30.6-1.fc34.x86_64.rpm",
+        "checksum": "sha256:344b1cc4edb49b7ac10f0d401fde43a2b67a61867652381825a24124d4af4d75",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.30.6",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.30.6-1.fc34.x86_64.rpm",
+        "checksum": "sha256:8d171fb436059f8ae1ba31f762c35e3ff96304b0e48e59842502d697bc04cdd3",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/a/audit-3.0.6-1.fc34.x86_64.rpm",
+        "checksum": "sha256:54616250eab59e08603e591ff38c1b4929d7799996b4834225ed2920e73bb379",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/a/audit-libs-3.0.6-1.fc34.x86_64.rpm",
+        "checksum": "sha256:6c5db6a0eb030c42b41b8e533c559ef81967dbb513d539754ff79b6c407d80d9",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/c-ares-1.17.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:80044e9d36ea73df2b3f3a947384a93182c0dd81a724741c24ae2b967338c384",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc34.noarch.rpm",
+        "checksum": "sha256:263b3d24403ef80313d3fa983b3276c653d1f9f1fa0f1e3ba530f8fcaf9e621a",
+        "check_gpg": true
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/chrony-4.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:4efbc2de7c8d2fcd78f542bf3e92a2d65084a08fff0a56f323c35ca0d4b98eb1",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/coreutils-8.32-30.fc34.x86_64.rpm",
+        "checksum": "sha256:1eead3a3a0b0ff0a9776309d838e0b154f6ad64f1e4a59dc773f3159c118dff0",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "30.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/coreutils-common-8.32-30.fc34.x86_64.rpm",
+        "checksum": "sha256:c568c7d0939faa7f3321d95d16ad6c84fb1e81e3c5b14b40bccc61fc3574bbc4",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/cracklib-2.9.6-27.fc34.x86_64.rpm",
+        "checksum": "sha256:8d75d66318cdf547cf7f141e149abd7fbaddf33eea71156e32f5b68edcfa81ec",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/cracklib-dicts-2.9.6-27.fc34.x86_64.rpm",
+        "checksum": "sha256:68e068283ebde084fc71d7adbfd29e519f37416fb8bcf746f89693d1ce90d0f3",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.3.6-1.fc34.x86_64.rpm",
+        "checksum": "sha256:f792d09a27deb8c45c2f0887351a3bea684b79ccb6127f8c59512f8866016daa",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/c/curl-7.76.1-12.fc34.x86_64.rpm",
+        "checksum": "sha256:ea89f3a15fdd80587a928ec156bdbdb1321c01c4c753e4eca036584e575e7e2f",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dbus-broker-29-2.fc34.x86_64.rpm",
+        "checksum": "sha256:5bc92a98366f89a5bd1089e60178ffac8b5111dfde74b34cf12ed27e1359cf08",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "11.b1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dhcp-client-4.4.2-11.b1.fc34.x86_64.rpm",
+        "checksum": "sha256:2b9ff5e4d35b7ede55110ead06f4f2aa326e6a45040ea2638eb03d30d1fe113a",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "11.b1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dhcp-common-4.4.2-11.b1.fc34.noarch.rpm",
+        "checksum": "sha256:11cd6fae157eb9e4800163633b57bcce21d59a1df4b86a99ba03707b6cee0cfc",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ad022321f0a562a8a5da1f841f71193166c67500deb7b54c905808b227e54589",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-data-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:0626d97e40232bdbb3c38549ebbad7af1e4e25dfe1ecc11e214059e742c4192e",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc34.noarch.rpm",
+        "checksum": "sha256:1feb6a045cb3e95e3c8e0112ecb4b8ffeb9986a503b52c5497fefce217846b90",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc34.x86_64.rpm",
+        "checksum": "sha256:bccfdce40119616d620fa9ddc61876a471ce2cf6f558d226910454f5b289d5b7",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc34.x86_64.rpm",
+        "checksum": "sha256:22ecb93be24849e734db3546e01dac762d152f22113b593b635544e256b98b52",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc34.x86_64.rpm",
+        "checksum": "sha256:6351c0b6cb6af4444e033c0558727e92298695eda47492af65a678e13a6ee1f2",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc34.noarch.rpm",
+        "checksum": "sha256:a22d334b48957e83819ffb1e07bef958fd8f70130864ead40a41af1100e3a41c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc34.x86_64.rpm",
+        "checksum": "sha256:f1f078ebde340cb37f7049555e78906b54e42ce22703e878305783a4b91e0477",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc34.x86_64.rpm",
+        "checksum": "sha256:3b7916a277cd7dac44e861b56c0915977f36396d5b4f5007508bf7c90f93e7bf",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/e/expat-2.4.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:59cfafb5b96fdb1d219743aaf3dfc72de9f2da527efc9c9db3c87815cade7517",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-gpg-keys-34-2.noarch.rpm",
+        "checksum": "sha256:a52149f5107e0ccb70940d0c767db37ae809bd4a3e6f107756614edc561793b0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-cloud",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-release-cloud-34-39.noarch.rpm",
+        "checksum": "sha256:d54b628e6d0b7813ec0b4cc0beb1b8f3f8510ffbaff8ae1d9c4b9993095e4edf",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-release-common-34-39.noarch.rpm",
+        "checksum": "sha256:7f6376e3a393b2501d6c38a8b82b8ebc54265e9b4cf3bb54f3e164a9aaf078f0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-cloud",
+        "epoch": 0,
+        "version": "34",
+        "release": "39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-cloud-34-39.noarch.rpm",
+        "checksum": "sha256:e035a5041c721ea40e47cbbc19eb1b91c520183f85137ee1dd3ed3b42a47c180",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-repos-34-2.noarch.rpm",
+        "checksum": "sha256:6aecfeee9cb3aa46d9fce1d37e51132aae345de3c9348f2b91ceecbf66936bb6",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "34",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/fedora-repos-modular-34-2.noarch.rpm",
+        "checksum": "sha256:eb88e660b9fd02e695a90c0266831b79e513c2f65ba5d6353e82726af96e9752",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/file-5.39-7.fc34.x86_64.rpm",
+        "checksum": "sha256:d5f486b818d86d5f79a5dd619b24abc039496801fb3d54134322715a9c6b489f",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "7.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/f/file-libs-5.39-7.fc34.x86_64.rpm",
+        "checksum": "sha256:442415a2b11394c551e9d3496a325e0365b726543981d98a12e5910eced08115",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.68.4",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glib2-2.68.4-1.fc34.x86_64.rpm",
+        "checksum": "sha256:c14d10994b488aa8f6b78f2aa3850fc4dbf8d791868d08aef8e929780d5012d4",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-2.33-20.fc34.x86_64.rpm",
+        "checksum": "sha256:f53686de3cd500fb010b54f69f7220e4c313453ca5a9aa6c3bbe94566725e838",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-common-2.33-20.fc34.x86_64.rpm",
+        "checksum": "sha256:8e9ab9dc0035e220a6e470553ce4d2fdba896a6630c8e70abee00659e0d8fc75",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-doc",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-doc-2.33-20.fc34.noarch.rpm",
+        "checksum": "sha256:f48d8a9ce5ab8f529f2c89a0e4314f0f670e61f0647b5622869946aa6ed7d800",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-langpack-en",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "20.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/glibc-langpack-en-2.33-20.fc34.x86_64.rpm",
+        "checksum": "sha256:923316dcae9e2da6a7ca355e9c26242cdc8bf21cd09a58934b3de297f6f12eba",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/gnutls-3.7.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:1480de09d5016b10258a24571534f4cdbbd644efb0799c40842f390f0cf65e91",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-9.fc34.noarch.rpm",
+        "checksum": "sha256:9d3e2e24cce87a77671ec717b3c7d9a8aa584768af441c86b0aa7565d6691fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-9.fc34.x86_64.rpm",
+        "checksum": "sha256:d999a3002712972253f264814ccc4cf2b0959a121c3cdd7e10a7c8423f4b6d32",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-9.fc34.noarch.rpm",
+        "checksum": "sha256:7c274d3c094f73d2ee7bebc3b9b854b3303330eac9fa2d1f4461fd7460b34605",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-9.fc34.x86_64.rpm",
+        "checksum": "sha256:5a4b0cc50d9929ef558617fecd879f80a459379047ec77bcc238e5b305258bf5",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "9.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-9.fc34.x86_64.rpm",
+        "checksum": "sha256:6d1b00e8e758af552fcad8be95fa8250d561fbfaa727f8790ea06d72005444b1",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/i/ipcalc-1.0.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:3d6181aa04e1bd81bc2f6d8eb2e5ddf5b18cd1ee8567815ecbf5932393a09f45",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "8.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/i/iptables-legacy-libs-1.8.7-8.fc34.x86_64.rpm",
+        "checksum": "sha256:e0b9fbbfc90d70bff8c64adc104a46b2bc4d9705720d2955468309c9a6d84610",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "8.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/i/iptables-libs-1.8.7-8.fc34.x86_64.rpm",
+        "checksum": "sha256:f58b4687fec5132064c12041f9356a2713c94b31c70c5afdc384e76992d13234",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "100.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/kernel-5.15.13-100.fc34.x86_64.rpm",
+        "checksum": "sha256:547588862120dc0431fa1687ca22b8723114b68aa5c21b95f28055ed556faf2a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "100.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/kernel-core-5.15.13-100.fc34.x86_64.rpm",
+        "checksum": "sha256:98f64ee7318237900c77a4dbf078e3a9dfda7fe907bc9eab9a45e27b2a2d0222",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "100.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-100.fc34.x86_64.rpm",
+        "checksum": "sha256:231740a6624ac820b99bdc0084b4aab99d0d3466a7f0b828cc5451f3ccd251ae",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/kmod-29-2.fc34.x86_64.rpm",
+        "checksum": "sha256:066af2860b14cfc346263dc85c2d320e38d81d078bf3fd88130494a7717b282f",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/kmod-libs-29-2.fc34.x86_64.rpm",
+        "checksum": "sha256:29d944588a122ae56cc35c310dd202601e39e26964a7bf22d04819a5409c07ed",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/k/krb5-libs-1.19.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:1f445df6b58ea1c9eb76d8cc2c9ec2eba81c45f00603c2b9e84eb86e038d4f89",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/less-590-2.fc34.x86_64.rpm",
+        "checksum": "sha256:e43f96ba7bae364527936f5c55f9d3949a97ecf37f57b3cc80b7d9bf93a17cb9",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libarchive-3.5.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:0586d4ad14181d8cca2979449ebec2d4ce1fde826c77feaa91ab47902055abdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcomps-0.1.18-1.fc34.x86_64.rpm",
+        "checksum": "sha256:bd01099dceac0df83ca40ac3ef49ed8b266f867d1c296bc2624c3b5e80c042d3",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.76.1",
+        "release": "12.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libcurl-7.76.1-12.fc34.x86_64.rpm",
+        "checksum": "sha256:c889bbe80604f66c2b72175838c13d00203f8f0dcf0938f0b6c1fb24690a63b2",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "49.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdb-5.3.28-49.fc34.x86_64.rpm",
+        "checksum": "sha256:5f62f6ef1124c3ca2c67bd37e8daee30fc248979d0cf8c65bfc1b6f1c0cb20bd",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libdnf-0.64.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:d45212d3297ef6d46c0614cbfa5ec3874827790f5bc722335e288f2886f001ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libeconf-0.4.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:d4b8f6fcbb1e1d0aca4d44bfd93f72e238b7ff35466c3f332d17a1354b6826c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "38.20210714cvs.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libedit-3.1-38.20210714cvs.fc34.x86_64.rpm",
+        "checksum": "sha256:f5630307e59bd28ac9f87ff56ebaf1752a7b3b79d655771b4a98bbe701573e38",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:af603a6e5e4696cfb1e7a4583940a46c5ef42de39778d55e08a7cde62bc14786",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libgcrypt-1.9.3-3.fc34.x86_64.rpm",
+        "checksum": "sha256:72b1000c285aa522fde63196bdeb3b32e1cff5859d345b753081cdad3cbd76d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:2acde8d21a1d5c88823fd667bbaac59a4af3f8ad47a9e833276f86e8cfcc2275",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "37.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libibverbs-37.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:c555acae201eda07e7f97a6d0c9d8e6d71065dca7efe3fb131f3b29fe1b080ce",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libidn2-2.3.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:0ebb518a40590402136a181c5c0ec8d0c73d3074817bf94bd7a3937eb38ad107",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libldb-2.3.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:37ccd5908e2e2c6a0ded948ffb7cb232f87515fa917bf1651226f6a5cf48b5ed",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libmodulemd-2.13.0-2.fc34.x86_64.rpm",
+        "checksum": "sha256:4508cdcb09754022d64f4057df575726f8b5869e38a61eb63257f8c45f34f418",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.5.4",
+        "release": "2.rc3.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libnfsidmap-2.5.4-2.rc3.fc34.x86_64.rpm",
+        "checksum": "sha256:5cdb39c3cd9ddffe4e363ab60e64838858751547bc547f2cbf9d35c4a36febd4",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libpcap-1.10.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:55819abd7651c8f0e7449967933909fa2c6a0f939e90c6074d4831b633cc6adc",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libpwquality-1.4.4-6.fc34.x86_64.rpm",
+        "checksum": "sha256:8b6e08341d1bd706a7b9f4dd75649db3d74048e1cd469b9310dded90cbda0a14",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/librepo-1.14.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:3b1f267f5eb00000bc8875cee5833f0f46e0892f34de0533e29475e1f17f3810",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libreport-filesystem-2.15.2-2.fc34.noarch.rpm",
+        "checksum": "sha256:21e337fe1378728b64ff60158c397771c46d76165b2898c488996c7cb084821d",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:a7dd48e65cd9bc6254c71d51aa473f0e1a5d99baf1f8ea077652884098969e2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libsepol-3.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:01c9d525eb77975631ff44b67e3ee65492445a3f1861f4f04a25be48218634a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libssh-0.9.6-1.fc34.x86_64.rpm",
+        "checksum": "sha256:46022a4e7d40f858d01fabd50bf2b22705022103d2708805e44ada62ed7ccfe2",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libssh-config-0.9.6-1.fc34.noarch.rpm",
+        "checksum": "sha256:71d6a22bf66430907d0ce7a7c77accd15e1a1033682bbfede6bdda8446b2b3e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libsss_autofs-2.5.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:8b11a97c1d2e28518505364fb1f8bf940e2a5203e80ea6f0cde11cfc420e0a3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libsss_certmap-2.5.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:f5c0b6b252acb19f9b7e3b066be252e6bc9812642fe2e76009ffed365140e236",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libsss_idmap-2.5.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:b3200e9726d4a0def9df15d6cef100a27f928aa198609940c3889f33ee635557",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.5.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:cbcd2e59caa454c8dc7a91c807189fad07a5ad6b4097e9a8c66eb169f911f127",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libsss_sudo-2.5.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:91cdce1b6c90021c8174afd1ab36afab4fab67cb9a8f5df7516fa81c40061015",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:039f11c0333b49318e60b1fa8e5621f16363fe77fb76602eccc085d0897fbdb1",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "0.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libtevent-0.11.0-0.fc34.x86_64.rpm",
+        "checksum": "sha256:12e04c0e335343ce1c87f4a13f22faa3fc8305ad0cc74fa6d755997ddd82ba3a",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "0.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libtirpc-1.3.2-0.fc34.x86_64.rpm",
+        "checksum": "sha256:a2052ecaa71b5dae58df3b651ba3437b098a2a804e55336b819e95a5a49f23f5",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libuser-0.63-4.fc34.x86_64.rpm",
+        "checksum": "sha256:d3494b25cf8bac271fe6b58b149c424e1a438583ffa0808f0750d8e662b305a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc34.x86_64.rpm",
+        "checksum": "sha256:f61173014cf0d8423088cd705352faed48e83a1b13fc33d8af0bfc12dd04f240",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc34.x86_64.rpm",
+        "checksum": "sha256:99bc964d8f2fc46e9ccdc567b159163b72a628432643bdd159464224a9d612c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libxkbcommon-1.3.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:ef9a875e12eb5f50864325121e648a54165aeec9a2b7da12e1630a57c2c33c22",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "4.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libxml2-2.9.12-4.fc34.x86_64.rpm",
+        "checksum": "sha256:d58e0ddac3c208aba6f507ea5df678dab7125dc3f741880cf831b1a76b0072de",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:b58e6fd55e8018e6632ddddc0564201f5cffc314a521f28c9e923c86d760a648",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc34.noarch.rpm",
+        "checksum": "sha256:8ab032e2a86f300d978e521ab030db1e7bb7eeccca205a5d2a4d68b51566f43f",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc34.noarch.rpm",
+        "checksum": "sha256:ce1cb95a026a4c695c0ddb4c9d160e67aa1a7a067ba7460a2921a206163aac7a",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/l/lua-libs-5.4.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:4a2ce807ef248c703b78d6f298a7e7eb64b08528aab890de5608c09e34d54f6c",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/m/mkpasswd-5.5.10-1.fc34.x86_64.rpm",
+        "checksum": "sha256:82473998562b047466a8082308e0e268f665e7a1bac3f7c74e124f2c37d80628",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "7.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/m/mpfr-4.1.0-7.fc34.x86_64.rpm",
+        "checksum": "sha256:a67d8e75329c0f5ab18a0b2a102351a09d2476f0479dea57d2dbb352245a7a03",
+        "check_gpg": true
+      },
+      {
+        "name": "mtools",
+        "epoch": 0,
+        "version": "4.0.36",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/m/mtools-4.0.36-1.fc34.x86_64.rpm",
+        "checksum": "sha256:0c9434feed1a753e13e76a5cce78ffbef99e8dbce74edd23d73af3627b8cd928",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/n/nettle-3.7.3-1.fc34.x86_64.rpm",
+        "checksum": "sha256:45ee87897faec4ad216eb111f76ecde2e7f6b864e63bdff4daf10efc97447eee",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.57",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/openldap-2.4.57-6.fc34.x86_64.rpm",
+        "checksum": "sha256:a196fc793d1578d7c4b423ec49bdf6ef0f792cb0f505fe8c708815315ac29d81",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.6p1",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/openssh-8.6p1-5.fc34.x86_64.rpm",
+        "checksum": "sha256:1b13e55eb2a2e9b7a01031e26f04655eec54a453831c9d68db25932d20e58453",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.6p1",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/openssh-clients-8.6p1-5.fc34.x86_64.rpm",
+        "checksum": "sha256:d737d05827d680cece3b0e6bb32a64f73562d99cfcba16d09ee765134d9a0826",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.6p1",
+        "release": "5.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/openssh-server-8.6p1-5.fc34.x86_64.rpm",
+        "checksum": "sha256:bcd3d68e3e86e62ac4f241cb3aebb35afd58c96558afabe5915a301291b90869",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/o/openssl-libs-1.1.1l-2.fc34.x86_64.rpm",
+        "checksum": "sha256:df22e432aaecb2059b714760bf075922af83e21e0ed5fdbca3185c4871d83c04",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "7.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/pam-1.5.1-7.fc34.x86_64.rpm",
+        "checksum": "sha256:6d01dc580d599af1fd761172c6aa9a602502f782179828586774b199e329ed16",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/pinentry-1.2.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:9c096de45950b1eccb9ae02a0dc83d7f0092cb9b5cfbcd643ad6b8b9c98e11d8",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "1.fc34.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/procps-ng-3.3.17-1.fc34.1.x86_64.rpm",
+        "checksum": "sha256:7d73ab186606e96644c34135f5e48e9407aff309d63f720b2d68aafc6797dfdd",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:3b252b1a9cde822cbbe7b54618defdacb3019c058af26903b9caf4a8a4710774",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python-setuptools-wheel-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:3799e7b1228da60f830f7bb558aa58e87ee968f22f902f2a54e7e739778bc316",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.9.9-2.fc34.noarch.rpm",
+        "checksum": "sha256:439af52b31078ea89d636a495517235a2b5860b0709064d704202edcc3f31d91",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-3.9.9-2.fc34.x86_64.rpm",
+        "checksum": "sha256:c44e6efc9a521ad24b919d7fab92e8864913a2ea994a2134492720648150699f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-audit-3.0.6-1.fc34.x86_64.rpm",
+        "checksum": "sha256:ae8410b779aaa5a5ed108d6b95fd7c2b1fb13f92a06d7c28383f233dcb1c47c7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-babel",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-babel-2.9.1-1.fc34.noarch.rpm",
+        "checksum": "sha256:59cc4d563ecb4c8b517f5dd7505f1cda297f950f32fc700344aa7789b69ca99c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dbus-1.2.18-1.fc34.x86_64.rpm",
+        "checksum": "sha256:6492193577a35112cac513566a71ee3d4cc40c7c2fb84a83a73698b320c2972f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:ed7afd7263d8223e77cb85c3ec7d3b91c511fff0a03f044dfd2df1e72be8c916",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc34.noarch.rpm",
+        "checksum": "sha256:bab19da8b6f553325decae00748f88fc0924b918136f065ab8995e1ebf5bde5b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-hawkey-0.64.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:b0ec886aff26e452de910d567ee5813718ccb8d31c3e1f5b679c6d98c5b3def4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libcomps-0.1.18-1.fc34.x86_64.rpm",
+        "checksum": "sha256:4bb3f608092b602166e090bb72558aa53941819a7d224ef4e52f04ff263e28b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libdnf-0.64.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:ce36cf8a27fdde5af3b1572ffa659daeb28a34ae2a1755bead0209a61f319684",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.9.9",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-libs-3.9.9-2.fc34.x86_64.rpm",
+        "checksum": "sha256:cd33d7742606c567f01e0c2125121cc4fde549ed8789778a7f10ce58bd528aea",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pip",
+        "epoch": 0,
+        "version": "21.0.1",
+        "release": "4.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-pip-21.0.1-4.fc34.noarch.rpm",
+        "checksum": "sha256:09900efbed2e3f17d8ff3d8577047abb062965d5f89bf2f3a35dfc0b602c2bec",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyrsistent",
+        "epoch": 0,
+        "version": "0.17.3",
+        "release": "6.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-pyrsistent-0.17.3-6.fc34.x86_64.rpm",
+        "checksum": "sha256:69773821114b06ee0e5720178f33323d32434ee67ada19a3535d7cc6cc84aaaf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pytz",
+        "epoch": 0,
+        "version": "2021.3",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc34.noarch.rpm",
+        "checksum": "sha256:eecc86b828ad436a9f397d2f7acdf5705bfd36bcad3edd2da73f3acc94363411",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "2.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-setuptools-53.0.0-2.fc34.noarch.rpm",
+        "checksum": "sha256:7efcbd1520047a5ffe36e0c30ce940467ab5dde5068dcb2a97b8fb986afc2527",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-unbound-1.13.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:d426f6a395246d9b0097dbbb097723c8d1c59aeb36c95c9300536363b70ef8b6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.25.10",
+        "release": "5.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/p/python3-urllib3-1.25.10-5.fc34.noarch.rpm",
+        "checksum": "sha256:f3c4ecb4440cef3f0151ef6a756edf54c790c56a1ff7d018b51fa27454199348",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc34.x86_64.rpm",
+        "checksum": "sha256:983a18e776aab5b2ae41f0cfa6a7da303de275f65f9d8c318b6ba99d19d3590f",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/selinux-policy-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:68330c4bb9a4ea3c6133aff170db07af654ea07ed82ef658ead35948f046d1cc",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "34.23",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/selinux-policy-targeted-34.23-1.fc34.noarch.rpm",
+        "checksum": "sha256:2dde59b0f889ca278c8db754fa02fa9da884424dac806a6d134827b5707993df",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.8.1",
+        "release": "10.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.8.1-10.fc34.x86_64.rpm",
+        "checksum": "sha256:c1f4a6f3bda5087a680c2a940fae2e02f0199c95a949dddc227390336681a405",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/sssd-client-2.5.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:bc67ce199727a497116c32ad260bf75c90ffeab9fa45960c2f7d8f725ffc87c0",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/sssd-common-2.5.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:11f35d539334ee51f49c19be2ef596082e818511638070a9d41a4681fa61d279",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/sssd-kcm-2.5.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:ac474501243d1a59ad02fdea585eaf523cd3d1aefeceead4f697fc92e3c30632",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.5.2",
+        "release": "2.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.5.2-2.fc34.x86_64.rpm",
+        "checksum": "sha256:66f820e1083c42d6a6b29a880720fd03a79edc66f32f8bc94e44461feafb02bb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-248.9-1.fc34.x86_64.rpm",
+        "checksum": "sha256:3b5f5b2129930d6eff8abcdadf70287fe92480c8deb9b622d1b31d7178e84e2d",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-libs-248.9-1.fc34.x86_64.rpm",
+        "checksum": "sha256:b0d3b898968868b627f62a2f1b18257dc89f4e04c5c3adc8c25baa36c6cf5fa6",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-networkd-248.9-1.fc34.x86_64.rpm",
+        "checksum": "sha256:f43356bc92e900004026937f9af3b350f7298b5040ec30fefd4e260bcaea6540",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-oomd-defaults-248.9-1.fc34.x86_64.rpm",
+        "checksum": "sha256:862eaaa6e3a3cee2baf0bf4027c85d513d1a16edb8cdf7814208e0b4f0c66db0",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-pam-248.9-1.fc34.x86_64.rpm",
+        "checksum": "sha256:90008dbecc37d3e4b9f495a2e2d92478094b6be272fb849017f8e3f51541e08f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-rpm-macros",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-rpm-macros-248.9-1.fc34.noarch.rpm",
+        "checksum": "sha256:c06454f0d06efc160c0d79156166b8707b8c1d0e94903889074f749c461aa1e8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "248.9",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/s/systemd-udev-248.9-1.fc34.x86_64.rpm",
+        "checksum": "sha256:b1db042b9b66ec1f24b59cac5fbb7acced19ae474399862406bc6737b434a9de",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tpm2-tss-3.1.0-1.fc34.x86_64.rpm",
+        "checksum": "sha256:de8e2416adfa4476e6fe7fdb79b1e949e0850618545c6903af9ad450e0dca2c9",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc34.noarch.rpm",
+        "checksum": "sha256:bbc34c1e2971e3b31071b016b641e86e7298d935fdc9d44e4b5b94d91a385adb",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/u/unbound-libs-1.13.2-1.fc34.x86_64.rpm",
+        "checksum": "sha256:6737dd0879348494f235a05aabd9b55bf54ac1b0f635758b76a1ae369fce06c8",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.3755",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/v/vim-data-8.2.3755-1.fc34.noarch.rpm",
+        "checksum": "sha256:adcd36cb0e582f5fb2d0465cf88bb813ffac17d25d6ec8aa608b647d008bebc3",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.3755",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/v/vim-minimal-8.2.3755-1.fc34.x86_64.rpm",
+        "checksum": "sha256:9e879df34e32ec5085e9863adb1221d2cb6b1cea1b4bd7d2345d7bfe91f66897",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "26.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/w/which-2.21-26.fc34.x86_64.rpm",
+        "checksum": "sha256:867da92a40eadf047aa6c4127cd0858b514ecb372c4fcdcb63bba87473c99fd8",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/w/whois-nls-5.5.10-1.fc34.noarch.rpm",
+        "checksum": "sha256:244f463f8a459211531e8537fe8de06599bbd1c75e74d665f4e82c636654be00",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/x/xkeyboard-config-2.33-1.fc34.noarch.rpm",
+        "checksum": "sha256:bcb5360f872256ffbc138e0ef79a53bed371f752499acce113077704e5ae75ee",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc34",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/y/yum-4.9.0-1.fc34.noarch.rpm",
+        "checksum": "sha256:30bc3583e503e0f459e323b27551f7b9a8ab784de15437b5b29f447b31f8d9cd",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "1.fc34",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220113/Packages/z/zchunk-libs-1.1.15-1.fc34.x86_64.rpm",
+        "checksum": "sha256:181b0cb7e49502dc59fff686869f29fc2500e6deba51d9b82da508dfcddfe03c",
+        "check_gpg": true
+      }
+    ]
+  },
+  "image-info": {
+    "/etc/resolv.conf": [],
+    "boot-environment": {
+      "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+    },
+    "bootloader": "grub",
+    "bootmenu": [
+      {
+        "grub_arg": "--unrestricted",
+        "grub_class": "fedora",
+        "grub_users": "$grub_users",
+        "initrd": "/boot/initramfs-5.15.13-100.fc34.x86_64.img",
+        "linux": "/boot/vmlinuz-5.15.13-100.fc34.x86_64",
+        "options": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8",
+        "title": "Fedora (5.15.13-100.fc34.x86_64) 34 (Cloud Edition)",
+        "version": "5.15.13-100.fc34.x86_64"
+      }
+    ],
+    "chrony": {
+      "leapsectz": [
+        "right/UTC"
+      ],
+      "pool": [
+        "2.fedora.pool.ntp.org iburst"
+      ]
+    },
+    "cloud-init": {
+      "/etc/cloud": {
+        "cloud.cfg": {
+          "cloud_config_modules": [
+            "ssh-import-id",
+            "locale",
+            "set-passwords",
+            "spacewalk",
+            "yum-add-repo",
+            "ntp",
+            "timezone",
+            "disable-ec2-metadata",
+            "runcmd"
+          ],
+          "cloud_final_modules": [
+            "package-update-upgrade-install",
+            "puppet",
+            "chef",
+            "mcollective",
+            "salt-minion",
+            "reset_rmc",
+            "refresh_rmc_and_interface",
+            "rightscale_userdata",
+            "scripts-vendor",
+            "scripts-per-once",
+            "scripts-per-boot",
+            "scripts-per-instance",
+            "scripts-user",
+            "ssh-authkey-fingerprints",
+            "keys-to-console",
+            "phone-home",
+            "final-message",
+            "power-state-change"
+          ],
+          "cloud_init_modules": [
+            "migrator",
+            "seed_random",
+            "bootcmd",
+            "write-files",
+            "growpart",
+            "resizefs",
+            "disk_setup",
+            "mounts",
+            "set_hostname",
+            "update_hostname",
+            "update_etc_hosts",
+            "ca-certs",
+            "rsyslog",
+            "users-groups",
+            "ssh"
+          ],
+          "disable_root": true,
+          "mount_default_fields": [
+            null,
+            null,
+            "auto",
+            "defaults,nofail",
+            "0",
+            "2"
+          ],
+          "preserve_hostname": false,
+          "resize_rootfs_tmp": "/dev",
+          "ssh_pwauth": 0,
+          "system_info": {
+            "default_user": {
+              "gecos": "fedora Cloud User",
+              "groups": [
+                "wheel",
+                "adm",
+                "systemd-journal"
+              ],
+              "lock_passwd": true,
+              "name": "fedora",
+              "shell": "/bin/bash",
+              "sudo": [
+                "ALL=(ALL) NOPASSWD:ALL"
+              ]
+            },
+            "distro": "fedora",
+            "paths": {
+              "cloud_dir": "/var/lib/cloud/",
+              "templates_dir": "/etc/cloud/templates/"
+            },
+            "ssh_svcname": "sshd"
+          },
+          "users": [
+            "default"
+          ]
+        }
+      },
+      "/etc/cloud/cloud.cfg.d": {
+        "05_logging.cfg": {
+          "_log": [
+            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
+            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
+          ],
+          "log_cfgs": [
+            [
+              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
+            ]
+          ],
+          "output": {
+            "all": "| tee -a /var/log/cloud-init-output.log"
+          }
+        }
+      }
+    },
+    "default-target": "graphical.target",
+    "dracut": {
+      "/usr/lib/dracut/dracut.conf.d": {
+        "01-dist.conf": {
+          "dbus": "/usr/share/dbus-1",
+          "dbusconfdir": "/etc/dbus-1",
+          "dbusinterfaces": "/usr/share/dbus-1/interfaces",
+          "dbusinterfacesconfdir": "/etc/dbus-1/interfaces",
+          "dbusservices": "/usr/share/dbus-1/services",
+          "dbusservicesconfdir": "/etc/dbus-1/services",
+          "dbussession": "/usr/share/dbus-1/session.d",
+          "dbussessionconfdir": "/etc/dbus-1/session.d",
+          "dbussystem": "confdir/etc/dbus-1/system.d",
+          "dbussystemservices": "/usr/share/dbus-1/system-services",
+          "dbussystemservicesconfdir": "/etc/dbus-1/system-services",
+          "early_microcode": "yes",
+          "environment": "/usr/lib/environment.d",
+          "environmentconfdir": "/etc/environment.d",
+          "hostonly": "yes",
+          "hostonly_cmdline": "no",
+          "i18n_default_font": "eurlatgr",
+          "i18n_install_all": "yes",
+          "i18n_vars": "/etc/sysconfig/keyboard:KEYTABLE-KEYMAP /etc/sysconfig/i18n:SYSFONT-FONT,FONTACM-FONT_MAP,FONT_UNIMAP",
+          "install_optional_items": " vi /etc/virc ps grep cat rm ",
+          "prefix": "/",
+          "reproducible": "yes",
+          "stdloglvl": "3",
+          "sysctlconfdir": "/etc/sysctl.d",
+          "sysctld": "/usr/lib/sysctl.d",
+          "sysloglvl": "5",
+          "systemdcatalog": "/usr/lib/systemd/catalog",
+          "systemdntpunits": "/usr/lib/systemd/ntp-units.d",
+          "systemdntpunitsconfdir": "/etc/systemd/ntp-units.d",
+          "systemdportable": "/usr/lib/systemd/portable",
+          "systemdportableconfdir": "/etc/systemd/portable",
+          "systemdsystemconfdir": "/etc/systemd/system",
+          "systemdsystemunitdir": "/usr/lib/systemd/system",
+          "systemduser": "/usr/lib/systemd/user",
+          "systemduserconfdir": "/etc/systemd/user",
+          "systemdutilconfdir": "/etc/systemd",
+          "systemdutildir": "/usr/lib/systemd",
+          "sysusers": "/usr/lib/sysusers.d",
+          "sysusersconfdir": "/etc/sysusers.d",
+          "udevdir": "/usr/lib/udev"
+        },
+        "02-generic-image.conf": {
+          "hostonly": "no"
+        }
+      }
+    },
+    "fstab": [
+      [
+        "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+        "/",
+        "ext4",
+        "defaults",
+        "1",
+        "1"
+      ]
+    ],
+    "groups": [
+      "adm:x:4:",
+      "audio:x:63:",
+      "bin:x:1:",
+      "cdrom:x:11:",
+      "chrony:x:994:",
+      "daemon:x:2:",
+      "dbus:x:81:",
+      "dialout:x:18:",
+      "disk:x:6:",
+      "floppy:x:19:",
+      "ftp:x:50:",
+      "games:x:20:",
+      "input:x:104:",
+      "kmem:x:9:",
+      "kvm:x:36:",
+      "lock:x:54:",
+      "lp:x:7:",
+      "mail:x:12:",
+      "man:x:15:",
+      "mem:x:8:",
+      "nobody:x:65534:",
+      "render:x:105:",
+      "root:x:0:",
+      "sgx:x:106:",
+      "ssh_keys:x:996:",
+      "sshd:x:74:",
+      "sys:x:3:",
+      "systemd-coredump:x:999:",
+      "systemd-journal:x:190:",
+      "systemd-network:x:192:",
+      "systemd-oom:x:998:",
+      "systemd-resolve:x:193:",
+      "systemd-timesync:x:997:",
+      "tape:x:33:",
+      "tss:x:59:",
+      "tty:x:5:",
+      "unbound:x:995:",
+      "users:x:100:",
+      "utempter:x:35:",
+      "utmp:x:22:",
+      "video:x:39:",
+      "wheel:x:10:"
+    ],
+    "hostname": "localhost.localdomain",
+    "hosts": [
+      "127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4",
+      "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
+    ],
+    "image-format": {
+      "compat": "1.1",
+      "type": "qcow2"
+    },
+    "locale": {
+      "LANG": "en_US"
+    },
+    "machine-id": "",
+    "os-release": {
+      "ANSI_COLOR": "0;38;2;60;110;180",
+      "BUG_REPORT_URL": "https://bugzilla.redhat.com/",
+      "CPE_NAME": "cpe:/o:fedoraproject:fedora:34",
+      "DOCUMENTATION_URL": "https://docs.fedoraproject.org/en-US/fedora/f34/system-administrators-guide/",
+      "HOME_URL": "https://fedoraproject.org/",
+      "ID": "fedora",
+      "LOGO": "fedora-logo-icon",
+      "NAME": "Fedora",
+      "PLATFORM_ID": "platform:f34",
+      "PRETTY_NAME": "Fedora 34 (Cloud Edition)",
+      "PRIVACY_POLICY_URL": "https://fedoraproject.org/wiki/Legal:PrivacyPolicy",
+      "REDHAT_BUGZILLA_PRODUCT": "Fedora",
+      "REDHAT_BUGZILLA_PRODUCT_VERSION": "34",
+      "REDHAT_SUPPORT_PRODUCT": "Fedora",
+      "REDHAT_SUPPORT_PRODUCT_VERSION": "34",
+      "SUPPORT_URL": "https://fedoraproject.org/wiki/Communicating_and_getting_help",
+      "VARIANT": "Cloud Edition",
+      "VARIANT_ID": "cloud",
+      "VERSION": "34 (Cloud Edition)",
+      "VERSION_CODENAME": "",
+      "VERSION_ID": "34"
+    },
+    "packages": [
+      "NetworkManager-1.30.6-1.fc34.x86_64",
+      "NetworkManager-libnm-1.30.6-1.fc34.x86_64",
+      "acl-2.3.1-1.fc34.x86_64",
+      "alternatives-1.15-2.fc34.x86_64",
+      "audit-3.0.6-1.fc34.x86_64",
+      "audit-libs-3.0.6-1.fc34.x86_64",
+      "basesystem-11-11.fc34.noarch",
+      "bash-5.1.0-2.fc34.x86_64",
+      "bzip2-libs-1.0.8-6.fc34.x86_64",
+      "c-ares-1.17.2-1.fc34.x86_64",
+      "ca-certificates-2021.2.52-1.0.fc34.noarch",
+      "checkpolicy-3.2-1.fc34.x86_64",
+      "chrony-4.1-1.fc34.x86_64",
+      "cloud-init-20.4-2.fc34.noarch",
+      "cloud-utils-growpart-0.31-8.fc34.noarch",
+      "console-login-helper-messages-0.21.2-1.fc34.noarch",
+      "console-login-helper-messages-issuegen-0.21.2-1.fc34.noarch",
+      "console-login-helper-messages-motdgen-0.21.2-1.fc34.noarch",
+      "console-login-helper-messages-profile-0.21.2-1.fc34.noarch",
+      "coreutils-8.32-30.fc34.x86_64",
+      "coreutils-common-8.32-30.fc34.x86_64",
+      "cpio-2.13-10.fc34.x86_64",
+      "cracklib-2.9.6-27.fc34.x86_64",
+      "cracklib-dicts-2.9.6-27.fc34.x86_64",
+      "crypto-policies-20210213-1.git5c710c0.fc34.noarch",
+      "crypto-policies-scripts-20210213-1.git5c710c0.fc34.noarch",
+      "cryptsetup-libs-2.3.6-1.fc34.x86_64",
+      "curl-7.76.1-12.fc34.x86_64",
+      "cyrus-sasl-lib-2.1.27-8.fc34.x86_64",
+      "dbus-1.12.20-3.fc34.x86_64",
+      "dbus-broker-29-2.fc34.x86_64",
+      "dbus-common-1.12.20-3.fc34.noarch",
+      "dbus-libs-1.12.20-3.fc34.x86_64",
+      "dejavu-sans-fonts-2.37-16.fc34.noarch",
+      "deltarpm-3.6.2-8.fc34.x86_64",
+      "device-mapper-1.02.175-1.fc34.x86_64",
+      "device-mapper-libs-1.02.175-1.fc34.x86_64",
+      "dhcp-client-4.4.2-11.b1.fc34.x86_64",
+      "dhcp-common-4.4.2-11.b1.fc34.noarch",
+      "diffutils-3.7-8.fc34.x86_64",
+      "dnf-4.9.0-1.fc34.noarch",
+      "dnf-data-4.9.0-1.fc34.noarch",
+      "dnf-plugins-core-4.0.24-1.fc34.noarch",
+      "dracut-055-6.fc34.x86_64",
+      "dracut-config-generic-055-6.fc34.x86_64",
+      "e2fsprogs-1.45.6-5.fc34.x86_64",
+      "e2fsprogs-libs-1.45.6-5.fc34.x86_64",
+      "elfutils-debuginfod-client-0.186-1.fc34.x86_64",
+      "elfutils-default-yama-scope-0.186-1.fc34.noarch",
+      "elfutils-libelf-0.186-1.fc34.x86_64",
+      "elfutils-libs-0.186-1.fc34.x86_64",
+      "expat-2.4.1-1.fc34.x86_64",
+      "fedora-gpg-keys-34-2.noarch",
+      "fedora-release-cloud-34-39.noarch",
+      "fedora-release-common-34-39.noarch",
+      "fedora-release-identity-cloud-34-39.noarch",
+      "fedora-repos-34-2.noarch",
+      "fedora-repos-modular-34-2.noarch",
+      "file-5.39-7.fc34.x86_64",
+      "file-libs-5.39-7.fc34.x86_64",
+      "filesystem-3.14-5.fc34.x86_64",
+      "findutils-4.8.0-2.fc34.x86_64",
+      "fonts-filesystem-2.0.5-5.fc34.noarch",
+      "fuse-libs-2.9.9-11.fc34.x86_64",
+      "gawk-5.1.0-3.fc34.x86_64",
+      "gawk-all-langpacks-5.1.0-3.fc34.x86_64",
+      "gdbm-libs-1.19-2.fc34.x86_64",
+      "gettext-0.21-4.fc34.x86_64",
+      "gettext-libs-0.21-4.fc34.x86_64",
+      "glib2-2.68.4-1.fc34.x86_64",
+      "glibc-2.33-20.fc34.x86_64",
+      "glibc-common-2.33-20.fc34.x86_64",
+      "glibc-doc-2.33-20.fc34.noarch",
+      "glibc-langpack-en-2.33-20.fc34.x86_64",
+      "gmp-6.2.0-6.fc34.x86_64",
+      "gnupg2-2.2.27-4.fc34.x86_64",
+      "gnupg2-smime-2.2.27-4.fc34.x86_64",
+      "gnutls-3.7.2-1.fc34.x86_64",
+      "gpg-pubkey-45719a39-5f2c0192",
+      "gpgme-1.15.1-2.fc34.x86_64",
+      "grep-3.6-2.fc34.x86_64",
+      "groff-base-1.22.4-7.fc34.x86_64",
+      "grub2-common-2.06-9.fc34.noarch",
+      "grub2-pc-2.06-9.fc34.x86_64",
+      "grub2-pc-modules-2.06-9.fc34.noarch",
+      "grub2-tools-2.06-9.fc34.x86_64",
+      "grub2-tools-minimal-2.06-9.fc34.x86_64",
+      "grubby-8.40-51.fc34.x86_64",
+      "gzip-1.10-4.fc34.x86_64",
+      "hostname-3.23-4.fc34.x86_64",
+      "ima-evm-utils-1.3.2-2.fc34.x86_64",
+      "inih-49-3.fc34.x86_64",
+      "initscripts-10.09-1.fc34.x86_64",
+      "ipcalc-1.0.1-1.fc34.x86_64",
+      "iproute-5.10.0-2.fc34.x86_64",
+      "iproute-tc-5.10.0-2.fc34.x86_64",
+      "iptables-legacy-libs-1.8.7-8.fc34.x86_64",
+      "iptables-libs-1.8.7-8.fc34.x86_64",
+      "iputils-20210202-2.fc34.x86_64",
+      "jansson-2.13.1-2.fc34.x86_64",
+      "json-c-0.14-8.fc34.x86_64",
+      "kbd-2.4.0-2.fc34.x86_64",
+      "kbd-misc-2.4.0-2.fc34.noarch",
+      "kernel-5.15.13-100.fc34.x86_64",
+      "kernel-core-5.15.13-100.fc34.x86_64",
+      "kernel-modules-5.15.13-100.fc34.x86_64",
+      "keyutils-libs-1.6.1-2.fc34.x86_64",
+      "kmod-29-2.fc34.x86_64",
+      "kmod-libs-29-2.fc34.x86_64",
+      "kpartx-0.8.5-4.fc34.x86_64",
+      "krb5-libs-1.19.2-2.fc34.x86_64",
+      "langpacks-core-en-3.0-14.fc34.noarch",
+      "langpacks-core-font-en-3.0-14.fc34.noarch",
+      "langpacks-en-3.0-14.fc34.noarch",
+      "less-590-2.fc34.x86_64",
+      "libacl-2.3.1-1.fc34.x86_64",
+      "libarchive-3.5.2-2.fc34.x86_64",
+      "libargon2-20171227-6.fc34.x86_64",
+      "libassuan-2.5.5-1.fc34.x86_64",
+      "libattr-2.5.1-1.fc34.x86_64",
+      "libbasicobjects-0.1.1-47.fc34.x86_64",
+      "libblkid-2.36.2-1.fc34.x86_64",
+      "libbrotli-1.0.9-4.fc34.x86_64",
+      "libcap-2.48-2.fc34.x86_64",
+      "libcap-ng-0.8.2-4.fc34.x86_64",
+      "libcbor-0.7.0-3.fc34.x86_64",
+      "libcollection-0.7.0-47.fc34.x86_64",
+      "libcom_err-1.45.6-5.fc34.x86_64",
+      "libcomps-0.1.18-1.fc34.x86_64",
+      "libcurl-7.76.1-12.fc34.x86_64",
+      "libdb-5.3.28-49.fc34.x86_64",
+      "libdhash-0.5.0-47.fc34.x86_64",
+      "libdnf-0.64.0-1.fc34.x86_64",
+      "libeconf-0.4.0-1.fc34.x86_64",
+      "libedit-3.1-38.20210714cvs.fc34.x86_64",
+      "libevent-2.1.12-3.fc34.x86_64",
+      "libfdisk-2.36.2-1.fc34.x86_64",
+      "libffi-3.1-28.fc34.x86_64",
+      "libfido2-1.6.0-2.fc34.x86_64",
+      "libgcc-11.2.1-1.fc34.x86_64",
+      "libgcrypt-1.9.3-3.fc34.x86_64",
+      "libgomp-11.2.1-1.fc34.x86_64",
+      "libgpg-error-1.42-1.fc34.x86_64",
+      "libibverbs-37.0-1.fc34.x86_64",
+      "libidn2-2.3.2-1.fc34.x86_64",
+      "libini_config-1.3.1-47.fc34.x86_64",
+      "libkcapi-1.2.1-1.fc34.x86_64",
+      "libkcapi-hmaccalc-1.2.1-1.fc34.x86_64",
+      "libksba-1.5.0-2.fc34.x86_64",
+      "libldb-2.3.2-1.fc34.x86_64",
+      "libmaxminddb-1.5.2-1.fc34.x86_64",
+      "libmnl-1.0.4-13.fc34.x86_64",
+      "libmodulemd-2.13.0-2.fc34.x86_64",
+      "libmount-2.36.2-1.fc34.x86_64",
+      "libndp-1.7-7.fc34.x86_64",
+      "libnetfilter_conntrack-1.0.8-2.fc34.x86_64",
+      "libnfnetlink-1.0.1-19.fc34.x86_64",
+      "libnfsidmap-2.5.4-2.rc3.fc34.x86_64",
+      "libnghttp2-1.43.0-2.fc34.x86_64",
+      "libnl3-3.5.0-6.fc34.x86_64",
+      "libnsl2-1.3.0-2.fc34.x86_64",
+      "libpath_utils-0.2.1-47.fc34.x86_64",
+      "libpcap-1.10.1-1.fc34.x86_64",
+      "libpipeline-1.5.3-2.fc34.x86_64",
+      "libpsl-0.21.1-3.fc34.x86_64",
+      "libpwquality-1.4.4-6.fc34.x86_64",
+      "libref_array-0.1.5-47.fc34.x86_64",
+      "librepo-1.14.2-1.fc34.x86_64",
+      "libreport-filesystem-2.15.2-2.fc34.noarch",
+      "libseccomp-2.5.3-1.fc34.x86_64",
+      "libsecret-0.20.4-2.fc34.x86_64",
+      "libselinux-3.2-1.fc34.x86_64",
+      "libselinux-utils-3.2-1.fc34.x86_64",
+      "libsemanage-3.2-1.fc34.x86_64",
+      "libsepol-3.2-2.fc34.x86_64",
+      "libsigsegv-2.13-2.fc34.x86_64",
+      "libsmartcols-2.36.2-1.fc34.x86_64",
+      "libsolv-0.7.17-3.fc34.x86_64",
+      "libss-1.45.6-5.fc34.x86_64",
+      "libssh-0.9.6-1.fc34.x86_64",
+      "libssh-config-0.9.6-1.fc34.noarch",
+      "libsss_autofs-2.5.2-2.fc34.x86_64",
+      "libsss_certmap-2.5.2-2.fc34.x86_64",
+      "libsss_idmap-2.5.2-2.fc34.x86_64",
+      "libsss_nss_idmap-2.5.2-2.fc34.x86_64",
+      "libsss_sudo-2.5.2-2.fc34.x86_64",
+      "libstdc++-11.2.1-1.fc34.x86_64",
+      "libtalloc-2.3.2-2.fc34.x86_64",
+      "libtasn1-4.16.0-4.fc34.x86_64",
+      "libtdb-1.4.3-6.fc34.x86_64",
+      "libtevent-0.11.0-0.fc34.x86_64",
+      "libtextstyle-0.21-4.fc34.x86_64",
+      "libtirpc-1.3.2-0.fc34.x86_64",
+      "libunistring-0.9.10-10.fc34.x86_64",
+      "libusbx-1.0.24-2.fc34.x86_64",
+      "libuser-0.63-4.fc34.x86_64",
+      "libutempter-1.2.1-4.fc34.x86_64",
+      "libuuid-2.36.2-1.fc34.x86_64",
+      "libverto-0.3.2-1.fc34.x86_64",
+      "libxcrypt-4.4.27-1.fc34.x86_64",
+      "libxcrypt-compat-4.4.27-1.fc34.x86_64",
+      "libxkbcommon-1.3.0-1.fc34.x86_64",
+      "libxml2-2.9.12-4.fc34.x86_64",
+      "libyaml-0.2.5-5.fc34.x86_64",
+      "libzstd-1.5.0-1.fc34.x86_64",
+      "linux-atm-libs-2.5.1-28.fc34.x86_64",
+      "linux-firmware-20211216-127.fc34.noarch",
+      "linux-firmware-whence-20211216-127.fc34.noarch",
+      "lmdb-libs-0.9.29-1.fc34.x86_64",
+      "lua-libs-5.4.3-1.fc34.x86_64",
+      "lz4-libs-1.9.3-2.fc34.x86_64",
+      "man-db-2.9.3-3.fc34.x86_64",
+      "memstrack-0.2.2-1.fc34.x86_64",
+      "mkpasswd-5.5.10-1.fc34.x86_64",
+      "mpfr-4.1.0-7.fc34.x86_64",
+      "mtools-4.0.36-1.fc34.x86_64",
+      "ncurses-6.2-4.20200222.fc34.x86_64",
+      "ncurses-base-6.2-4.20200222.fc34.noarch",
+      "ncurses-libs-6.2-4.20200222.fc34.x86_64",
+      "net-tools-2.0-0.59.20160912git.fc34.x86_64",
+      "nettle-3.7.3-1.fc34.x86_64",
+      "npth-1.6-6.fc34.x86_64",
+      "openldap-2.4.57-6.fc34.x86_64",
+      "openssh-8.6p1-5.fc34.x86_64",
+      "openssh-clients-8.6p1-5.fc34.x86_64",
+      "openssh-server-8.6p1-5.fc34.x86_64",
+      "openssl-libs-1.1.1l-2.fc34.x86_64",
+      "openssl-pkcs11-0.4.11-2.fc34.x86_64",
+      "os-prober-1.77-7.fc34.x86_64",
+      "p11-kit-0.23.22-3.fc34.x86_64",
+      "p11-kit-trust-0.23.22-3.fc34.x86_64",
+      "pam-1.5.1-7.fc34.x86_64",
+      "parted-3.4-2.fc34.x86_64",
+      "passwd-0.80-10.fc34.x86_64",
+      "pcre-8.44-3.fc34.1.x86_64",
+      "pcre2-10.36-4.fc34.x86_64",
+      "pcre2-syntax-10.36-4.fc34.noarch",
+      "pigz-2.5-1.fc34.x86_64",
+      "pinentry-1.2.0-1.fc34.x86_64",
+      "policycoreutils-3.2-1.fc34.x86_64",
+      "popt-1.18-4.fc34.x86_64",
+      "procps-ng-3.3.17-1.fc34.1.x86_64",
+      "protobuf-c-1.3.3-7.fc34.x86_64",
+      "psmisc-23.4-1.fc34.x86_64",
+      "publicsuffix-list-dafsa-20190417-5.fc34.noarch",
+      "python-pip-wheel-21.0.1-4.fc34.noarch",
+      "python-setuptools-wheel-53.0.0-2.fc34.noarch",
+      "python-unversioned-command-3.9.9-2.fc34.noarch",
+      "python3-3.9.9-2.fc34.x86_64",
+      "python3-attrs-20.3.0-2.fc34.noarch",
+      "python3-audit-3.0.6-1.fc34.x86_64",
+      "python3-babel-2.9.1-1.fc34.noarch",
+      "python3-cffi-1.14.5-1.fc34.x86_64",
+      "python3-chardet-4.0.0-1.fc34.noarch",
+      "python3-configobj-5.0.6-23.fc34.noarch",
+      "python3-cryptography-3.4.6-1.fc34.x86_64",
+      "python3-dateutil-2.8.1-3.fc34.noarch",
+      "python3-dbus-1.2.18-1.fc34.x86_64",
+      "python3-distro-1.5.0-5.fc34.noarch",
+      "python3-dnf-4.9.0-1.fc34.noarch",
+      "python3-dnf-plugins-core-4.0.24-1.fc34.noarch",
+      "python3-gpg-1.15.1-2.fc34.x86_64",
+      "python3-hawkey-0.64.0-1.fc34.x86_64",
+      "python3-idna-2.10-3.fc34.noarch",
+      "python3-jinja2-2.11.3-1.fc34.noarch",
+      "python3-jsonpatch-1.21-14.fc34.noarch",
+      "python3-jsonpointer-2.0-2.fc34.noarch",
+      "python3-jsonschema-3.2.0-9.fc34.noarch",
+      "python3-jwt+crypto-1.7.1-11.fc34.noarch",
+      "python3-jwt-1.7.1-11.fc34.noarch",
+      "python3-libcomps-0.1.18-1.fc34.x86_64",
+      "python3-libdnf-0.64.0-1.fc34.x86_64",
+      "python3-libs-3.9.9-2.fc34.x86_64",
+      "python3-libselinux-3.2-1.fc34.x86_64",
+      "python3-libsemanage-3.2-1.fc34.x86_64",
+      "python3-markupsafe-1.1.1-10.fc34.x86_64",
+      "python3-oauthlib+signedtoken-3.0.2-9.fc34.noarch",
+      "python3-oauthlib-3.0.2-9.fc34.noarch",
+      "python3-pip-21.0.1-4.fc34.noarch",
+      "python3-ply-3.11-11.fc34.noarch",
+      "python3-policycoreutils-3.2-1.fc34.noarch",
+      "python3-prettytable-0.7.2-25.fc34.noarch",
+      "python3-pycparser-2.20-3.fc34.noarch",
+      "python3-pyrsistent-0.17.3-6.fc34.x86_64",
+      "python3-pyserial-3.4-10.fc34.noarch",
+      "python3-pysocks-1.7.1-8.fc34.noarch",
+      "python3-pytz-2021.3-1.fc34.noarch",
+      "python3-pyyaml-5.4.1-2.fc34.x86_64",
+      "python3-requests-2.25.1-1.fc34.noarch",
+      "python3-rpm-4.16.1.3-1.fc34.x86_64",
+      "python3-setools-4.4.0-1.fc34.x86_64",
+      "python3-setuptools-53.0.0-2.fc34.noarch",
+      "python3-six-1.15.0-5.fc34.noarch",
+      "python3-unbound-1.13.2-1.fc34.x86_64",
+      "python3-urllib3-1.25.10-5.fc34.noarch",
+      "qrencode-libs-4.1.1-1.fc34.x86_64",
+      "readline-8.1-2.fc34.x86_64",
+      "rootfiles-8.1-29.fc34.noarch",
+      "rpm-4.16.1.3-1.fc34.x86_64",
+      "rpm-build-libs-4.16.1.3-1.fc34.x86_64",
+      "rpm-libs-4.16.1.3-1.fc34.x86_64",
+      "rpm-plugin-selinux-4.16.1.3-1.fc34.x86_64",
+      "rpm-plugin-systemd-inhibit-4.16.1.3-1.fc34.x86_64",
+      "rpm-sign-libs-4.16.1.3-1.fc34.x86_64",
+      "rsync-3.2.3-5.fc34.x86_64",
+      "sed-4.8-7.fc34.x86_64",
+      "selinux-policy-34.23-1.fc34.noarch",
+      "selinux-policy-targeted-34.23-1.fc34.noarch",
+      "setup-2.13.7-3.fc34.noarch",
+      "shadow-utils-4.8.1-10.fc34.x86_64",
+      "shared-mime-info-2.1-2.fc34.x86_64",
+      "sqlite-libs-3.34.1-2.fc34.x86_64",
+      "sssd-client-2.5.2-2.fc34.x86_64",
+      "sssd-common-2.5.2-2.fc34.x86_64",
+      "sssd-kcm-2.5.2-2.fc34.x86_64",
+      "sssd-nfs-idmap-2.5.2-2.fc34.x86_64",
+      "sudo-1.9.5p2-1.fc34.x86_64",
+      "sudo-python-plugin-1.9.5p2-1.fc34.x86_64",
+      "syslinux-6.04-0.17.fc34.x86_64",
+      "syslinux-extlinux-6.04-0.17.fc34.x86_64",
+      "syslinux-extlinux-nonlinux-6.04-0.17.fc34.noarch",
+      "syslinux-nonlinux-6.04-0.17.fc34.noarch",
+      "systemd-248.9-1.fc34.x86_64",
+      "systemd-libs-248.9-1.fc34.x86_64",
+      "systemd-networkd-248.9-1.fc34.x86_64",
+      "systemd-oomd-defaults-248.9-1.fc34.x86_64",
+      "systemd-pam-248.9-1.fc34.x86_64",
+      "systemd-rpm-macros-248.9-1.fc34.noarch",
+      "systemd-udev-248.9-1.fc34.x86_64",
+      "tar-1.34-1.fc34.x86_64",
+      "tpm2-tss-3.1.0-1.fc34.x86_64",
+      "trousers-0.3.15-2.fc34.x86_64",
+      "trousers-lib-0.3.15-2.fc34.x86_64",
+      "tzdata-2021e-1.fc34.noarch",
+      "unbound-libs-1.13.2-1.fc34.x86_64",
+      "util-linux-2.36.2-1.fc34.x86_64",
+      "vim-data-8.2.3755-1.fc34.noarch",
+      "vim-minimal-8.2.3755-1.fc34.x86_64",
+      "which-2.21-26.fc34.x86_64",
+      "whois-nls-5.5.10-1.fc34.noarch",
+      "xfsprogs-5.10.0-2.fc34.x86_64",
+      "xkeyboard-config-2.33-1.fc34.noarch",
+      "xz-5.2.5-5.fc34.x86_64",
+      "xz-libs-5.2.5-5.fc34.x86_64",
+      "yum-4.9.0-1.fc34.noarch",
+      "zchunk-libs-1.1.15-1.fc34.x86_64",
+      "zlib-1.2.11-26.fc34.x86_64"
+    ],
+    "partition-table": "dos",
+    "partition-table-id": "0x14fc63d2",
+    "partitions": [
+      {
+        "bootable": true,
+        "fstype": "ext4",
+        "label": null,
+        "partuuid": "14fc63d2-01",
+        "size": 2146435072,
+        "start": 1048576,
+        "type": "83",
+        "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+      }
+    ],
+    "passwd": [
+      "adm:x:3:4:adm:/var/adm:/sbin/nologin",
+      "bin:x:1:1:bin:/bin:/sbin/nologin",
+      "chrony:x:995:994::/var/lib/chrony:/sbin/nologin",
+      "daemon:x:2:2:daemon:/sbin:/sbin/nologin",
+      "dbus:x:81:81:System message bus:/:/sbin/nologin",
+      "ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin",
+      "games:x:12:100:games:/usr/games:/sbin/nologin",
+      "halt:x:7:0:halt:/sbin:/sbin/halt",
+      "lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin",
+      "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
+      "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
+      "operator:x:11:0:operator:/root:/sbin/nologin",
+      "root:x:0:0:root:/root:/bin/bash",
+      "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
+      "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
+      "sync:x:5:0:sync:/sbin:/bin/sync",
+      "systemd-coredump:x:999:999:systemd Core Dumper:/:/sbin/nologin",
+      "systemd-network:x:192:192:systemd Network Management:/:/sbin/nologin",
+      "systemd-oom:x:998:998:systemd Userspace OOM Killer:/:/sbin/nologin",
+      "systemd-resolve:x:193:193:systemd Resolver:/:/sbin/nologin",
+      "systemd-timesync:x:997:997:systemd Time Synchronization:/:/sbin/nologin",
+      "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
+      "unbound:x:996:995:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
+    ],
+    "rpm-verify": {
+      "changed": {
+        "/etc/machine-id": ".M.......",
+        "/etc/udev/hwdb.bin": ".M.......",
+        "/proc": ".M.......",
+        "/sys": ".M.......",
+        "/var/log/lastlog": ".M....G.."
+      },
+      "missing": []
+    },
+    "selinux": {
+      "context-mismatch": [
+        {
+          "actual": "system_u:object_r:unlabeled_t:s0",
+          "expected": "system_u:object_r:lost_found_t:s0",
+          "filename": "/lost+found"
+        }
+      ],
+      "policy": {
+        "SELINUX": "enforcing",
+        "SELINUXTYPE": "targeted"
+      }
+    },
+    "services-disabled": [
+      "arp-ethers.service",
+      "chrony-wait.service",
+      "console-getty.service",
+      "console-login-helper-messages-gensnippet-os-release.service",
+      "console-login-helper-messages-gensnippet-ssh-keys.service",
+      "debug-shell.service",
+      "exit.target",
+      "halt.target",
+      "kexec.target",
+      "loadmodules.service",
+      "man-db-restart-cache-update.service",
+      "nis-domainname.service",
+      "poweroff.target",
+      "proc-sys-fs-binfmt_misc.mount",
+      "rdisc.service",
+      "remote-cryptsetup.target",
+      "remote-veritysetup.target",
+      "runlevel0.target",
+      "selinux-check-proper-disable.service",
+      "serial-getty@.service",
+      "sshd-keygen@.service",
+      "sshd.socket",
+      "sssd-autofs.socket",
+      "sssd-nss.socket",
+      "sssd-pac.socket",
+      "sssd-pam-priv.socket",
+      "sssd-pam.socket",
+      "sssd-ssh.socket",
+      "sssd-sudo.socket",
+      "systemd-boot-check-no-failures.service",
+      "systemd-network-generator.service",
+      "systemd-networkd-wait-online.service",
+      "systemd-networkd.service",
+      "systemd-networkd.socket",
+      "systemd-pstore.service",
+      "systemd-sysext.service",
+      "systemd-time-wait-sync.service",
+      "systemd-timesyncd.service",
+      "tcsd.service"
+    ],
+    "services-enabled": [
+      "NetworkManager-dispatcher.service",
+      "NetworkManager-wait-online.service",
+      "NetworkManager.service",
+      "auditd.service",
+      "autovt@.service",
+      "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
+      "ctrl-alt-del.target",
+      "dbus-broker.service",
+      "dbus-org.freedesktop.home1.service",
+      "dbus-org.freedesktop.nm-dispatcher.service",
+      "dbus-org.freedesktop.oom1.service",
+      "dbus-org.freedesktop.resolve1.service",
+      "dbus.service",
+      "dbus.socket",
+      "dnf-makecache.timer",
+      "fstrim.timer",
+      "getty@.service",
+      "import-state.service",
+      "reboot.target",
+      "remote-fs.target",
+      "rpmdb-rebuild.service",
+      "runlevel6.target",
+      "selinux-autorelabel-mark.service",
+      "sshd.service",
+      "sssd-kcm.socket",
+      "sssd.service",
+      "systemd-homed-activate.service",
+      "systemd-homed.service",
+      "systemd-oomd.service",
+      "systemd-resolved.service",
+      "systemd-userdbd.socket",
+      "unbound-anchor.timer"
+    ],
+    "sudoers": {
+      "/etc/sudoers": [
+        "Defaults   !visiblepw",
+        "Defaults    always_set_home",
+        "Defaults    match_group_by_gid",
+        "Defaults    always_query_group_plugin",
+        "Defaults    env_reset",
+        "Defaults    env_keep =  \"COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS\"",
+        "Defaults    env_keep += \"MAIL QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE\"",
+        "Defaults    env_keep += \"LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES\"",
+        "Defaults    env_keep += \"LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE\"",
+        "Defaults    env_keep += \"LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY\"",
+        "Defaults    secure_path = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+        "root\tALL=(ALL) \tALL",
+        "%wheel\tALL=(ALL)\tALL"
+      ]
+    },
+    "sysctl.d": {
+      "/usr/lib/sysctl.d": {
+        "10-default-yama-scope.conf": [
+          "kernel.yama.ptrace_scope = 0"
+        ],
+        "50-coredump.conf": [
+          "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h",
+          "kernel.core_pipe_limit=16",
+          "fs.suid_dumpable=2"
+        ],
+        "50-default.conf": [
+          "kernel.sysrq = 16",
+          "kernel.core_uses_pid = 1",
+          "net.ipv4.conf.default.rp_filter = 2",
+          "net.ipv4.conf.*.rp_filter = 2",
+          "-net.ipv4.conf.all.rp_filter",
+          "net.ipv4.conf.default.accept_source_route = 0",
+          "net.ipv4.conf.*.accept_source_route = 0",
+          "-net.ipv4.conf.all.accept_source_route",
+          "net.ipv4.conf.default.promote_secondaries = 1",
+          "net.ipv4.conf.*.promote_secondaries = 1",
+          "-net.ipv4.conf.all.promote_secondaries",
+          "-net.ipv4.ping_group_range = 0 2147483647",
+          "-net.core.default_qdisc = fq_codel",
+          "fs.protected_hardlinks = 1",
+          "fs.protected_symlinks = 1",
+          "fs.protected_regular = 1",
+          "fs.protected_fifos = 1"
+        ],
+        "50-libkcapi-optmem_max.conf": [
+          "net.core.optmem_max = 81920"
+        ],
+        "50-pid-max.conf": [
+          "kernel.pid_max = 4194304"
+        ]
+      }
+    },
+    "systemd-service-dropins": {
+      "/usr/lib/systemd/system": {
+        "systemd-hostnamed.service.d": {
+          "Service": {
+            "PrivateDevices": "no"
+          }
+        },
+        "systemd-logind.service.d": {
+          "Service": {
+            "Environment": "SYSTEMD_REBOOT_TO_BOOT_LOADER_MENU=true"
+          }
+        },
+        "systemd-udev-trigger.service.d": {
+          "Unit": {
+            "RefuseManualStop": "true"
+          }
+        },
+        "user@.service.d": {
+          "Service": {
+            "ManagedOOMMemoryPressure": "kill",
+            "ManagedOOMMemoryPressureLimit": "50%"
+          }
+        }
+      }
+    },
+    "timezone": "UTC",
+    "tmpfiles.d": {
+      "/usr/lib/tmpfiles.d": {
+        "cloud-init.conf": [
+          "d /run/cloud-init 0700 root root - -"
+        ],
+        "console-login-helper-messages-issuegen.conf": [
+          "r /etc/issue.d/*_clhm_*.issue - - - - -"
+        ],
+        "console-login-helper-messages-motdgen.conf": [
+          "d /run/motd.d - - - - -"
+        ],
+        "console-login-helper-messages-profile.conf": [
+          "L /etc/profile.d/console-login-helper-messages-profile.sh - - - - ../../usr/share/console-login-helper-messages/profile.sh"
+        ],
+        "console-login-helper-messages.conf": [
+          "d /run/console-login-helper-messages - - - - -"
+        ],
+        "cryptsetup.conf": [
+          "d /run/cryptsetup 0700 root root -"
+        ],
+        "dnf.conf": [
+          "R /var/tmp/dnf*/locks/*",
+          "r /var/cache/dnf/download_lock.pid",
+          "r /var/cache/dnf/metadata_lock.pid",
+          "r /var/lib/dnf/rpmdb_lock.pid",
+          "r /var/log/log_lock.pid"
+        ],
+        "etc.conf": [
+          "L /etc/os-release - - - - ../usr/lib/os-release",
+          "L+ /etc/mtab - - - - ../proc/self/mounts",
+          "L! /etc/resolv.conf - - - - ../run/systemd/resolve/stub-resolv.conf",
+          "C! /etc/nsswitch.conf - - - -",
+          "C! /etc/pam.d - - - -",
+          "C! /etc/issue - - - -"
+        ],
+        "home.conf": [
+          "Q /home 0755 - - -",
+          "q /srv 0755 - - -"
+        ],
+        "journal-nocow.conf": [
+          "h /var/log/journal - - - - +C",
+          "h /var/log/journal/%m - - - - +C",
+          "h /var/log/journal/remote - - - - +C"
+        ],
+        "legacy.conf": [
+          "d /run/lock 0755 root root -",
+          "L /var/lock - - - - ../run/lock",
+          "d /run/lock/subsys 0755 root root -",
+          "r! /forcefsck",
+          "r! /fastboot",
+          "r! /forcequotacheck"
+        ],
+        "libselinux.conf": [
+          "d /run/setrans 0755 root root"
+        ],
+        "man-db.conf": [
+          "d /var/cache/man 0755 root root 1w"
+        ],
+        "pam.conf": [
+          "d /run/console 0755 root root -",
+          "d /run/faillock 0755 root root -",
+          "d /run/sepermit 0755 root root -",
+          "d /run/motd.d 0755 root root -",
+          "f /var/log/tallylog 0600 root root -"
+        ],
+        "portables.conf": [
+          "Q /var/lib/portables 0700"
+        ],
+        "selinux-policy.conf": [
+          "z /sys/devices/system/cpu/online - - -",
+          "Z /sys/class/net - - -",
+          "z /sys/kernel/uevent_helper - - -",
+          "w /sys/fs/selinux/checkreqprot - - - - 0"
+        ],
+        "setup.conf": [
+          "f /run/motd 0644 root root -",
+          "d /run/motd.d 0755 root root -"
+        ],
+        "static-nodes-permissions.conf": [
+          "z /dev/snd/seq      0660 - audio -",
+          "z /dev/snd/timer    0660 - audio -",
+          "z /dev/loop-control 0660 - disk  -",
+          "z /dev/net/tun      0666 - -     -",
+          "z /dev/fuse         0666 - -     -",
+          "z /dev/kvm          0666 - kvm -",
+          "z /dev/vhost-net    0666 - kvm -",
+          "z /dev/vhost-vsock  0666 - kvm -"
+        ],
+        "sudo.conf": [
+          "d /run/sudo 0711 root root",
+          "D /run/sudo/ts 0700 root root"
+        ],
+        "systemd-nologin.conf": [
+          "F! /run/nologin 0644 - - - \"System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8).\""
+        ],
+        "systemd-pstore.conf": [
+          "d /var/lib/systemd/pstore 0755 root root 14d"
+        ],
+        "systemd-tmp.conf": [
+          "x /tmp/systemd-private-%b-*",
+          "X /tmp/systemd-private-%b-*/tmp",
+          "x /var/tmp/systemd-private-%b-*",
+          "X /var/tmp/systemd-private-%b-*/tmp",
+          "R! /tmp/systemd-private-*",
+          "R! /var/tmp/systemd-private-*",
+          "x  /var/lib/systemd/coredump/.#core*.%b*",
+          "r! /var/lib/systemd/coredump/.#*"
+        ],
+        "systemd.conf": [
+          "d /run/user 0755 root root -",
+          "F! /run/utmp 0664 root utmp -",
+          "d /run/systemd/ask-password 0755 root root -",
+          "d /run/systemd/seats 0755 root root -",
+          "d /run/systemd/sessions 0755 root root -",
+          "d /run/systemd/users 0755 root root -",
+          "d /run/systemd/machines 0755 root root -",
+          "d /run/systemd/shutdown 0755 root root -",
+          "d /run/systemd/netif 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/links 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/leases 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/lldp 0755 systemd-network systemd-network -",
+          "d /run/log 0755 root root -",
+          "z /run/log/journal 2755 root systemd-journal - -",
+          "Z /run/log/journal/%m ~2750 root systemd-journal - -",
+          "a+ /run/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m/*.journal* - - - - group:adm:r--,group:wheel:r--",
+          "z /var/log/journal 2755 root systemd-journal - -",
+          "z /var/log/journal/%m 2755 root systemd-journal - -",
+          "z /var/log/journal/%m/system.journal 0640 root systemd-journal - -",
+          "a+ /var/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m/system.journal - - - - group:adm:r--,group:wheel:r--",
+          "d /var/lib/systemd 0755 root root -",
+          "d /var/lib/systemd/coredump 0755 root root 3d",
+          "d /var/lib/private 0700 root root -",
+          "d /var/log/private 0700 root root -",
+          "d /var/cache/private 0700 root root -"
+        ],
+        "tmp.conf": [
+          "q /tmp 1777 root root 10d",
+          "q /var/tmp 1777 root root 30d"
+        ],
+        "tpm2-tss-fapi.conf": [
+          "d       /var/lib/tpm2-tss/system/keystore   2775 tss  tss   -           -",
+          "a+      /var/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx",
+          "d       /run/tpm2-tss/eventlog                2775 tss  tss   -           -",
+          "a+      /run/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx"
+        ],
+        "var.conf": [
+          "q /var 0755 - - -",
+          "L /var/run - - - - ../run",
+          "d /var/log 0755 - - -",
+          "f /var/log/wtmp 0664 root utmp -",
+          "f /var/log/btmp 0660 root utmp -",
+          "f /var/log/lastlog 0664 root utmp -",
+          "d /var/cache 0755 - - -",
+          "d /var/lib 0755 - - -",
+          "d /var/spool 0755 - - -"
+        ],
+        "x11.conf": [
+          "D! /tmp/.X11-unix 1777 root root 10d",
+          "D! /tmp/.ICE-unix 1777 root root 10d",
+          "D! /tmp/.XIM-unix 1777 root root 10d",
+          "D! /tmp/.font-unix 1777 root root 10d",
+          "D! /tmp/.Test-unix 1777 root root 10d",
+          "r! /tmp/.X[0-9]*-lock"
+        ]
+      }
+    }
+  }
+}

--- a/test/data/manifests/fedora_35-aarch64-oci-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-oci-boot.json
@@ -1,0 +1,10582 @@
+{
+  "compose-request": {
+    "distro": "fedora-35",
+    "arch": "aarch64",
+    "image-type": "oci",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-modular-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-modular-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      }
+    ],
+    "filename": "disk.qcow2",
+    "blueprint": {}
+  },
+  "manifest": {
+    "sources": {
+      "org.osbuild.files": {
+        "urls": {
+          "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.aarch64.rpm"
+          },
+          "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm"
+          },
+          "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm"
+          },
+          "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.aarch64.rpm"
+          },
+          "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm"
+          },
+          "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-jsonpatch-1.21-18.fc35.noarch.rpm"
+          },
+          "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm"
+          },
+          "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm"
+          },
+          "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm"
+          },
+          "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm"
+          },
+          "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm"
+          },
+          "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.aarch64.rpm"
+          },
+          "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm"
+          },
+          "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm"
+          },
+          "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-font-en-3.0-15.fc35.noarch.rpm"
+          },
+          "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fonts-filesystem-2.0.5-6.fc35.noarch.rpm"
+          },
+          "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm"
+          },
+          "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm"
+          },
+          "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm"
+          },
+          "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm"
+          },
+          "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm"
+          },
+          "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm"
+          },
+          "sha256:228e6fbe3646a580e871378f374a1d7cebc4c592ea8262600e4b41a5c39b1169": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-motdgen-0.21.2-3.fc35.noarch.rpm"
+          },
+          "sha256:22a906074aaab00a9c1bac318f9d10323566670fc7772c61e196574dfc63ee9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-policycoreutils-3.3-1.fc35.noarch.rpm"
+          },
+          "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:2402ad97f754eb094e4c4f49b3045fdf919e413b6a78582e3c1850ba09ff93f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/freetype-2.11.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm"
+          },
+          "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm"
+          },
+          "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-attrs-21.2.0-4.fc35.noarch.rpm"
+          },
+          "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm"
+          },
+          "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm"
+          },
+          "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efibootmgr-16-11.fc35.aarch64.rpm"
+          },
+          "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm"
+          },
+          "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm"
+          },
+          "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm"
+          },
+          "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.26.7-2.fc35.noarch.rpm"
+          },
+          "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efi-filesystem-5-4.fc35.noarch.rpm"
+          },
+          "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm"
+          },
+          "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-requests-2.27.0-1.fc35.noarch.rpm"
+          },
+          "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm"
+          },
+          "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-ply-3.11-13.fc35.noarch.rpm"
+          },
+          "sha256:360960053a501c11bc407c6c8a2f379b79bd249133b7c0ffaba54068385860e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-cloud-35-36.noarch.rpm"
+          },
+          "sha256:375b89f3a452a62f3a02ada8971b14e854fa95b0d4cb9efb0449e5f85d6959c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-markupsafe-2.0.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/less-590-2.fc35.aarch64.rpm"
+          },
+          "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:39fd9eb8e77b430637602dc7cfce448e1792ace9cc9041c33f957b70d7b205c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/inih-49-4.fc35.aarch64.rpm"
+          },
+          "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm"
+          },
+          "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm"
+          },
+          "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.aarch64.rpm"
+          },
+          "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm"
+          },
+          "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm"
+          },
+          "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:3eecb51a03f9eed59710f6c6cbc5d66aea9bc521940d0b8d73fca835f1402897": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chrony-4.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm"
+          },
+          "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm"
+          },
+          "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm"
+          },
+          "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm"
+          },
+          "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.aarch64.rpm"
+          },
+          "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm"
+          },
+          "sha256:469ec3ace1ffa4e3153c772d5ec5a65f8cb6e98d07405134c6b06545796e31c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyyaml-5.4.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:4a1dbb7d6a22598bc31d917e42759d7332a343670e35e0022db39a2ebb9e5c99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cloud-utils-growpart-0.31-9.fc35.noarch.rpm"
+          },
+          "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/parted-3.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-charset-normalizer-2.0.4-1.fc35.noarch.rpm"
+          },
+          "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm"
+          },
+          "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt-2.1.0-2.fc35.noarch.rpm"
+          },
+          "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4df41f9a100eca994899d304473024c37382220b4e3c0812c69701bfa450aa06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-cloud-35-36.noarch.rpm"
+          },
+          "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.aarch64.rpm"
+          },
+          "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-en-3.0-15.fc35.noarch.rpm"
+          },
+          "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:50d0b3571e271cce3c9f314f3fab80485b706c347cb6e9c710c28cf552c07ec5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/checkpolicy-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm"
+          },
+          "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm"
+          },
+          "sha256:539d9ef12227716ff904a3e4605c765e6204ffd49a7a2d42762ccd5d921b341c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-issuegen-0.21.2-3.fc35.noarch.rpm"
+          },
+          "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.aarch64.rpm"
+          },
+          "sha256:5437317aa8a5d94a9de9cd15d58399146783b4b96ee52a0a134c09b79933a8b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:5702b6d62b7efb235cf49b6174288053d345236107a43de33d6c80d9784d7140": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-audit-3.0.6-1.fc35.aarch64.rpm"
+          },
+          "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm"
+          },
+          "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-configobj-5.0.6-25.fc35.noarch.rpm"
+          },
+          "sha256:58b6c3272af7450868f9b6ee3e15f05e45104751cacaa4a22345983caaea14da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-filesystem-1.7.0-11.fc35.aarch64.rpm"
+          },
+          "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.aarch64.rpm"
+          },
+          "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.aarch64.rpm"
+          },
+          "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm"
+          },
+          "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm"
+          },
+          "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.aarch64.rpm"
+          },
+          "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm"
+          },
+          "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm"
+          },
+          "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pycparser-2.20-5.fc35.noarch.rpm"
+          },
+          "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.aarch64.rpm"
+          },
+          "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm"
+          },
+          "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm"
+          },
+          "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm"
+          },
+          "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm"
+          },
+          "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-en-3.0-15.fc35.noarch.rpm"
+          },
+          "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-GB-0.20140811.1-20.fc35.noarch.rpm"
+          },
+          "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm"
+          },
+          "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efivar-libs-37-17.fc35.aarch64.rpm"
+          },
+          "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm"
+          },
+          "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm"
+          },
+          "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setuptools-57.4.0-1.fc35.noarch.rpm"
+          },
+          "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.aarch64.rpm"
+          },
+          "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm"
+          },
+          "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm"
+          },
+          "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm"
+          },
+          "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm"
+          },
+          "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:77f17b1b61648436b2ceb31f9447ce6b363ac2de62216277fb05b6ff8eb9654c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/graphite2-1.3.14-8.fc35.aarch64.rpm"
+          },
+          "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm"
+          },
+          "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm"
+          },
+          "sha256:7e7205d1d01f5c6e2635f3b80c2efc04440449482ac8024391af00007952c487": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/harfbuzz-2.8.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm"
+          },
+          "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.aarch64.rpm"
+          },
+          "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm"
+          },
+          "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm"
+          },
+          "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-idna-3.2-1.fc35.noarch.rpm"
+          },
+          "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.aarch64.rpm"
+          },
+          "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonschema-3.2.0-12.fc35.noarch.rpm"
+          },
+          "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jinja2-3.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm"
+          },
+          "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib-3.0.2-11.fc35.noarch.rpm"
+          },
+          "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dejavu-sans-fonts-2.37-17.fc35.noarch.rpm"
+          },
+          "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.aarch64.rpm"
+          },
+          "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyserial-3.4-12.fc35.noarch.rpm"
+          },
+          "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm"
+          },
+          "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm"
+          },
+          "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm"
+          },
+          "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm"
+          },
+          "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.aarch64.rpm"
+          },
+          "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm"
+          },
+          "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.aarch64.rpm"
+          },
+          "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm"
+          },
+          "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:9593a8e47f980af2a61700947cf6da75b409621598029854c05f1a4f5749d1cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libsemanage-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:9605b7a0fbfb73c13a99ae45476c02cf3a0cde1b7edf137e90f8006863519a83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setools-4.4.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-babel-2.9.1-4.fc35.noarch.rpm"
+          },
+          "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.aarch64.rpm"
+          },
+          "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm"
+          },
+          "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm"
+          },
+          "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm"
+          },
+          "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm"
+          },
+          "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm"
+          },
+          "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm"
+          },
+          "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm"
+          },
+          "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm"
+          },
+          "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.aarch64.rpm"
+          },
+          "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc35.noarch.rpm"
+          },
+          "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.aarch64.rpm"
+          },
+          "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm"
+          },
+          "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.aarch64.rpm"
+          },
+          "sha256:aa00ac7809f0965b1e09a31862ccbe2cf11753ffc0c7575f2e40c96aa1c162d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpng-1.6.37-11.fc35.aarch64.rpm"
+          },
+          "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm"
+          },
+          "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:ac16154e7ad3440e137a65b0d9bc96942f257651aaf1f41298f15329a216c2c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rsync-3.2.3-8.fc35.aarch64.rpm"
+          },
+          "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm"
+          },
+          "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.aarch64.rpm"
+          },
+          "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.aarch64.rpm"
+          },
+          "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:b30f029f856c7ff5a9ef7c71b4f8d0858b96962c5523ee7c7bcc6313b13a3b0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cryptography-3.4.7-5.fc35.aarch64.rpm"
+          },
+          "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm"
+          },
+          "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm"
+          },
+          "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm"
+          },
+          "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.aarch64.rpm"
+          },
+          "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm"
+          },
+          "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.aarch64.rpm"
+          },
+          "sha256:b98735362bb79e3def6794fa863fe09a1c3690c8c7880e83f572c20860ba25ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libselinux-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:ba4e1520f0409329c8d29839d510c4721f4475e6b17727485c95b634e61a9cb8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-extra-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:baf6082e248e7e84f3cb5ec2695f0dc9afeca615b3f39c60283902ab06d3f564": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cffi-1.14.6-2.fc35.aarch64.rpm"
+          },
+          "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm"
+          },
+          "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.aarch64.rpm"
+          },
+          "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm"
+          },
+          "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm"
+          },
+          "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm"
+          },
+          "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm"
+          },
+          "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm"
+          },
+          "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pysocks-1.7.1-11.fc35.noarch.rpm"
+          },
+          "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cloud-init-20.4-7.fc35.noarch.rpm"
+          },
+          "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.aarch64.rpm"
+          },
+          "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm"
+          },
+          "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.aarch64.rpm"
+          },
+          "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm"
+          },
+          "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/mokutil-0.5.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm"
+          },
+          "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm"
+          },
+          "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch.rpm"
+          },
+          "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm"
+          },
+          "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm"
+          },
+          "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm"
+          },
+          "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm"
+          },
+          "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.aarch64.rpm"
+          },
+          "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm"
+          },
+          "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm"
+          },
+          "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm"
+          },
+          "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm"
+          },
+          "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm"
+          },
+          "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.aarch64.rpm"
+          },
+          "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-0.20140811.1-20.fc35.noarch.rpm"
+          },
+          "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm"
+          },
+          "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt+crypto-2.1.0-2.fc35.noarch.rpm"
+          },
+          "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm"
+          },
+          "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm"
+          },
+          "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm"
+          },
+          "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm"
+          },
+          "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm"
+          },
+          "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm"
+          },
+          "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm"
+          },
+          "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-US-0.20140811.1-20.fc35.noarch.rpm"
+          },
+          "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonpointer-2.0-4.fc35.noarch.rpm"
+          },
+          "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.aarch64.rpm"
+          },
+          "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm"
+          },
+          "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm"
+          },
+          "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/shim-aa64-15.4-5.aarch64.rpm"
+          },
+          "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm"
+          },
+          "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.aarch64.rpm"
+          },
+          "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm"
+          },
+          "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm"
+          },
+          "sha256:ef8f0dbb997b8f1e9a133a85f5e8a6b8579f23e95dbfd0604ac4d4809a759aa9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-profile-0.21.2-3.fc35.noarch.rpm"
+          },
+          "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm"
+          },
+          "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm"
+          },
+          "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm"
+          },
+          "sha256:f4a4e83a8e1a1ba33bbd58ab720d2ba66bc76ef05101dd68d5ccd37a6e4e0b7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-0.21.2-3.fc35.noarch.rpm"
+          },
+          "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-prettytable-0.7.2-27.fc35.noarch.rpm"
+          },
+          "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm"
+          },
+          "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.aarch64.rpm"
+          },
+          "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm"
+          },
+          "sha256:f878dd687438db0e07f2eb571246103ae0e136647242f0bf7f806ddd77e04a91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-1.7.0-11.fc35.aarch64.rpm"
+          },
+          "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.aarch64.rpm"
+          },
+          "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm"
+          },
+          "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm"
+          },
+          "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.aarch64.rpm"
+          },
+          "sha256:fc05e6abb02bcb99462711686ddfc47783c0a5575bdb451a7fce641a3b809e8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.18.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:fccda302546302309788e451ccaa2fb2abba72fa7b4184e82e1ff89830d8e306": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/net-tools-2.0-0.60.20160912git.fc35.aarch64.rpm"
+          },
+          "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:fe1323e767bb5941d49d5b6565750614a2f649d5d34453e5ace10b3012b7a413": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xfsprogs-5.12.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm"
+          },
+          "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm"
+          },
+          "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm"
+          }
+        }
+      }
+    },
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.rpm",
+              "options": {
+                "gpgkeys": [
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+                ],
+                "packages": [
+                  {
+                    "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                    "check_gpg": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "org.osbuild.selinux",
+              "options": {
+                "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+                "labels": {
+                  "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+                }
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.fedora33"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8"
+          }
+        },
+        {
+          "name": "org.osbuild.rpm",
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "packages": [
+              {
+                "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3eecb51a03f9eed59710f6c6cbc5d66aea9bc521940d0b8d73fca835f1402897",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4a1dbb7d6a22598bc31d917e42759d7332a343670e35e0022db39a2ebb9e5c99",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2402ad97f754eb094e4c4f49b3045fdf919e413b6a78582e3c1850ba09ff93f3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:77f17b1b61648436b2ceb31f9447ce6b363ac2de62216277fb05b6ff8eb9654c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7e7205d1d01f5c6e2635f3b80c2efc04440449482ac8024391af00007952c487",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f878dd687438db0e07f2eb571246103ae0e136647242f0bf7f806ddd77e04a91",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:58b6c3272af7450868f9b6ee3e15f05e45104751cacaa4a22345983caaea14da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:39fd9eb8e77b430637602dc7cfce448e1792ace9cc9041c33f957b70d7b205c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aa00ac7809f0965b1e09a31862ccbe2cf11753ffc0c7575f2e40c96aa1c162d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fccda302546302309788e451ccaa2fb2abba72fa7b4184e82e1ff89830d8e306",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5702b6d62b7efb235cf49b6174288053d345236107a43de33d6c80d9784d7140",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:baf6082e248e7e84f3cb5ec2695f0dc9afeca615b3f39c60283902ab06d3f564",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b30f029f856c7ff5a9ef7c71b4f8d0858b96962c5523ee7c7bcc6313b13a3b0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:375b89f3a452a62f3a02ada8971b14e854fa95b0d4cb9efb0449e5f85d6959c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:469ec3ace1ffa4e3153c772d5ec5a65f8cb6e98d07405134c6b06545796e31c2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9605b7a0fbfb73c13a99ae45476c02cf3a0cde1b7edf137e90f8006863519a83",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac16154e7ad3440e137a65b0d9bc96942f257651aaf1f41298f15329a216c2c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fe1323e767bb5941d49d5b6565750614a2f649d5d34453e5ace10b3012b7a413",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:50d0b3571e271cce3c9f314f3fab80485b706c347cb6e9c710c28cf552c07ec5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4a4e83a8e1a1ba33bbd58ab720d2ba66bc76ef05101dd68d5ccd37a6e4e0b7e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:539d9ef12227716ff904a3e4605c765e6204ffd49a7a2d42762ccd5d921b341c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:228e6fbe3646a580e871378f374a1d7cebc4c592ea8262600e4b41a5c39b1169",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ef8f0dbb997b8f1e9a133a85f5e8a6b8579f23e95dbfd0604ac4d4809a759aa9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:360960053a501c11bc407c6c8a2f379b79bd249133b7c0ffaba54068385860e9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4df41f9a100eca994899d304473024c37382220b4e3c0812c69701bfa450aa06",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5437317aa8a5d94a9de9cd15d58399146783b4b96ee52a0a134c09b79933a8b0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ba4e1520f0409329c8d29839d510c4721f4475e6b17727485c95b634e61a9cb8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b98735362bb79e3def6794fa863fe09a1c3690c8c7880e83f572c20860ba25ba",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9593a8e47f980af2a61700947cf6da75b409621598029854c05f1a4f5749d1cb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:22a906074aaab00a9c1bac318f9d10323566670fc7772c61e196574dfc63ee9b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fc05e6abb02bcb99462711686ddfc47783c0a5575bdb451a7fce641a3b809e8e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f",
+                "check_gpg": true
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.hostname",
+          "options": {
+            "hostname": "localhost.localdomain"
+          }
+        },
+        {
+          "name": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              },
+              {
+                "uuid": "46BB-8120",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "umask=0077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "uefi": {
+              "vendor": "fedora"
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
+        "options": {
+          "format": "qcow2",
+          "filename": "disk.qcow2",
+          "size": 2147483648,
+          "ptuuid": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
+          "pttype": "gpt",
+          "partitions": [
+            {
+              "start": 2048,
+              "size": 972800,
+              "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+              "uuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
+              "filesystem": {
+                "type": "vfat",
+                "uuid": "46BB-8120",
+                "label": "EFI-SYSTEM",
+                "mountpoint": "/boot/efi"
+              }
+            },
+            {
+              "start": 976896,
+              "uuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build-packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm",
+        "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm",
+        "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm",
+        "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
+        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
+        "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm",
+        "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm",
+        "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm",
+        "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm",
+        "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "12.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.aarch64.rpm",
+        "checksum": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
+        "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm",
+        "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm",
+        "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm",
+        "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
+        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm",
+        "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
+        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+        "check_gpg": true
+      },
+      {
+        "name": "liburing",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm",
+        "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm",
+        "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm",
+        "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm",
+        "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
+        "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs78",
+        "epoch": 0,
+        "version": "78.15.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm",
+        "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm",
+        "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm",
+        "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm",
+        "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm",
+        "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm",
+        "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm",
+        "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.70.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.4.36",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm",
+        "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+        "check_gpg": true
+      },
+      {
+        "name": "qemu-img",
+        "epoch": 2,
+        "version": "6.1.0",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm",
+        "checksum": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm",
+        "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
+    "packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm",
+        "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65",
+        "check_gpg": true
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75",
+        "check_gpg": true
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chrony-4.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3eecb51a03f9eed59710f6c6cbc5d66aea9bc521940d0b8d73fca835f1402897",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "20.4",
+        "release": "7.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cloud-init-20.4-7.fc35.noarch.rpm",
+        "checksum": "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-utils-growpart",
+        "epoch": 0,
+        "version": "0.31",
+        "release": "9.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cloud-utils-growpart-0.31-9.fc35.noarch.rpm",
+        "checksum": "sha256:4a1dbb7d6a22598bc31d917e42759d7332a343670e35e0022db39a2ebb9e5c99",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm",
+        "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm",
+        "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+        "check_gpg": true
+      },
+      {
+        "name": "dejavu-sans-fonts",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "17.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dejavu-sans-fonts-2.37-17.fc35.noarch.rpm",
+        "checksum": "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
+        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.aarch64.rpm",
+        "checksum": "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm",
+        "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
+        "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efi-filesystem-5-4.fc35.noarch.rpm",
+        "checksum": "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efibootmgr-16-11.fc35.aarch64.rpm",
+        "checksum": "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "37",
+        "release": "17.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efivar-libs-37-17.fc35.aarch64.rpm",
+        "checksum": "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm",
+        "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm",
+        "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+        "check_gpg": true
+      },
+      {
+        "name": "fonts-filesystem",
+        "epoch": 1,
+        "version": "2.0.5",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fonts-filesystem-2.0.5-6.fc35.noarch.rpm",
+        "checksum": "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee",
+        "check_gpg": true
+      },
+      {
+        "name": "freetype",
+        "epoch": 0,
+        "version": "2.11.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/freetype-2.11.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2402ad97f754eb094e4c4f49b3045fdf919e413b6a78582e3c1850ba09ff93f3",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+        "check_gpg": true
+      },
+      {
+        "name": "graphite2",
+        "epoch": 0,
+        "version": "1.3.14",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/graphite2-1.3.14-8.fc35.aarch64.rpm",
+        "checksum": "sha256:77f17b1b61648436b2ceb31f9447ce6b363ac2de62216277fb05b6ff8eb9654c",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm",
+        "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.aarch64.rpm",
+        "checksum": "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm",
+        "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+        "check_gpg": true
+      },
+      {
+        "name": "harfbuzz",
+        "epoch": 0,
+        "version": "2.8.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/harfbuzz-2.8.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7e7205d1d01f5c6e2635f3b80c2efc04440449482ac8024391af00007952c487",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.aarch64.rpm",
+        "checksum": "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell",
+        "epoch": 0,
+        "version": "1.7.0",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-1.7.0-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f878dd687438db0e07f2eb571246103ae0e136647242f0bf7f806ddd77e04a91",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-en",
+        "epoch": 0,
+        "version": "0.20140811.1",
+        "release": "20.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-0.20140811.1-20.fc35.noarch.rpm",
+        "checksum": "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-en-GB",
+        "epoch": 0,
+        "version": "0.20140811.1",
+        "release": "20.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-GB-0.20140811.1-20.fc35.noarch.rpm",
+        "checksum": "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-en-US",
+        "epoch": 0,
+        "version": "0.20140811.1",
+        "release": "20.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-US-0.20140811.1-20.fc35.noarch.rpm",
+        "checksum": "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-filesystem",
+        "epoch": 0,
+        "version": "1.7.0",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-filesystem-1.7.0-11.fc35.aarch64.rpm",
+        "checksum": "sha256:58b6c3272af7450868f9b6ee3e15f05e45104751cacaa4a22345983caaea14da",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "49",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/inih-49-4.fc35.aarch64.rpm",
+        "checksum": "sha256:39fd9eb8e77b430637602dc7cfce448e1792ace9cc9041c33f957b70d7b205c5",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm",
+        "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute-tc",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20210722",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm",
+        "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "15.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-en-3.0-15.fc35.noarch.rpm",
+        "checksum": "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-font-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "15.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-font-en-3.0-15.fc35.noarch.rpm",
+        "checksum": "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "15.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-en-3.0-15.fc35.noarch.rpm",
+        "checksum": "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
+        "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm",
+        "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm",
+        "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.aarch64.rpm",
+        "checksum": "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm",
+        "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.aarch64.rpm",
+        "checksum": "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "40.20210910cvs.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.aarch64.rpm",
+        "checksum": "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
+        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm",
+        "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.aarch64.rpm",
+        "checksum": "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.5.4",
+        "release": "2.rc3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.aarch64.rpm",
+        "checksum": "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libpng",
+        "epoch": 2,
+        "version": "1.6.37",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpng-1.6.37-11.fc35.aarch64.rpm",
+        "checksum": "sha256:aa00ac7809f0965b1e09a31862ccbe2cf11753ffc0c7575f2e40c96aa1c162d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.aarch64.rpm",
+        "checksum": "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
+        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm",
+        "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.aarch64.rpm",
+        "checksum": "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm",
+        "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm",
+        "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm",
+        "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.aarch64.rpm",
+        "checksum": "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.aarch64.rpm",
+        "checksum": "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
+        "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs78",
+        "epoch": 0,
+        "version": "78.15.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+        "check_gpg": true
+      },
+      {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.60.20160912git.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/net-tools-2.0-0.60.20160912git.fc35.aarch64.rpm",
+        "checksum": "sha256:fccda302546302309788e451ccaa2fb2abba72fa7b4184e82e1ff89830d8e306",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm",
+        "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm",
+        "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm",
+        "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/parted-3.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.aarch64.rpm",
+        "checksum": "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-attrs",
+        "epoch": 0,
+        "version": "21.2.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-attrs-21.2.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-audit-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5702b6d62b7efb235cf49b6174288053d345236107a43de33d6c80d9784d7140",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-babel",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-babel-2.9.1-4.fc35.noarch.rpm",
+        "checksum": "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cffi",
+        "epoch": 0,
+        "version": "1.14.6",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cffi-1.14.6-2.fc35.aarch64.rpm",
+        "checksum": "sha256:baf6082e248e7e84f3cb5ec2695f0dc9afeca615b3f39c60283902ab06d3f564",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-charset-normalizer",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-charset-normalizer-2.0.4-1.fc35.noarch.rpm",
+        "checksum": "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-configobj",
+        "epoch": 0,
+        "version": "5.0.6",
+        "release": "25.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-configobj-5.0.6-25.fc35.noarch.rpm",
+        "checksum": "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cryptography",
+        "epoch": 0,
+        "version": "3.4.7",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cryptography-3.4.7-5.fc35.aarch64.rpm",
+        "checksum": "sha256:b30f029f856c7ff5a9ef7c71b4f8d0858b96962c5523ee7c7bcc6313b13a3b0c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "7.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm",
+        "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.aarch64.rpm",
+        "checksum": "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-idna-3.2-1.fc35.noarch.rpm",
+        "checksum": "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jinja2",
+        "epoch": 0,
+        "version": "3.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jinja2-3.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpointer",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonpointer-2.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonschema",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonschema-3.2.0-12.fc35.noarch.rpm",
+        "checksum": "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt+crypto",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt+crypto-2.1.0-2.fc35.noarch.rpm",
+        "checksum": "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt-2.1.0-2.fc35.noarch.rpm",
+        "checksum": "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-markupsafe-2.0.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:375b89f3a452a62f3a02ada8971b14e854fa95b0d4cb9efb0449e5f85d6959c6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib+signedtoken",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "11.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch.rpm",
+        "checksum": "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "11.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib-3.0.2-11.fc35.noarch.rpm",
+        "checksum": "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ply",
+        "epoch": 0,
+        "version": "3.11",
+        "release": "13.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-ply-3.11-13.fc35.noarch.rpm",
+        "checksum": "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "27.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-prettytable-0.7.2-27.fc35.noarch.rpm",
+        "checksum": "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pycparser",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pycparser-2.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyserial",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyserial-3.4-12.fc35.noarch.rpm",
+        "checksum": "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "11.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pysocks-1.7.1-11.fc35.noarch.rpm",
+        "checksum": "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyyaml-5.4.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:469ec3ace1ffa4e3153c772d5ec5a65f8cb6e98d07405134c6b06545796e31c2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.4.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setools-4.4.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9605b7a0fbfb73c13a99ae45476c02cf3a0cde1b7edf137e90f8006863519a83",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setuptools-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "30.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm",
+        "checksum": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+        "check_gpg": true
+      },
+      {
+        "name": "rsync",
+        "epoch": 0,
+        "version": "3.2.3",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rsync-3.2.3-8.fc35.aarch64.rpm",
+        "checksum": "sha256:ac16154e7ad3440e137a65b0d9bc96942f257651aaf1f41298f15329a216c2c6",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm",
+        "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.4",
+        "release": "5",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/shim-aa64-15.4-5.aarch64.rpm",
+        "checksum": "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm",
+        "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm",
+        "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.12.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xfsprogs-5.12.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:fe1323e767bb5941d49d5b6565750614a2f649d5d34453e5ace10b3012b7a413",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm",
+        "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.aarch64.rpm",
+        "checksum": "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/checkpolicy-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:50d0b3571e271cce3c9f314f3fab80485b706c347cb6e9c710c28cf552c07ec5",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-0.21.2-3.fc35.noarch.rpm",
+        "checksum": "sha256:f4a4e83a8e1a1ba33bbd58ab720d2ba66bc76ef05101dd68d5ccd37a6e4e0b7e",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-issuegen",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-issuegen-0.21.2-3.fc35.noarch.rpm",
+        "checksum": "sha256:539d9ef12227716ff904a3e4605c765e6204ffd49a7a2d42762ccd5d921b341c",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-motdgen",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-motdgen-0.21.2-3.fc35.noarch.rpm",
+        "checksum": "sha256:228e6fbe3646a580e871378f374a1d7cebc4c592ea8262600e4b41a5c39b1169",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-profile",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-profile-0.21.2-3.fc35.noarch.rpm",
+        "checksum": "sha256:ef8f0dbb997b8f1e9a133a85f5e8a6b8579f23e95dbfd0604ac4d4809a759aa9",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-cloud",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-cloud-35-36.noarch.rpm",
+        "checksum": "sha256:360960053a501c11bc407c6c8a2f379b79bd249133b7c0ffaba54068385860e9",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-cloud",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-cloud-35-36.noarch.rpm",
+        "checksum": "sha256:4df41f9a100eca994899d304473024c37382220b4e3c0812c69701bfa450aa06",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.70.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-langpack-en",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:5437317aa8a5d94a9de9cd15d58399146783b4b96ee52a0a134c09b79933a8b0",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-extra",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-extra-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:ba4e1520f0409329c8d29839d510c4721f4475e6b17727485c95b634e61a9cb8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/less-590-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-atm-libs",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.aarch64.rpm",
+        "checksum": "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.5.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/mokutil-0.5.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.4.36",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm",
+        "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpatch",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "18.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-jsonpatch-1.21-18.fc35.noarch.rpm",
+        "checksum": "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b98735362bb79e3def6794fa863fe09a1c3690c8c7880e83f572c20860ba25ba",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9593a8e47f980af2a61700947cf6da75b409621598029854c05f1a4f5749d1cb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-policycoreutils-3.3-1.fc35.noarch.rpm",
+        "checksum": "sha256:22a906074aaab00a9c1bac318f9d10323566670fc7772c61e196574dfc63ee9b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyrsistent",
+        "epoch": 0,
+        "version": "0.18.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.18.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:fc05e6abb02bcb99462711686ddfc47783c0a5575bdb451a7fce641a3b809e8e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pytz",
+        "epoch": 0,
+        "version": "2021.3",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc35.noarch.rpm",
+        "checksum": "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.27.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-requests-2.27.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.7",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.26.7-2.fc35.noarch.rpm",
+        "checksum": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm",
+        "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm",
+        "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm",
+        "checksum": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f",
+        "check_gpg": true
+      }
+    ]
+  },
+  "image-info": {
+    "/etc/resolv.conf": [],
+    "boot-environment": {
+      "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+    },
+    "bootloader": "unknown",
+    "bootmenu": [
+      {
+        "grub_arg": "--unrestricted",
+        "grub_class": "fedora",
+        "grub_users": "$grub_users",
+        "initrd": "/boot/initramfs-5.15.13-200.fc35.aarch64.img",
+        "linux": "/boot/vmlinuz-5.15.13-200.fc35.aarch64",
+        "options": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8",
+        "title": "Fedora Linux (5.15.13-200.fc35.aarch64) 35 (Cloud Edition)",
+        "version": "5.15.13-200.fc35.aarch64"
+      }
+    ],
+    "chrony": {
+      "leapsectz": [
+        "right/UTC"
+      ],
+      "pool": [
+        "2.fedora.pool.ntp.org iburst"
+      ]
+    },
+    "cloud-init": {
+      "/etc/cloud": {
+        "cloud.cfg": {
+          "cloud_config_modules": [
+            "ssh-import-id",
+            "locale",
+            "set-passwords",
+            "spacewalk",
+            "yum-add-repo",
+            "ntp",
+            "timezone",
+            "disable-ec2-metadata",
+            "runcmd"
+          ],
+          "cloud_final_modules": [
+            "package-update-upgrade-install",
+            "puppet",
+            "chef",
+            "mcollective",
+            "salt-minion",
+            "reset_rmc",
+            "refresh_rmc_and_interface",
+            "rightscale_userdata",
+            "scripts-vendor",
+            "scripts-per-once",
+            "scripts-per-boot",
+            "scripts-per-instance",
+            "scripts-user",
+            "ssh-authkey-fingerprints",
+            "keys-to-console",
+            "phone-home",
+            "final-message",
+            "power-state-change"
+          ],
+          "cloud_init_modules": [
+            "migrator",
+            "seed_random",
+            "bootcmd",
+            "write-files",
+            "growpart",
+            "resizefs",
+            "disk_setup",
+            "mounts",
+            "set_hostname",
+            "update_hostname",
+            "update_etc_hosts",
+            "ca-certs",
+            "rsyslog",
+            "users-groups",
+            "ssh"
+          ],
+          "disable_root": true,
+          "mount_default_fields": [
+            null,
+            null,
+            "auto",
+            "defaults,nofail",
+            "0",
+            "2"
+          ],
+          "preserve_hostname": false,
+          "resize_rootfs_tmp": "/dev",
+          "ssh_pwauth": 0,
+          "system_info": {
+            "default_user": {
+              "gecos": "fedora Cloud User",
+              "groups": [
+                "wheel",
+                "adm",
+                "systemd-journal"
+              ],
+              "lock_passwd": true,
+              "name": "fedora",
+              "shell": "/bin/bash",
+              "sudo": [
+                "ALL=(ALL) NOPASSWD:ALL"
+              ]
+            },
+            "distro": "fedora",
+            "paths": {
+              "cloud_dir": "/var/lib/cloud/",
+              "templates_dir": "/etc/cloud/templates/"
+            },
+            "ssh_svcname": "sshd"
+          },
+          "users": [
+            "default"
+          ]
+        }
+      },
+      "/etc/cloud/cloud.cfg.d": {
+        "05_logging.cfg": {
+          "_log": [
+            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
+            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
+          ],
+          "log_cfgs": [
+            [
+              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
+            ]
+          ],
+          "output": {
+            "all": "| tee -a /var/log/cloud-init-output.log"
+          }
+        }
+      }
+    },
+    "default-target": "graphical.target",
+    "dracut": {
+      "/usr/lib/dracut/dracut.conf.d": {
+        "01-dist.conf": {
+          "dbus": "/usr/share/dbus-1",
+          "dbusconfdir": "/etc/dbus-1",
+          "dbusinterfaces": "/usr/share/dbus-1/interfaces",
+          "dbusinterfacesconfdir": "/etc/dbus-1/interfaces",
+          "dbusservices": "/usr/share/dbus-1/services",
+          "dbusservicesconfdir": "/etc/dbus-1/services",
+          "dbussession": "/usr/share/dbus-1/session.d",
+          "dbussessionconfdir": "/etc/dbus-1/session.d",
+          "dbussystem": "confdir/etc/dbus-1/system.d",
+          "dbussystemservices": "/usr/share/dbus-1/system-services",
+          "dbussystemservicesconfdir": "/etc/dbus-1/system-services",
+          "early_microcode": "yes",
+          "environment": "/usr/lib/environment.d",
+          "environmentconfdir": "/etc/environment.d",
+          "hostonly": "yes",
+          "hostonly_cmdline": "no",
+          "i18n_default_font": "eurlatgr",
+          "i18n_install_all": "yes",
+          "i18n_vars": "/etc/sysconfig/keyboard:KEYTABLE-KEYMAP /etc/sysconfig/i18n:SYSFONT-FONT,FONTACM-FONT_MAP,FONT_UNIMAP",
+          "install_optional_items": " vi /etc/virc ps grep cat rm ",
+          "prefix": "/",
+          "reproducible": "yes",
+          "stdloglvl": "3",
+          "sysctlconfdir": "/etc/sysctl.d",
+          "sysctld": "/usr/lib/sysctl.d",
+          "sysloglvl": "5",
+          "systemdcatalog": "/usr/lib/systemd/catalog",
+          "systemdntpunits": "/usr/lib/systemd/ntp-units.d",
+          "systemdntpunitsconfdir": "/etc/systemd/ntp-units.d",
+          "systemdportable": "/usr/lib/systemd/portable",
+          "systemdportableconfdir": "/etc/systemd/portable",
+          "systemdsystemconfdir": "/etc/systemd/system",
+          "systemdsystemunitdir": "/usr/lib/systemd/system",
+          "systemduser": "/usr/lib/systemd/user",
+          "systemduserconfdir": "/etc/systemd/user",
+          "systemdutilconfdir": "/etc/systemd",
+          "systemdutildir": "/usr/lib/systemd",
+          "sysusers": "/usr/lib/sysusers.d",
+          "sysusersconfdir": "/etc/sysusers.d",
+          "udevdir": "/usr/lib/udev"
+        },
+        "02-generic-image.conf": {
+          "hostonly": "no"
+        }
+      }
+    },
+    "fstab": [
+      [
+        "UUID=46BB-8120",
+        "/boot/efi",
+        "vfat",
+        "umask=0077,shortname=winnt",
+        "0",
+        "2"
+      ],
+      [
+        "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+        "/",
+        "ext4",
+        "defaults",
+        "1",
+        "1"
+      ]
+    ],
+    "groups": [
+      "adm:x:4:",
+      "audio:x:63:",
+      "bin:x:1:",
+      "cdrom:x:11:",
+      "chrony:x:993:",
+      "daemon:x:2:",
+      "dbus:x:81:",
+      "dialout:x:18:",
+      "disk:x:6:",
+      "floppy:x:19:",
+      "ftp:x:50:",
+      "games:x:20:",
+      "input:x:104:",
+      "kmem:x:9:",
+      "kvm:x:36:",
+      "lock:x:54:",
+      "lp:x:7:",
+      "mail:x:12:",
+      "man:x:15:",
+      "mem:x:8:",
+      "nobody:x:65534:",
+      "polkitd:x:994:",
+      "render:x:105:",
+      "root:x:0:",
+      "sgx:x:106:",
+      "ssh_keys:x:996:",
+      "sshd:x:74:",
+      "sys:x:3:",
+      "systemd-coredump:x:997:",
+      "systemd-journal:x:190:",
+      "systemd-network:x:192:",
+      "systemd-oom:x:999:",
+      "systemd-resolve:x:193:",
+      "systemd-timesync:x:998:",
+      "tape:x:33:",
+      "tss:x:59:",
+      "tty:x:5:",
+      "unbound:x:995:",
+      "users:x:100:",
+      "utempter:x:35:",
+      "utmp:x:22:",
+      "video:x:39:",
+      "wheel:x:10:"
+    ],
+    "hostname": "localhost.localdomain",
+    "hosts": [
+      "127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4",
+      "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
+    ],
+    "image-format": {
+      "compat": "1.1",
+      "type": "qcow2"
+    },
+    "locale": {
+      "LANG": "en_US"
+    },
+    "machine-id": "",
+    "os-release": {
+      "ANSI_COLOR": "0;38;2;60;110;180",
+      "BUG_REPORT_URL": "https://bugzilla.redhat.com/",
+      "CPE_NAME": "cpe:/o:fedoraproject:fedora:35",
+      "DOCUMENTATION_URL": "https://docs.fedoraproject.org/en-US/fedora/f35/system-administrators-guide/",
+      "HOME_URL": "https://fedoraproject.org/",
+      "ID": "fedora",
+      "LOGO": "fedora-logo-icon",
+      "NAME": "Fedora Linux",
+      "PLATFORM_ID": "platform:f35",
+      "PRETTY_NAME": "Fedora Linux 35 (Cloud Edition)",
+      "PRIVACY_POLICY_URL": "https://fedoraproject.org/wiki/Legal:PrivacyPolicy",
+      "REDHAT_BUGZILLA_PRODUCT": "Fedora",
+      "REDHAT_BUGZILLA_PRODUCT_VERSION": "35",
+      "REDHAT_SUPPORT_PRODUCT": "Fedora",
+      "REDHAT_SUPPORT_PRODUCT_VERSION": "35",
+      "SUPPORT_URL": "https://ask.fedoraproject.org/",
+      "VARIANT": "Cloud Edition",
+      "VARIANT_ID": "cloud",
+      "VERSION": "35 (Cloud Edition)",
+      "VERSION_CODENAME": "",
+      "VERSION_ID": "35"
+    },
+    "packages": [
+      "NetworkManager-1.32.12-2.fc35.aarch64",
+      "NetworkManager-libnm-1.32.12-2.fc35.aarch64",
+      "acl-2.3.1-2.fc35.aarch64",
+      "alternatives-1.19-1.fc35.aarch64",
+      "audit-3.0.6-1.fc35.aarch64",
+      "audit-libs-3.0.6-1.fc35.aarch64",
+      "basesystem-11-12.fc35.noarch",
+      "bash-5.1.8-2.fc35.aarch64",
+      "bzip2-libs-1.0.8-9.fc35.aarch64",
+      "c-ares-1.17.2-1.fc35.aarch64",
+      "ca-certificates-2021.2.52-1.0.fc35.noarch",
+      "checkpolicy-3.3-1.fc35.aarch64",
+      "chkconfig-1.19-1.fc35.aarch64",
+      "chrony-4.1-3.fc35.aarch64",
+      "cloud-init-20.4-7.fc35.noarch",
+      "cloud-utils-growpart-0.31-9.fc35.noarch",
+      "console-login-helper-messages-0.21.2-3.fc35.noarch",
+      "console-login-helper-messages-issuegen-0.21.2-3.fc35.noarch",
+      "console-login-helper-messages-motdgen-0.21.2-3.fc35.noarch",
+      "console-login-helper-messages-profile-0.21.2-3.fc35.noarch",
+      "coreutils-8.32-31.fc35.aarch64",
+      "coreutils-common-8.32-31.fc35.aarch64",
+      "cpio-2.13-11.fc35.aarch64",
+      "cracklib-2.9.6-27.fc35.aarch64",
+      "cracklib-dicts-2.9.6-27.fc35.aarch64",
+      "crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch",
+      "crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch",
+      "cryptsetup-libs-2.4.2-1.fc35.aarch64",
+      "curl-7.79.1-1.fc35.aarch64",
+      "cyrus-sasl-lib-2.1.27-13.fc35.aarch64",
+      "dbus-1.12.20-5.fc35.aarch64",
+      "dbus-broker-29-4.fc35.aarch64",
+      "dbus-common-1.12.20-5.fc35.noarch",
+      "dbus-libs-1.12.20-5.fc35.aarch64",
+      "dejavu-sans-fonts-2.37-17.fc35.noarch",
+      "deltarpm-3.6.2-10.fc35.aarch64",
+      "device-mapper-1.02.175-6.fc35.aarch64",
+      "device-mapper-libs-1.02.175-6.fc35.aarch64",
+      "dhcp-client-4.4.2-16.b1.fc35.aarch64",
+      "dhcp-common-4.4.2-16.b1.fc35.noarch",
+      "diffutils-3.8-1.fc35.aarch64",
+      "dnf-4.9.0-1.fc35.noarch",
+      "dnf-data-4.9.0-1.fc35.noarch",
+      "dnf-plugins-core-4.0.24-1.fc35.noarch",
+      "dracut-055-6.fc35.aarch64",
+      "dracut-config-generic-055-6.fc35.aarch64",
+      "e2fsprogs-1.46.3-1.fc35.aarch64",
+      "e2fsprogs-libs-1.46.3-1.fc35.aarch64",
+      "efi-filesystem-5-4.fc35.noarch",
+      "efibootmgr-16-11.fc35.aarch64",
+      "efivar-libs-37-17.fc35.aarch64",
+      "elfutils-debuginfod-client-0.186-1.fc35.aarch64",
+      "elfutils-default-yama-scope-0.186-1.fc35.noarch",
+      "elfutils-libelf-0.186-1.fc35.aarch64",
+      "elfutils-libs-0.186-1.fc35.aarch64",
+      "expat-2.4.1-2.fc35.aarch64",
+      "fedora-gpg-keys-35-1.noarch",
+      "fedora-release-cloud-35-36.noarch",
+      "fedora-release-common-35-36.noarch",
+      "fedora-release-identity-cloud-35-36.noarch",
+      "fedora-repos-35-1.noarch",
+      "fedora-repos-modular-35-1.noarch",
+      "file-5.40-9.fc35.aarch64",
+      "file-libs-5.40-9.fc35.aarch64",
+      "filesystem-3.14-7.fc35.aarch64",
+      "findutils-4.8.0-4.fc35.aarch64",
+      "fonts-filesystem-2.0.5-6.fc35.noarch",
+      "freetype-2.11.0-1.fc35.aarch64",
+      "fuse-libs-2.9.9-13.fc35.aarch64",
+      "gawk-5.1.0-4.fc35.aarch64",
+      "gawk-all-langpacks-5.1.0-4.fc35.aarch64",
+      "gdbm-libs-1.22-1.fc35.aarch64",
+      "gettext-0.21-8.fc35.aarch64",
+      "gettext-libs-0.21-8.fc35.aarch64",
+      "glib2-2.70.2-1.fc35.aarch64",
+      "glibc-2.34-11.fc35.aarch64",
+      "glibc-common-2.34-11.fc35.aarch64",
+      "glibc-gconv-extra-2.34-11.fc35.aarch64",
+      "glibc-langpack-en-2.34-11.fc35.aarch64",
+      "gmp-6.2.0-7.fc35.aarch64",
+      "gnupg2-2.3.4-1.fc35.aarch64",
+      "gnupg2-smime-2.3.4-1.fc35.aarch64",
+      "gnutls-3.7.2-2.fc35.aarch64",
+      "gpg-pubkey-9867c58f-601c49ca",
+      "gpgme-1.15.1-6.fc35.aarch64",
+      "graphite2-1.3.14-8.fc35.aarch64",
+      "grep-3.6-4.fc35.aarch64",
+      "groff-base-1.22.4-8.fc35.aarch64",
+      "grub2-common-2.06-10.fc35.noarch",
+      "grub2-efi-aa64-2.06-10.fc35.aarch64",
+      "grub2-tools-2.06-10.fc35.aarch64",
+      "grub2-tools-extra-2.06-10.fc35.aarch64",
+      "grub2-tools-minimal-2.06-10.fc35.aarch64",
+      "grubby-8.40-55.fc35.aarch64",
+      "gzip-1.10-5.fc35.aarch64",
+      "harfbuzz-2.8.2-2.fc35.aarch64",
+      "hostname-3.23-5.fc35.aarch64",
+      "hunspell-1.7.0-11.fc35.aarch64",
+      "hunspell-en-0.20140811.1-20.fc35.noarch",
+      "hunspell-en-GB-0.20140811.1-20.fc35.noarch",
+      "hunspell-en-US-0.20140811.1-20.fc35.noarch",
+      "hunspell-filesystem-1.7.0-11.fc35.aarch64",
+      "ima-evm-utils-1.3.2-3.fc35.aarch64",
+      "inih-49-4.fc35.aarch64",
+      "initscripts-10.11-1.fc35.aarch64",
+      "initscripts-service-10.11-1.fc35.noarch",
+      "ipcalc-1.0.1-2.fc35.aarch64",
+      "iproute-5.13.0-2.fc35.aarch64",
+      "iproute-tc-5.13.0-2.fc35.aarch64",
+      "iptables-legacy-libs-1.8.7-13.fc35.aarch64",
+      "iptables-libs-1.8.7-13.fc35.aarch64",
+      "iputils-20210722-1.fc35.aarch64",
+      "json-c-0.15-2.fc35.aarch64",
+      "kbd-2.4.0-8.fc35.aarch64",
+      "kbd-misc-2.4.0-8.fc35.noarch",
+      "kernel-5.15.13-200.fc35.aarch64",
+      "kernel-core-5.15.13-200.fc35.aarch64",
+      "kernel-modules-5.15.13-200.fc35.aarch64",
+      "keyutils-libs-1.6.1-3.fc35.aarch64",
+      "kmod-29-4.fc35.aarch64",
+      "kmod-libs-29-4.fc35.aarch64",
+      "kpartx-0.8.6-5.fc35.aarch64",
+      "krb5-libs-1.19.2-2.fc35.aarch64",
+      "langpacks-core-en-3.0-15.fc35.noarch",
+      "langpacks-core-font-en-3.0-15.fc35.noarch",
+      "langpacks-en-3.0-15.fc35.noarch",
+      "less-590-2.fc35.aarch64",
+      "libacl-2.3.1-2.fc35.aarch64",
+      "libarchive-3.5.2-2.fc35.aarch64",
+      "libargon2-20171227-7.fc35.aarch64",
+      "libassuan-2.5.5-3.fc35.aarch64",
+      "libattr-2.5.1-3.fc35.aarch64",
+      "libbasicobjects-0.1.1-48.fc35.aarch64",
+      "libblkid-2.37.2-1.fc35.aarch64",
+      "libbrotli-1.0.9-6.fc35.aarch64",
+      "libcap-2.48-3.fc35.aarch64",
+      "libcap-ng-0.8.2-8.fc35.aarch64",
+      "libcbor-0.7.0-4.fc35.aarch64",
+      "libcollection-0.7.0-48.fc35.aarch64",
+      "libcom_err-1.46.3-1.fc35.aarch64",
+      "libcomps-0.1.18-1.fc35.aarch64",
+      "libcurl-7.79.1-1.fc35.aarch64",
+      "libdb-5.3.28-50.fc35.aarch64",
+      "libdhash-0.5.0-48.fc35.aarch64",
+      "libdnf-0.64.0-1.fc35.aarch64",
+      "libeconf-0.4.0-2.fc35.aarch64",
+      "libedit-3.1-40.20210910cvs.fc35.aarch64",
+      "libevent-2.1.12-4.fc35.aarch64",
+      "libfdisk-2.37.2-1.fc35.aarch64",
+      "libffi-3.1-29.fc35.aarch64",
+      "libfido2-1.8.0-1.fc35.aarch64",
+      "libfsverity-1.4-6.fc35.aarch64",
+      "libgcc-11.2.1-7.fc35.aarch64",
+      "libgcrypt-1.9.4-1.fc35.aarch64",
+      "libgomp-11.2.1-7.fc35.aarch64",
+      "libgpg-error-1.43-1.fc35.aarch64",
+      "libibverbs-38.0-1.fc35.aarch64",
+      "libidn2-2.3.2-3.fc35.aarch64",
+      "libini_config-1.3.1-48.fc35.aarch64",
+      "libkcapi-1.3.1-3.fc35.aarch64",
+      "libkcapi-hmaccalc-1.3.1-3.fc35.aarch64",
+      "libksba-1.6.0-2.fc35.aarch64",
+      "libldb-2.4.1-1.fc35.aarch64",
+      "libmaxminddb-1.6.0-1.fc35.aarch64",
+      "libmnl-1.0.4-14.fc35.aarch64",
+      "libmodulemd-2.13.0-3.fc35.aarch64",
+      "libmount-2.37.2-1.fc35.aarch64",
+      "libndp-1.8-2.fc35.aarch64",
+      "libnetfilter_conntrack-1.0.8-3.fc35.aarch64",
+      "libnfnetlink-1.0.1-20.fc35.aarch64",
+      "libnfsidmap-2.5.4-2.rc3.fc35.aarch64",
+      "libnghttp2-1.45.1-1.fc35.aarch64",
+      "libnl3-3.5.0-8.fc35.aarch64",
+      "libnsl2-1.3.0-4.fc35.aarch64",
+      "libpath_utils-0.2.1-48.fc35.aarch64",
+      "libpcap-1.10.1-2.fc35.aarch64",
+      "libpipeline-1.5.3-3.fc35.aarch64",
+      "libpng-1.6.37-11.fc35.aarch64",
+      "libpsl-0.21.1-4.fc35.aarch64",
+      "libpwquality-1.4.4-6.fc35.aarch64",
+      "libref_array-0.1.5-48.fc35.aarch64",
+      "librepo-1.14.2-1.fc35.aarch64",
+      "libreport-filesystem-2.15.2-6.fc35.noarch",
+      "libseccomp-2.5.3-1.fc35.aarch64",
+      "libsecret-0.20.4-3.fc35.aarch64",
+      "libselinux-3.3-1.fc35.aarch64",
+      "libselinux-utils-3.3-1.fc35.aarch64",
+      "libsemanage-3.3-1.fc35.aarch64",
+      "libsepol-3.3-2.fc35.aarch64",
+      "libsigsegv-2.13-3.fc35.aarch64",
+      "libsmartcols-2.37.2-1.fc35.aarch64",
+      "libsolv-0.7.19-3.fc35.aarch64",
+      "libss-1.46.3-1.fc35.aarch64",
+      "libssh-0.9.6-1.fc35.aarch64",
+      "libssh-config-0.9.6-1.fc35.noarch",
+      "libsss_autofs-2.6.1-1.fc35.aarch64",
+      "libsss_certmap-2.6.1-1.fc35.aarch64",
+      "libsss_idmap-2.6.1-1.fc35.aarch64",
+      "libsss_nss_idmap-2.6.1-1.fc35.aarch64",
+      "libsss_sudo-2.6.1-1.fc35.aarch64",
+      "libstdc++-11.2.1-7.fc35.aarch64",
+      "libtalloc-2.3.3-2.fc35.aarch64",
+      "libtasn1-4.16.0-6.fc35.aarch64",
+      "libtdb-1.4.4-3.fc35.aarch64",
+      "libtevent-0.11.0-1.fc35.aarch64",
+      "libtirpc-1.3.2-1.fc35.aarch64",
+      "libunistring-0.9.10-14.fc35.aarch64",
+      "libusb1-1.0.24-4.fc35.aarch64",
+      "libuser-0.63-7.fc35.aarch64",
+      "libutempter-1.2.1-5.fc35.aarch64",
+      "libuuid-2.37.2-1.fc35.aarch64",
+      "libverto-0.3.2-2.fc35.aarch64",
+      "libxcrypt-4.4.27-1.fc35.aarch64",
+      "libxkbcommon-1.3.1-1.fc35.aarch64",
+      "libxml2-2.9.12-6.fc35.aarch64",
+      "libyaml-0.2.5-6.fc35.aarch64",
+      "libzstd-1.5.1-4.fc35.aarch64",
+      "linux-atm-libs-2.5.1-30.fc35.aarch64",
+      "linux-firmware-20211216-127.fc35.noarch",
+      "linux-firmware-whence-20211216-127.fc35.noarch",
+      "lmdb-libs-0.9.29-2.fc35.aarch64",
+      "lua-libs-5.4.3-2.fc35.aarch64",
+      "lz4-libs-1.9.3-3.fc35.aarch64",
+      "man-db-2.9.4-2.fc35.aarch64",
+      "memstrack-0.2.4-1.fc35.aarch64",
+      "mkpasswd-5.5.10-2.fc35.aarch64",
+      "mokutil-0.5.0-1.fc35.aarch64",
+      "mozjs78-78.15.0-1.fc35.aarch64",
+      "mpdecimal-2.5.1-2.fc35.aarch64",
+      "mpfr-4.1.0-8.fc35.aarch64",
+      "ncurses-6.2-8.20210508.fc35.aarch64",
+      "ncurses-base-6.2-8.20210508.fc35.noarch",
+      "ncurses-libs-6.2-8.20210508.fc35.aarch64",
+      "net-tools-2.0-0.60.20160912git.fc35.aarch64",
+      "nettle-3.7.3-2.fc35.aarch64",
+      "npth-1.6-7.fc35.aarch64",
+      "openldap-2.4.59-3.fc35.aarch64",
+      "openssh-8.7p1-3.fc35.aarch64",
+      "openssh-clients-8.7p1-3.fc35.aarch64",
+      "openssh-server-8.7p1-3.fc35.aarch64",
+      "openssl-libs-1.1.1l-2.fc35.aarch64",
+      "openssl-pkcs11-0.4.11-4.fc35.aarch64",
+      "os-prober-1.77-8.fc35.aarch64",
+      "p11-kit-0.23.22-4.fc35.aarch64",
+      "p11-kit-trust-0.23.22-4.fc35.aarch64",
+      "pam-1.5.2-5.fc35.aarch64",
+      "parted-3.4-6.fc35.aarch64",
+      "passwd-0.80-11.fc35.aarch64",
+      "pcre-8.45-1.fc35.aarch64",
+      "pcre2-10.37-4.fc35.aarch64",
+      "pcre2-syntax-10.37-4.fc35.noarch",
+      "pcsc-lite-1.9.5-1.fc35.aarch64",
+      "pcsc-lite-ccid-1.4.36-2.fc35.aarch64",
+      "pcsc-lite-libs-1.9.5-1.fc35.aarch64",
+      "pigz-2.5-2.fc35.aarch64",
+      "pinentry-1.2.0-1.fc35.aarch64",
+      "policycoreutils-3.3-1.fc35.aarch64",
+      "polkit-0.120-1.fc35.aarch64",
+      "polkit-libs-0.120-1.fc35.aarch64",
+      "polkit-pkla-compat-0.1-20.fc35.aarch64",
+      "popt-1.18-6.fc35.aarch64",
+      "procps-ng-3.3.17-3.fc35.aarch64",
+      "protobuf-c-1.4.0-1.fc35.aarch64",
+      "psmisc-23.4-2.fc35.aarch64",
+      "publicsuffix-list-dafsa-20210518-2.fc35.noarch",
+      "python-pip-wheel-21.2.3-4.fc35.noarch",
+      "python-setuptools-wheel-57.4.0-1.fc35.noarch",
+      "python-unversioned-command-3.10.1-2.fc35.noarch",
+      "python3-3.10.1-2.fc35.aarch64",
+      "python3-attrs-21.2.0-4.fc35.noarch",
+      "python3-audit-3.0.6-1.fc35.aarch64",
+      "python3-babel-2.9.1-4.fc35.noarch",
+      "python3-cffi-1.14.6-2.fc35.aarch64",
+      "python3-charset-normalizer-2.0.4-1.fc35.noarch",
+      "python3-configobj-5.0.6-25.fc35.noarch",
+      "python3-cryptography-3.4.7-5.fc35.aarch64",
+      "python3-dateutil-2.8.1-7.fc35.noarch",
+      "python3-dbus-1.2.18-2.fc35.aarch64",
+      "python3-distro-1.6.0-1.fc35.noarch",
+      "python3-dnf-4.9.0-1.fc35.noarch",
+      "python3-dnf-plugins-core-4.0.24-1.fc35.noarch",
+      "python3-gpg-1.15.1-6.fc35.aarch64",
+      "python3-hawkey-0.64.0-1.fc35.aarch64",
+      "python3-idna-3.2-1.fc35.noarch",
+      "python3-jinja2-3.0.1-2.fc35.noarch",
+      "python3-jsonpatch-1.21-18.fc35.noarch",
+      "python3-jsonpointer-2.0-4.fc35.noarch",
+      "python3-jsonschema-3.2.0-12.fc35.noarch",
+      "python3-jwt+crypto-2.1.0-2.fc35.noarch",
+      "python3-jwt-2.1.0-2.fc35.noarch",
+      "python3-libcomps-0.1.18-1.fc35.aarch64",
+      "python3-libdnf-0.64.0-1.fc35.aarch64",
+      "python3-libs-3.10.1-2.fc35.aarch64",
+      "python3-libselinux-3.3-1.fc35.aarch64",
+      "python3-libsemanage-3.3-1.fc35.aarch64",
+      "python3-markupsafe-2.0.0-2.fc35.aarch64",
+      "python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch",
+      "python3-oauthlib-3.0.2-11.fc35.noarch",
+      "python3-ply-3.11-13.fc35.noarch",
+      "python3-policycoreutils-3.3-1.fc35.noarch",
+      "python3-prettytable-0.7.2-27.fc35.noarch",
+      "python3-pycparser-2.20-5.fc35.noarch",
+      "python3-pyrsistent-0.18.0-8.fc35.aarch64",
+      "python3-pyserial-3.4-12.fc35.noarch",
+      "python3-pysocks-1.7.1-11.fc35.noarch",
+      "python3-pytz-2021.3-1.fc35.noarch",
+      "python3-pyyaml-5.4.1-4.fc35.aarch64",
+      "python3-requests-2.27.0-1.fc35.noarch",
+      "python3-rpm-4.17.0-1.fc35.aarch64",
+      "python3-setools-4.4.0-3.fc35.aarch64",
+      "python3-setuptools-57.4.0-1.fc35.noarch",
+      "python3-six-1.16.0-4.fc35.noarch",
+      "python3-unbound-1.13.2-1.fc35.aarch64",
+      "python3-urllib3-1.26.7-2.fc35.noarch",
+      "qrencode-libs-4.1.1-1.fc35.aarch64",
+      "readline-8.1-3.fc35.aarch64",
+      "rootfiles-8.1-30.fc35.noarch",
+      "rpm-4.17.0-1.fc35.aarch64",
+      "rpm-build-libs-4.17.0-1.fc35.aarch64",
+      "rpm-libs-4.17.0-1.fc35.aarch64",
+      "rpm-plugin-selinux-4.17.0-1.fc35.aarch64",
+      "rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64",
+      "rpm-sign-libs-4.17.0-1.fc35.aarch64",
+      "rsync-3.2.3-8.fc35.aarch64",
+      "sed-4.8-8.fc35.aarch64",
+      "selinux-policy-35.8-1.fc35.noarch",
+      "selinux-policy-targeted-35.8-1.fc35.noarch",
+      "setup-2.13.9.1-2.fc35.noarch",
+      "shadow-utils-4.9-8.fc35.aarch64",
+      "shim-aa64-15.4-5.aarch64",
+      "sqlite-libs-3.36.0-3.fc35.aarch64",
+      "sssd-client-2.6.1-1.fc35.aarch64",
+      "sssd-common-2.6.1-1.fc35.aarch64",
+      "sssd-kcm-2.6.1-1.fc35.aarch64",
+      "sssd-nfs-idmap-2.6.1-1.fc35.aarch64",
+      "sudo-1.9.7p2-2.fc35.aarch64",
+      "sudo-python-plugin-1.9.7p2-2.fc35.aarch64",
+      "systemd-249.7-2.fc35.aarch64",
+      "systemd-libs-249.7-2.fc35.aarch64",
+      "systemd-networkd-249.7-2.fc35.aarch64",
+      "systemd-oomd-defaults-249.7-2.fc35.noarch",
+      "systemd-pam-249.7-2.fc35.aarch64",
+      "systemd-resolved-249.7-2.fc35.aarch64",
+      "systemd-udev-249.7-2.fc35.aarch64",
+      "tar-1.34-2.fc35.aarch64",
+      "tpm2-tss-3.1.0-3.fc35.aarch64",
+      "trousers-0.3.15-4.fc35.aarch64",
+      "trousers-lib-0.3.15-4.fc35.aarch64",
+      "tzdata-2021e-1.fc35.noarch",
+      "unbound-libs-1.13.2-1.fc35.aarch64",
+      "util-linux-2.37.2-1.fc35.aarch64",
+      "util-linux-core-2.37.2-1.fc35.aarch64",
+      "vim-data-8.2.4006-1.fc35.noarch",
+      "vim-minimal-8.2.4006-1.fc35.aarch64",
+      "which-2.21-27.fc35.aarch64",
+      "whois-nls-5.5.10-2.fc35.noarch",
+      "xfsprogs-5.12.0-2.fc35.aarch64",
+      "xkeyboard-config-2.33-2.fc35.noarch",
+      "xz-5.2.5-7.fc35.aarch64",
+      "xz-libs-5.2.5-7.fc35.aarch64",
+      "yum-4.9.0-1.fc35.noarch",
+      "zchunk-libs-1.1.15-2.fc35.aarch64",
+      "zlib-1.2.11-30.fc35.aarch64"
+    ],
+    "partition-table": "gpt",
+    "partition-table-id": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
+    "partitions": [
+      {
+        "bootable": false,
+        "fstype": "vfat",
+        "label": "EFI-SYSTEM",
+        "partuuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
+        "size": 498073600,
+        "start": 1048576,
+        "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+        "uuid": "46BB-8120"
+      },
+      {
+        "bootable": false,
+        "fstype": "ext4",
+        "label": null,
+        "partuuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
+        "size": 1647296000,
+        "start": 500170752,
+        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+        "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+      }
+    ],
+    "passwd": [
+      "adm:x:3:4:adm:/var/adm:/sbin/nologin",
+      "bin:x:1:1:bin:/bin:/sbin/nologin",
+      "chrony:x:994:993::/var/lib/chrony:/sbin/nologin",
+      "daemon:x:2:2:daemon:/sbin:/sbin/nologin",
+      "dbus:x:81:81:System message bus:/:/sbin/nologin",
+      "ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin",
+      "games:x:12:100:games:/usr/games:/sbin/nologin",
+      "halt:x:7:0:halt:/sbin:/sbin/halt",
+      "lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin",
+      "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
+      "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
+      "operator:x:11:0:operator:/root:/sbin/nologin",
+      "polkitd:x:995:994:User for polkitd:/:/sbin/nologin",
+      "root:x:0:0:root:/root:/bin/bash",
+      "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
+      "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
+      "sync:x:5:0:sync:/sbin:/bin/sync",
+      "systemd-coredump:x:997:997:systemd Core Dumper:/:/usr/sbin/nologin",
+      "systemd-network:x:192:192:systemd Network Management:/:/usr/sbin/nologin",
+      "systemd-oom:x:999:999:systemd Userspace OOM Killer:/:/usr/sbin/nologin",
+      "systemd-resolve:x:193:193:systemd Resolver:/:/usr/sbin/nologin",
+      "systemd-timesync:x:998:998:systemd Time Synchronization:/:/usr/sbin/nologin",
+      "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
+      "unbound:x:996:995:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
+    ],
+    "rpm-verify": {
+      "changed": {
+        "/boot/efi/EFI": ".M.......",
+        "/boot/efi/EFI/BOOT/BOOTAA64.EFI": ".......T.",
+        "/boot/efi/EFI/BOOT/fbaa64.efi": ".......T.",
+        "/boot/efi/EFI/fedora/BOOTAA64.CSV": ".......T.",
+        "/boot/efi/EFI/fedora/grubaa64.efi": ".......T.",
+        "/boot/efi/EFI/fedora/mmaa64.efi": ".......T.",
+        "/boot/efi/EFI/fedora/shim.efi": ".......T.",
+        "/boot/efi/EFI/fedora/shimaa64.efi": ".......T.",
+        "/etc/machine-id": ".M.......",
+        "/etc/udev/hwdb.bin": ".M.......",
+        "/proc": ".M.......",
+        "/sys": ".M.......",
+        "/var/log/lastlog": ".M....G.."
+      },
+      "missing": []
+    },
+    "selinux": {
+      "context-mismatch": [
+        {
+          "actual": "system_u:object_r:unlabeled_t:s0",
+          "expected": "system_u:object_r:lost_found_t:s0",
+          "filename": "/lost+found"
+        }
+      ],
+      "policy": {
+        "SELINUX": "enforcing",
+        "SELINUXTYPE": "targeted"
+      }
+    },
+    "services-disabled": [
+      "arp-ethers.service",
+      "chrony-wait.service",
+      "console-getty.service",
+      "console-login-helper-messages-gensnippet-os-release.service",
+      "console-login-helper-messages-gensnippet-ssh-keys.service",
+      "debug-shell.service",
+      "exit.target",
+      "halt.target",
+      "kexec.target",
+      "loadmodules.service",
+      "man-db-restart-cache-update.service",
+      "nis-domainname.service",
+      "poweroff.target",
+      "proc-sys-fs-binfmt_misc.mount",
+      "rdisc.service",
+      "remote-cryptsetup.target",
+      "remote-veritysetup.target",
+      "runlevel0.target",
+      "selinux-check-proper-disable.service",
+      "serial-getty@.service",
+      "sshd-keygen@.service",
+      "sshd.socket",
+      "sssd-autofs.socket",
+      "sssd-nss.socket",
+      "sssd-pac.socket",
+      "sssd-pam-priv.socket",
+      "sssd-pam.socket",
+      "sssd-ssh.socket",
+      "sssd-sudo.socket",
+      "systemd-boot-check-no-failures.service",
+      "systemd-network-generator.service",
+      "systemd-networkd-wait-online.service",
+      "systemd-networkd.service",
+      "systemd-networkd.socket",
+      "systemd-pstore.service",
+      "systemd-sysext.service",
+      "systemd-time-wait-sync.service",
+      "systemd-timesyncd.service",
+      "tcsd.service"
+    ],
+    "services-enabled": [
+      "NetworkManager-dispatcher.service",
+      "NetworkManager-wait-online.service",
+      "NetworkManager.service",
+      "auditd.service",
+      "autovt@.service",
+      "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
+      "ctrl-alt-del.target",
+      "dbus-broker.service",
+      "dbus-org.freedesktop.home1.service",
+      "dbus-org.freedesktop.nm-dispatcher.service",
+      "dbus-org.freedesktop.oom1.service",
+      "dbus-org.freedesktop.resolve1.service",
+      "dbus.service",
+      "dbus.socket",
+      "dnf-makecache.timer",
+      "fstrim.timer",
+      "getty@.service",
+      "import-state.service",
+      "pcscd.socket",
+      "reboot.target",
+      "remote-fs.target",
+      "rpmdb-rebuild.service",
+      "runlevel6.target",
+      "selinux-autorelabel-mark.service",
+      "sshd.service",
+      "sssd-kcm.socket",
+      "sssd.service",
+      "systemd-homed-activate.service",
+      "systemd-homed.service",
+      "systemd-oomd.service",
+      "systemd-resolved.service",
+      "systemd-userdbd.socket",
+      "unbound-anchor.timer"
+    ],
+    "sudoers": {
+      "/etc/sudoers": [
+        "Defaults   !visiblepw",
+        "Defaults    always_set_home",
+        "Defaults    match_group_by_gid",
+        "Defaults    always_query_group_plugin",
+        "Defaults    env_reset",
+        "Defaults    env_keep =  \"COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS\"",
+        "Defaults    env_keep += \"MAIL QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE\"",
+        "Defaults    env_keep += \"LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES\"",
+        "Defaults    env_keep += \"LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE\"",
+        "Defaults    env_keep += \"LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY\"",
+        "Defaults    secure_path = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+        "root\tALL=(ALL) \tALL",
+        "%wheel\tALL=(ALL)\tALL"
+      ]
+    },
+    "sysctl.d": {
+      "/usr/lib/sysctl.d": {
+        "10-default-yama-scope.conf": [
+          "kernel.yama.ptrace_scope = 0"
+        ],
+        "50-coredump.conf": [
+          "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h",
+          "kernel.core_pipe_limit=16",
+          "fs.suid_dumpable=2"
+        ],
+        "50-default.conf": [
+          "kernel.sysrq = 16",
+          "kernel.core_uses_pid = 1",
+          "net.ipv4.conf.default.rp_filter = 2",
+          "net.ipv4.conf.*.rp_filter = 2",
+          "-net.ipv4.conf.all.rp_filter",
+          "net.ipv4.conf.default.accept_source_route = 0",
+          "net.ipv4.conf.*.accept_source_route = 0",
+          "-net.ipv4.conf.all.accept_source_route",
+          "net.ipv4.conf.default.promote_secondaries = 1",
+          "net.ipv4.conf.*.promote_secondaries = 1",
+          "-net.ipv4.conf.all.promote_secondaries",
+          "-net.ipv4.ping_group_range = 0 2147483647",
+          "-net.core.default_qdisc = fq_codel",
+          "fs.protected_hardlinks = 1",
+          "fs.protected_symlinks = 1",
+          "fs.protected_regular = 1",
+          "fs.protected_fifos = 1"
+        ],
+        "50-libkcapi-optmem_max.conf": [
+          "net.core.optmem_max = 81920"
+        ],
+        "50-pid-max.conf": [
+          "kernel.pid_max = 4194304"
+        ]
+      }
+    },
+    "systemd-service-dropins": {
+      "/usr/lib/systemd/system": {
+        "systemd-hostnamed.service.d": {
+          "Service": {
+            "PrivateDevices": "no"
+          }
+        },
+        "systemd-logind.service.d": {
+          "Service": {
+            "Environment": "SYSTEMD_REBOOT_TO_BOOT_LOADER_MENU=true"
+          }
+        },
+        "systemd-udev-trigger.service.d": {
+          "Unit": {
+            "RefuseManualStop": "true"
+          }
+        },
+        "user@.service.d": {
+          "Service": {
+            "ManagedOOMMemoryPressure": "kill",
+            "ManagedOOMMemoryPressureLimit": "50%"
+          }
+        }
+      }
+    },
+    "timezone": "UTC",
+    "tmpfiles.d": {
+      "/usr/lib/tmpfiles.d": {
+        "cloud-init.conf": [
+          "d /run/cloud-init 0700 root root - -"
+        ],
+        "console-login-helper-messages-issuegen.conf": [
+          "r /etc/issue.d/*_clhm_*.issue - - - - -"
+        ],
+        "console-login-helper-messages-motdgen.conf": [
+          "d /run/motd.d - - - - -"
+        ],
+        "console-login-helper-messages-profile.conf": [
+          "L /etc/profile.d/console-login-helper-messages-profile.sh - - - - ../../usr/share/console-login-helper-messages/profile.sh"
+        ],
+        "console-login-helper-messages.conf": [
+          "d /run/console-login-helper-messages - - - - -"
+        ],
+        "cryptsetup.conf": [
+          "d /run/cryptsetup 0700 root root -"
+        ],
+        "dnf.conf": [
+          "R /var/tmp/dnf*/locks/*",
+          "r /var/cache/dnf/download_lock.pid",
+          "r /var/cache/dnf/metadata_lock.pid",
+          "r /var/lib/dnf/rpmdb_lock.pid",
+          "r /var/log/log_lock.pid"
+        ],
+        "etc.conf": [
+          "L /etc/os-release - - - - ../usr/lib/os-release",
+          "L+ /etc/mtab - - - - ../proc/self/mounts",
+          "L! /etc/resolv.conf - - - - ../run/systemd/resolve/stub-resolv.conf",
+          "C! /etc/nsswitch.conf - - - -",
+          "C! /etc/pam.d - - - -",
+          "C! /etc/issue - - - -"
+        ],
+        "home.conf": [
+          "Q /home 0755 - - -",
+          "q /srv 0755 - - -"
+        ],
+        "journal-nocow.conf": [
+          "h /var/log/journal - - - - +C",
+          "h /var/log/journal/%m - - - - +C",
+          "h /var/log/journal/remote - - - - +C"
+        ],
+        "legacy.conf": [
+          "d /run/lock 0755 root root -",
+          "L /var/lock - - - - ../run/lock",
+          "d /run/lock/subsys 0755 root root -",
+          "r! /forcefsck",
+          "r! /fastboot",
+          "r! /forcequotacheck"
+        ],
+        "libselinux.conf": [
+          "d /run/setrans 0755 root root"
+        ],
+        "man-db.conf": [
+          "d /var/cache/man 0755 root root 1w"
+        ],
+        "pam.conf": [
+          "d /run/console 0755 root root -",
+          "d /run/faillock 0755 root root -",
+          "d /run/sepermit 0755 root root -",
+          "d /run/motd.d 0755 root root -",
+          "f /var/log/tallylog 0600 root root -"
+        ],
+        "portables.conf": [
+          "Q /var/lib/portables 0700"
+        ],
+        "selinux-policy.conf": [
+          "z /sys/devices/system/cpu/online - - -",
+          "Z /sys/class/net - - -",
+          "z /sys/kernel/uevent_helper - - -",
+          "w /sys/fs/selinux/checkreqprot - - - - 0"
+        ],
+        "setup.conf": [
+          "f /run/motd 0644 root root -",
+          "d /run/motd.d 0755 root root -"
+        ],
+        "static-nodes-permissions.conf": [
+          "z /dev/snd/seq      0660 - audio -",
+          "z /dev/snd/timer    0660 - audio -",
+          "z /dev/loop-control 0660 - disk  -",
+          "z /dev/net/tun      0666 - -     -",
+          "z /dev/fuse         0666 - -     -",
+          "z /dev/kvm          0666 - kvm -",
+          "z /dev/vhost-net    0666 - kvm -",
+          "z /dev/vhost-vsock  0666 - kvm -"
+        ],
+        "sudo.conf": [
+          "d /run/sudo 0711 root root",
+          "D /run/sudo/ts 0700 root root"
+        ],
+        "systemd-nologin.conf": [
+          "F! /run/nologin 0644 - - - \"System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8).\""
+        ],
+        "systemd-pstore.conf": [
+          "d /var/lib/systemd/pstore 0755 root root 14d"
+        ],
+        "systemd-tmp.conf": [
+          "x /tmp/systemd-private-%b-*",
+          "X /tmp/systemd-private-%b-*/tmp",
+          "x /var/tmp/systemd-private-%b-*",
+          "X /var/tmp/systemd-private-%b-*/tmp",
+          "R! /tmp/systemd-private-*",
+          "R! /var/tmp/systemd-private-*",
+          "x  /var/lib/systemd/coredump/.#core*.%b*",
+          "r! /var/lib/systemd/coredump/.#*"
+        ],
+        "systemd.conf": [
+          "d /run/user 0755 root root -",
+          "F! /run/utmp 0664 root utmp -",
+          "d /run/systemd/ask-password 0755 root root -",
+          "d /run/systemd/seats 0755 root root -",
+          "d /run/systemd/sessions 0755 root root -",
+          "d /run/systemd/users 0755 root root -",
+          "d /run/systemd/machines 0755 root root -",
+          "d /run/systemd/shutdown 0755 root root -",
+          "d /run/systemd/netif 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/links 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/leases 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/lldp 0755 systemd-network systemd-network -",
+          "d /run/log 0755 root root -",
+          "z /run/log/journal 2755 root systemd-journal - -",
+          "Z /run/log/journal/%m ~2750 root systemd-journal - -",
+          "a+ /run/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m/*.journal* - - - - group:adm:r--,group:wheel:r--",
+          "z /var/log/journal 2755 root systemd-journal - -",
+          "z /var/log/journal/%m 2755 root systemd-journal - -",
+          "z /var/log/journal/%m/system.journal 0640 root systemd-journal - -",
+          "a+ /var/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m/system.journal - - - - group:adm:r--,group:wheel:r--",
+          "d /var/lib/systemd 0755 root root -",
+          "d /var/lib/systemd/coredump 0755 root root 3d",
+          "d /var/lib/private 0700 root root -",
+          "d /var/log/private 0700 root root -",
+          "d /var/cache/private 0700 root root -"
+        ],
+        "tmp.conf": [
+          "q /tmp 1777 root root 10d",
+          "q /var/tmp 1777 root root 30d"
+        ],
+        "tpm2-tss-fapi.conf": [
+          "d       /var/lib/tpm2-tss/system/keystore   2775 tss  tss   -           -",
+          "a+      /var/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx",
+          "d       /run/tpm2-tss/eventlog                2775 tss  tss   -           -",
+          "a+      /run/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx"
+        ],
+        "var.conf": [
+          "q /var 0755 - - -",
+          "L /var/run - - - - ../run",
+          "d /var/log 0755 - - -",
+          "f /var/log/wtmp 0664 root utmp -",
+          "f /var/log/btmp 0660 root utmp -",
+          "f /var/log/lastlog 0664 root utmp -",
+          "d /var/cache 0755 - - -",
+          "d /var/lib 0755 - - -",
+          "d /var/spool 0755 - - -"
+        ],
+        "x11.conf": [
+          "D! /tmp/.X11-unix 1777 root root 10d",
+          "D! /tmp/.ICE-unix 1777 root root 10d",
+          "D! /tmp/.XIM-unix 1777 root root 10d",
+          "D! /tmp/.font-unix 1777 root root 10d",
+          "D! /tmp/.Test-unix 1777 root root 10d",
+          "r! /tmp/.X[0-9]*-lock"
+        ]
+      }
+    }
+  }
+}

--- a/test/data/manifests/fedora_35-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-openstack-boot.json
@@ -1,0 +1,11042 @@
+{
+  "boot": {
+    "type": "openstack"
+  },
+  "compose-request": {
+    "distro": "fedora-35",
+    "arch": "aarch64",
+    "image-type": "openstack",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-modular-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-modular-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      }
+    ],
+    "filename": "disk.qcow2",
+    "blueprint": {
+      "name": "openstack-boot-test",
+      "description": "Image for boot test",
+      "packages": [],
+      "modules": [],
+      "groups": [],
+      "customizations": {
+        "user": [
+          {
+            "name": "redhat",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+          }
+        ]
+      }
+    }
+  },
+  "manifest": {
+    "sources": {
+      "org.osbuild.files": {
+        "urls": {
+          "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.aarch64.rpm"
+          },
+          "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:01c4eedbedec34f5413a98f2dae6a84466270a71aceb647206e84e64b452ed96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-python3-0.8.2-8.fc35.aarch64.rpm"
+          },
+          "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm"
+          },
+          "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm"
+          },
+          "sha256:02f5457be9eac8a6ae4b19950895850da94f62a9c5e5f390a68a590092096c96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/a/alsa-lib-1.2.6.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.aarch64.rpm"
+          },
+          "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm"
+          },
+          "sha256:07fd0548f64b358ffd9ce32e885b7b91dc7e6208171d7efb9874923aead0fa5c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm"
+          },
+          "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-jsonpatch-1.21-18.fc35.noarch.rpm"
+          },
+          "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm"
+          },
+          "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm"
+          },
+          "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm"
+          },
+          "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm"
+          },
+          "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm"
+          },
+          "sha256:10190a125e7f12c0fb5c138b041c1c3625c43be574b1a42a845217cf2737cd88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/spice-vdagent-0.21.0-5.fc35.aarch64.rpm"
+          },
+          "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.aarch64.rpm"
+          },
+          "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm"
+          },
+          "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm"
+          },
+          "sha256:137e82364adba68a95cf5af5369af68318afe9fea740c5deb6cd40f71727db34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-guest-agent-6.1.0-10.fc35.aarch64.rpm"
+          },
+          "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-font-en-3.0-15.fc35.noarch.rpm"
+          },
+          "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fonts-filesystem-2.0.5-6.fc35.noarch.rpm"
+          },
+          "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm"
+          },
+          "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm"
+          },
+          "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm"
+          },
+          "sha256:1f81a2122f9b9482a6b41b2bd98ec47a9f06697a4f3d08ed81dfaca7ee7b1c6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipset-7.15-1.fc35.aarch64.rpm"
+          },
+          "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm"
+          },
+          "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm"
+          },
+          "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm"
+          },
+          "sha256:22a906074aaab00a9c1bac318f9d10323566670fc7772c61e196574dfc63ee9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-policycoreutils-3.3-1.fc35.noarch.rpm"
+          },
+          "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm"
+          },
+          "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm"
+          },
+          "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-attrs-21.2.0-4.fc35.noarch.rpm"
+          },
+          "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm"
+          },
+          "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm"
+          },
+          "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efibootmgr-16-11.fc35.aarch64.rpm"
+          },
+          "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm"
+          },
+          "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm"
+          },
+          "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm"
+          },
+          "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.26.7-2.fc35.noarch.rpm"
+          },
+          "sha256:2db66e2d4cb69b7433e334870a06b167dfbe38ba8c8be5d6eb6d3fe69ac0f769": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXext-1.3.4-7.fc35.aarch64.rpm"
+          },
+          "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efi-filesystem-5-4.fc35.noarch.rpm"
+          },
+          "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm"
+          },
+          "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:30c4143715cbe6d44c23039777276fe7b900130ea6193d75512f5d4651e52e13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gobject-introspection-1.70.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-requests-2.27.0-1.fc35.noarch.rpm"
+          },
+          "sha256:31e3038cdc752f890970d60653b510eb815e56be7854ba627ef7843b4c760ec9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-nftables-1.0.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm"
+          },
+          "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-ply-3.11-13.fc35.noarch.rpm"
+          },
+          "sha256:375b89f3a452a62f3a02ada8971b14e854fa95b0d4cb9efb0449e5f85d6959c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-markupsafe-2.0.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/less-590-2.fc35.aarch64.rpm"
+          },
+          "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/firewalld-1.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:39fd9eb8e77b430637602dc7cfce448e1792ace9cc9041c33f957b70d7b205c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/inih-49-4.fc35.aarch64.rpm"
+          },
+          "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm"
+          },
+          "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm"
+          },
+          "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.aarch64.rpm"
+          },
+          "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm"
+          },
+          "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm"
+          },
+          "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:3eecb51a03f9eed59710f6c6cbc5d66aea9bc521940d0b8d73fca835f1402897": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chrony-4.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:3f7252d59a6cafd37c6ce4851ba6ab13a0594e0a435bce4d8c392485888278a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libdrm-2.4.109-1.fc35.aarch64.rpm"
+          },
+          "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm"
+          },
+          "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm"
+          },
+          "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm"
+          },
+          "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm"
+          },
+          "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.aarch64.rpm"
+          },
+          "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm"
+          },
+          "sha256:469ec3ace1ffa4e3153c772d5ec5a65f8cb6e98d07405134c6b06545796e31c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyyaml-5.4.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/parted-3.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-charset-normalizer-2.0.4-1.fc35.noarch.rpm"
+          },
+          "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm"
+          },
+          "sha256:4c728458d61305c022946aa7199e2b462ac4449f04303def895923581b05d8c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libX11-common-1.7.3.1-1.fc35.noarch.rpm"
+          },
+          "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt-2.1.0-2.fc35.noarch.rpm"
+          },
+          "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/firewalld-filesystem-1.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.aarch64.rpm"
+          },
+          "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-en-3.0-15.fc35.noarch.rpm"
+          },
+          "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:501d1c9a812d927bc37ec65f11d818fef9f0647d711f132c91c1718124c32dc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-gobject-base-3.42.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:50d0b3571e271cce3c9f314f3fab80485b706c347cb6e9c710c28cf552c07ec5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/checkpolicy-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm"
+          },
+          "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm"
+          },
+          "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.aarch64.rpm"
+          },
+          "sha256:5437317aa8a5d94a9de9cd15d58399146783b4b96ee52a0a134c09b79933a8b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:5702b6d62b7efb235cf49b6174288053d345236107a43de33d6c80d9784d7140": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-audit-3.0.6-1.fc35.aarch64.rpm"
+          },
+          "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm"
+          },
+          "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-configobj-5.0.6-25.fc35.noarch.rpm"
+          },
+          "sha256:58b6c3272af7450868f9b6ee3e15f05e45104751cacaa4a22345983caaea14da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-filesystem-1.7.0-11.fc35.aarch64.rpm"
+          },
+          "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.aarch64.rpm"
+          },
+          "sha256:5969e69eb5d24f65384e616513a940894f570a0423469dbcdead3d3b3d6c0b7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/h/hwdata-0.355-1.fc35.noarch.rpm"
+          },
+          "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.aarch64.rpm"
+          },
+          "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm"
+          },
+          "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm"
+          },
+          "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:5d3d700fc60b7ec85915692030f7fa121ca83ea74acca62b6dfdbc9f8cd5ae7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdt-1.6.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.aarch64.rpm"
+          },
+          "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm"
+          },
+          "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm"
+          },
+          "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pycparser-2.20-5.fc35.noarch.rpm"
+          },
+          "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.aarch64.rpm"
+          },
+          "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm"
+          },
+          "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:69e19b20bc15ca446f218e1106357f6ee2fbe78fccfe4eb7100a9eafd91cce23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpciaccess-0.16-5.fc35.aarch64.rpm"
+          },
+          "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm"
+          },
+          "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm"
+          },
+          "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm"
+          },
+          "sha256:6c5f9498b18f3634aff99c8c07148876906a35357a86d473ff62f1073059a7aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-core-libs-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm"
+          },
+          "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-en-3.0-15.fc35.noarch.rpm"
+          },
+          "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-GB-0.20140811.1-20.fc35.noarch.rpm"
+          },
+          "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm"
+          },
+          "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efivar-libs-37-17.fc35.aarch64.rpm"
+          },
+          "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm"
+          },
+          "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm"
+          },
+          "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setuptools-57.4.0-1.fc35.noarch.rpm"
+          },
+          "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.aarch64.rpm"
+          },
+          "sha256:717d52dab884a42e0c346dd8d2b6f5bcb80b85703c7a208df04ff96ec4114f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nftables-1.0.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm"
+          },
+          "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm"
+          },
+          "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm"
+          },
+          "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm"
+          },
+          "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:7bc35d9fda6ebfe33a63cf1093a2c64b03da111461fce2b213f4fc5e91519eaa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnftnl-1.2.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm"
+          },
+          "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm"
+          },
+          "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm"
+          },
+          "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.aarch64.rpm"
+          },
+          "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm"
+          },
+          "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm"
+          },
+          "sha256:81b1b84501851960326a165de6e938696a6a69f69bfac3478b26c5e2a24a6c73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXrandr-1.5.2-7.fc35.aarch64.rpm"
+          },
+          "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-idna-3.2-1.fc35.noarch.rpm"
+          },
+          "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.aarch64.rpm"
+          },
+          "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonschema-3.2.0-12.fc35.noarch.rpm"
+          },
+          "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jinja2-3.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm"
+          },
+          "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib-3.0.2-11.fc35.noarch.rpm"
+          },
+          "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dejavu-sans-fonts-2.37-17.fc35.noarch.rpm"
+          },
+          "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.aarch64.rpm"
+          },
+          "sha256:8a93cb5f7a78270157d8bc5272478d64104a7d89dccfea2dd227d8692fc510c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-nft-1.8.7-13.fc35.aarch64.rpm"
+          },
+          "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyserial-3.4-12.fc35.noarch.rpm"
+          },
+          "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm"
+          },
+          "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm"
+          },
+          "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm"
+          },
+          "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm"
+          },
+          "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.aarch64.rpm"
+          },
+          "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm"
+          },
+          "sha256:92165f8506bcde6d8b121033f17441f51c57b163b2d24e591c6d7d667d967f07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXau-1.0.9-7.fc35.aarch64.rpm"
+          },
+          "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.aarch64.rpm"
+          },
+          "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm"
+          },
+          "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:9593a8e47f980af2a61700947cf6da75b409621598029854c05f1a4f5749d1cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libsemanage-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:95f62c37836b177bbaff44da7e94c70bd9badddbd873cc0b470f14c56257eee5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipset-libs-7.15-1.fc35.aarch64.rpm"
+          },
+          "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:9605b7a0fbfb73c13a99ae45476c02cf3a0cde1b7edf137e90f8006863519a83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setools-4.4.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-babel-2.9.1-4.fc35.noarch.rpm"
+          },
+          "sha256:972e63fdf149b8fa4cc48d07c77a5b2a8d630b2a71deee28d78c8eb260df65b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/jansson-2.13.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:97c959173adc41a960200043e95347cb2ef9035dd7eec79d5489b11e3332a23d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-scripts-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm"
+          },
+          "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.aarch64.rpm"
+          },
+          "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm"
+          },
+          "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm"
+          },
+          "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:9da9f25dfdfb817d5ed99288c9bec5a6547dfe388c156e9dd83f10c0a04204ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxcb-1.13.1-8.fc35.aarch64.rpm"
+          },
+          "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm"
+          },
+          "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm"
+          },
+          "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm"
+          },
+          "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:a0bcda38ffb40a7e6d28c88dbbbf9b6f2d77e2614aafb53d69bd24bf111ba46a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXrender-0.9.10-15.fc35.aarch64.rpm"
+          },
+          "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm"
+          },
+          "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm"
+          },
+          "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm"
+          },
+          "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.aarch64.rpm"
+          },
+          "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc35.noarch.rpm"
+          },
+          "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.aarch64.rpm"
+          },
+          "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm"
+          },
+          "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.aarch64.rpm"
+          },
+          "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm"
+          },
+          "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm"
+          },
+          "sha256:aca22d55edba0d7f60f4d6f8f5c064ce64df4561af9c44e592fa842d1b83110c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libX11-1.7.3.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.aarch64.rpm"
+          },
+          "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.aarch64.rpm"
+          },
+          "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:b30f029f856c7ff5a9ef7c71b4f8d0858b96962c5523ee7c7bcc6313b13a3b0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cryptography-3.4.7-5.fc35.aarch64.rpm"
+          },
+          "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm"
+          },
+          "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm"
+          },
+          "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm"
+          },
+          "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.aarch64.rpm"
+          },
+          "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm"
+          },
+          "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.aarch64.rpm"
+          },
+          "sha256:b98735362bb79e3def6794fa863fe09a1c3690c8c7880e83f572c20860ba25ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libselinux-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:baf6082e248e7e84f3cb5ec2695f0dc9afeca615b3f39c60283902ab06d3f564": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cffi-1.14.6-2.fc35.aarch64.rpm"
+          },
+          "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm"
+          },
+          "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.aarch64.rpm"
+          },
+          "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm"
+          },
+          "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm"
+          },
+          "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm"
+          },
+          "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm"
+          },
+          "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm"
+          },
+          "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pysocks-1.7.1-11.fc35.noarch.rpm"
+          },
+          "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cloud-init-20.4-7.fc35.noarch.rpm"
+          },
+          "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.aarch64.rpm"
+          },
+          "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm"
+          },
+          "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.aarch64.rpm"
+          },
+          "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm"
+          },
+          "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/mokutil-0.5.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm"
+          },
+          "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm"
+          },
+          "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch.rpm"
+          },
+          "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm"
+          },
+          "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm"
+          },
+          "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm"
+          },
+          "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm"
+          },
+          "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.aarch64.rpm"
+          },
+          "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm"
+          },
+          "sha256:cd38bc0d85c3664d68bc57e006a9b0d31abec2a71a56e0a5a11a81a673f90a2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/x/xen-licenses-4.15.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:cd892e1d1657846057a26c5abe7cc78d190742b81933a099bbe2c75e766b37d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXinerama-1.1.4-9.fc35.aarch64.rpm"
+          },
+          "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-firewall-1.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm"
+          },
+          "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm"
+          },
+          "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm"
+          },
+          "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm"
+          },
+          "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.aarch64.rpm"
+          },
+          "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-0.20140811.1-20.fc35.noarch.rpm"
+          },
+          "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm"
+          },
+          "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt+crypto-2.1.0-2.fc35.noarch.rpm"
+          },
+          "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm"
+          },
+          "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm"
+          },
+          "sha256:d9101cea75c34b8380bc5474b987316e776cdb52d7247aa10f449e8fb70a4eb2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yajl-2.1.0-17.fc35.aarch64.rpm"
+          },
+          "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm"
+          },
+          "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm"
+          },
+          "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm"
+          },
+          "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm"
+          },
+          "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm"
+          },
+          "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-US-0.20140811.1-20.fc35.noarch.rpm"
+          },
+          "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonpointer-2.0-4.fc35.noarch.rpm"
+          },
+          "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.aarch64.rpm"
+          },
+          "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm"
+          },
+          "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm"
+          },
+          "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/shim-aa64-15.4-5.aarch64.rpm"
+          },
+          "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm"
+          },
+          "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.aarch64.rpm"
+          },
+          "sha256:ee9c63222e5d761bf50ada5b6c5068e7555c08f159489b5da9d4944684426308": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXfixes-6.0.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm"
+          },
+          "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm"
+          },
+          "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm"
+          },
+          "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm"
+          },
+          "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm"
+          },
+          "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-prettytable-0.7.2-27.fc35.noarch.rpm"
+          },
+          "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm"
+          },
+          "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.aarch64.rpm"
+          },
+          "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm"
+          },
+          "sha256:f878dd687438db0e07f2eb571246103ae0e136647242f0bf7f806ddd77e04a91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-1.7.0-11.fc35.aarch64.rpm"
+          },
+          "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.aarch64.rpm"
+          },
+          "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm"
+          },
+          "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm"
+          },
+          "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.aarch64.rpm"
+          },
+          "sha256:fc05e6abb02bcb99462711686ddfc47783c0a5575bdb451a7fce641a3b809e8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.18.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:fccda302546302309788e451ccaa2fb2abba72fa7b4184e82e1ff89830d8e306": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/net-tools-2.0-0.60.20160912git.fc35.aarch64.rpm"
+          },
+          "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:fdb23c2568785740578c8c2aef40f717f37cac51f71a8e2fc27c0ffd83bc7884": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/x/xen-libs-4.15.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:fe1323e767bb5941d49d5b6565750614a2f649d5d34453e5ace10b3012b7a413": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xfsprogs-5.12.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm"
+          },
+          "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm"
+          },
+          "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm"
+          }
+        }
+      }
+    },
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.rpm",
+              "options": {
+                "gpgkeys": [
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+                ],
+                "packages": [
+                  {
+                    "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                    "check_gpg": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "org.osbuild.selinux",
+              "options": {
+                "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+                "labels": {
+                  "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+                }
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.fedora33"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8"
+          }
+        },
+        {
+          "name": "org.osbuild.rpm",
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "packages": [
+              {
+                "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3eecb51a03f9eed59710f6c6cbc5d66aea9bc521940d0b8d73fca835f1402897",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30c4143715cbe6d44c23039777276fe7b900130ea6193d75512f5d4651e52e13",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f878dd687438db0e07f2eb571246103ae0e136647242f0bf7f806ddd77e04a91",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:58b6c3272af7450868f9b6ee3e15f05e45104751cacaa4a22345983caaea14da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:39fd9eb8e77b430637602dc7cfce448e1792ace9cc9041c33f957b70d7b205c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1f81a2122f9b9482a6b41b2bd98ec47a9f06697a4f3d08ed81dfaca7ee7b1c6c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:95f62c37836b177bbaff44da7e94c70bd9badddbd873cc0b470f14c56257eee5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a93cb5f7a78270157d8bc5272478d64104a7d89dccfea2dd227d8692fc510c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:972e63fdf149b8fa4cc48d07c77a5b2a8d630b2a71deee28d78c8eb260df65b0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:92165f8506bcde6d8b121033f17441f51c57b163b2d24e591c6d7d667d967f07",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2db66e2d4cb69b7433e334870a06b167dfbe38ba8c8be5d6eb6d3fe69ac0f769",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ee9c63222e5d761bf50ada5b6c5068e7555c08f159489b5da9d4944684426308",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cd892e1d1657846057a26c5abe7cc78d190742b81933a099bbe2c75e766b37d3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:81b1b84501851960326a165de6e938696a6a69f69bfac3478b26c5e2a24a6c73",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a0bcda38ffb40a7e6d28c88dbbbf9b6f2d77e2614aafb53d69bd24bf111ba46a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d3d700fc60b7ec85915692030f7fa121ca83ea74acca62b6dfdbc9f8cd5ae7e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7bc35d9fda6ebfe33a63cf1093a2c64b03da111461fce2b213f4fc5e91519eaa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:69e19b20bc15ca446f218e1106357f6ee2fbe78fccfe4eb7100a9eafd91cce23",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9da9f25dfdfb817d5ed99288c9bec5a6547dfe388c156e9dd83f10c0a04204ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fccda302546302309788e451ccaa2fb2abba72fa7b4184e82e1ff89830d8e306",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:717d52dab884a42e0c346dd8d2b6f5bcb80b85703c7a208df04ff96ec4114f6f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07fd0548f64b358ffd9ce32e885b7b91dc7e6208171d7efb9874923aead0fa5c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6c5f9498b18f3634aff99c8c07148876906a35357a86d473ff62f1073059a7aa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:97c959173adc41a960200043e95347cb2ef9035dd7eec79d5489b11e3332a23d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5702b6d62b7efb235cf49b6174288053d345236107a43de33d6c80d9784d7140",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:baf6082e248e7e84f3cb5ec2695f0dc9afeca615b3f39c60283902ab06d3f564",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b30f029f856c7ff5a9ef7c71b4f8d0858b96962c5523ee7c7bcc6313b13a3b0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:501d1c9a812d927bc37ec65f11d818fef9f0647d711f132c91c1718124c32dc4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:375b89f3a452a62f3a02ada8971b14e854fa95b0d4cb9efb0449e5f85d6959c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:31e3038cdc752f890970d60653b510eb815e56be7854ba627ef7843b4c760ec9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:469ec3ace1ffa4e3153c772d5ec5a65f8cb6e98d07405134c6b06545796e31c2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9605b7a0fbfb73c13a99ae45476c02cf3a0cde1b7edf137e90f8006863519a83",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:10190a125e7f12c0fb5c138b041c1c3625c43be574b1a42a845217cf2737cd88",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fe1323e767bb5941d49d5b6565750614a2f649d5d34453e5ace10b3012b7a413",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d9101cea75c34b8380bc5474b987316e776cdb52d7247aa10f449e8fb70a4eb2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:02f5457be9eac8a6ae4b19950895850da94f62a9c5e5f390a68a590092096c96",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:50d0b3571e271cce3c9f314f3fab80485b706c347cb6e9c710c28cf552c07ec5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5437317aa8a5d94a9de9cd15d58399146783b4b96ee52a0a134c09b79933a8b0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5969e69eb5d24f65384e616513a940894f570a0423469dbcdead3d3b3d6c0b7f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aca22d55edba0d7f60f4d6f8f5c064ce64df4561af9c44e592fa842d1b83110c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4c728458d61305c022946aa7199e2b462ac4449f04303def895923581b05d8c2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:01c4eedbedec34f5413a98f2dae6a84466270a71aceb647206e84e64b452ed96",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3f7252d59a6cafd37c6ce4851ba6ab13a0594e0a435bce4d8c392485888278a5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b98735362bb79e3def6794fa863fe09a1c3690c8c7880e83f572c20860ba25ba",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9593a8e47f980af2a61700947cf6da75b409621598029854c05f1a4f5749d1cb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:22a906074aaab00a9c1bac318f9d10323566670fc7772c61e196574dfc63ee9b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fc05e6abb02bcb99462711686ddfc47783c0a5575bdb451a7fce641a3b809e8e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:137e82364adba68a95cf5af5369af68318afe9fea740c5deb6cd40f71727db34",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fdb23c2568785740578c8c2aef40f717f37cac51f71a8e2fc27c0ffd83bc7884",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cd38bc0d85c3664d68bc57e006a9b0d31abec2a71a56e0a5a11a81a673f90a2a",
+                "check_gpg": true
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.hostname",
+          "options": {
+            "hostname": "localhost.localdomain"
+          }
+        },
+        {
+          "name": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "redhat": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              },
+              {
+                "uuid": "46BB-8120",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "umask=0077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "uefi": {
+              "vendor": "fedora"
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
+        "options": {
+          "format": "qcow2",
+          "filename": "disk.qcow2",
+          "size": 2147483648,
+          "ptuuid": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
+          "pttype": "gpt",
+          "partitions": [
+            {
+              "start": 2048,
+              "size": 972800,
+              "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+              "uuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
+              "filesystem": {
+                "type": "vfat",
+                "uuid": "46BB-8120",
+                "label": "EFI-SYSTEM",
+                "mountpoint": "/boot/efi"
+              }
+            },
+            {
+              "start": 976896,
+              "uuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build-packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm",
+        "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm",
+        "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm",
+        "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
+        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
+        "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm",
+        "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm",
+        "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm",
+        "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm",
+        "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "12.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.aarch64.rpm",
+        "checksum": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
+        "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm",
+        "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm",
+        "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm",
+        "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
+        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm",
+        "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
+        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+        "check_gpg": true
+      },
+      {
+        "name": "liburing",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm",
+        "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm",
+        "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm",
+        "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm",
+        "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
+        "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs78",
+        "epoch": 0,
+        "version": "78.15.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm",
+        "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm",
+        "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm",
+        "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm",
+        "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm",
+        "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm",
+        "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm",
+        "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.70.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.4.36",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm",
+        "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+        "check_gpg": true
+      },
+      {
+        "name": "qemu-img",
+        "epoch": 2,
+        "version": "6.1.0",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm",
+        "checksum": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm",
+        "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
+    "packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm",
+        "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65",
+        "check_gpg": true
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75",
+        "check_gpg": true
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chrony-4.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3eecb51a03f9eed59710f6c6cbc5d66aea9bc521940d0b8d73fca835f1402897",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "20.4",
+        "release": "7.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cloud-init-20.4-7.fc35.noarch.rpm",
+        "checksum": "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm",
+        "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm",
+        "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+        "check_gpg": true
+      },
+      {
+        "name": "dejavu-sans-fonts",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "17.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dejavu-sans-fonts-2.37-17.fc35.noarch.rpm",
+        "checksum": "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
+        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.aarch64.rpm",
+        "checksum": "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm",
+        "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
+        "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efi-filesystem-5-4.fc35.noarch.rpm",
+        "checksum": "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efibootmgr-16-11.fc35.aarch64.rpm",
+        "checksum": "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "37",
+        "release": "17.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efivar-libs-37-17.fc35.aarch64.rpm",
+        "checksum": "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm",
+        "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm",
+        "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/firewalld-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/firewalld-filesystem-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65",
+        "check_gpg": true
+      },
+      {
+        "name": "fonts-filesystem",
+        "epoch": 1,
+        "version": "2.0.5",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fonts-filesystem-2.0.5-6.fc35.noarch.rpm",
+        "checksum": "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.70.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gobject-introspection-1.70.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30c4143715cbe6d44c23039777276fe7b900130ea6193d75512f5d4651e52e13",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm",
+        "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.aarch64.rpm",
+        "checksum": "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm",
+        "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.aarch64.rpm",
+        "checksum": "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell",
+        "epoch": 0,
+        "version": "1.7.0",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-1.7.0-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f878dd687438db0e07f2eb571246103ae0e136647242f0bf7f806ddd77e04a91",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-en",
+        "epoch": 0,
+        "version": "0.20140811.1",
+        "release": "20.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-0.20140811.1-20.fc35.noarch.rpm",
+        "checksum": "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-en-GB",
+        "epoch": 0,
+        "version": "0.20140811.1",
+        "release": "20.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-GB-0.20140811.1-20.fc35.noarch.rpm",
+        "checksum": "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-en-US",
+        "epoch": 0,
+        "version": "0.20140811.1",
+        "release": "20.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-US-0.20140811.1-20.fc35.noarch.rpm",
+        "checksum": "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-filesystem",
+        "epoch": 0,
+        "version": "1.7.0",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-filesystem-1.7.0-11.fc35.aarch64.rpm",
+        "checksum": "sha256:58b6c3272af7450868f9b6ee3e15f05e45104751cacaa4a22345983caaea14da",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "49",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/inih-49-4.fc35.aarch64.rpm",
+        "checksum": "sha256:39fd9eb8e77b430637602dc7cfce448e1792ace9cc9041c33f957b70d7b205c5",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm",
+        "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute-tc",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipset-7.15-1.fc35.aarch64.rpm",
+        "checksum": "sha256:1f81a2122f9b9482a6b41b2bd98ec47a9f06697a4f3d08ed81dfaca7ee7b1c6c",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipset-libs-7.15-1.fc35.aarch64.rpm",
+        "checksum": "sha256:95f62c37836b177bbaff44da7e94c70bd9badddbd873cc0b470f14c56257eee5",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-nft-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:8a93cb5f7a78270157d8bc5272478d64104a7d89dccfea2dd227d8692fc510c3",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20210722",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/jansson-2.13.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:972e63fdf149b8fa4cc48d07c77a5b2a8d630b2a71deee28d78c8eb260df65b0",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm",
+        "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "15.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-en-3.0-15.fc35.noarch.rpm",
+        "checksum": "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-font-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "15.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-font-en-3.0-15.fc35.noarch.rpm",
+        "checksum": "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "15.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-en-3.0-15.fc35.noarch.rpm",
+        "checksum": "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a",
+        "check_gpg": true
+      },
+      {
+        "name": "libXau",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXau-1.0.9-7.fc35.aarch64.rpm",
+        "checksum": "sha256:92165f8506bcde6d8b121033f17441f51c57b163b2d24e591c6d7d667d967f07",
+        "check_gpg": true
+      },
+      {
+        "name": "libXext",
+        "epoch": 0,
+        "version": "1.3.4",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXext-1.3.4-7.fc35.aarch64.rpm",
+        "checksum": "sha256:2db66e2d4cb69b7433e334870a06b167dfbe38ba8c8be5d6eb6d3fe69ac0f769",
+        "check_gpg": true
+      },
+      {
+        "name": "libXfixes",
+        "epoch": 0,
+        "version": "6.0.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXfixes-6.0.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:ee9c63222e5d761bf50ada5b6c5068e7555c08f159489b5da9d4944684426308",
+        "check_gpg": true
+      },
+      {
+        "name": "libXinerama",
+        "epoch": 0,
+        "version": "1.1.4",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXinerama-1.1.4-9.fc35.aarch64.rpm",
+        "checksum": "sha256:cd892e1d1657846057a26c5abe7cc78d190742b81933a099bbe2c75e766b37d3",
+        "check_gpg": true
+      },
+      {
+        "name": "libXrandr",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXrandr-1.5.2-7.fc35.aarch64.rpm",
+        "checksum": "sha256:81b1b84501851960326a165de6e938696a6a69f69bfac3478b26c5e2a24a6c73",
+        "check_gpg": true
+      },
+      {
+        "name": "libXrender",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "15.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXrender-0.9.10-15.fc35.aarch64.rpm",
+        "checksum": "sha256:a0bcda38ffb40a7e6d28c88dbbbf9b6f2d77e2614aafb53d69bd24bf111ba46a",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
+        "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm",
+        "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm",
+        "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.aarch64.rpm",
+        "checksum": "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm",
+        "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.aarch64.rpm",
+        "checksum": "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "40.20210910cvs.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.aarch64.rpm",
+        "checksum": "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
+        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdt",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdt-1.6.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:5d3d700fc60b7ec85915692030f7fa121ca83ea74acca62b6dfdbc9f8cd5ae7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm",
+        "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.aarch64.rpm",
+        "checksum": "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.5.4",
+        "release": "2.rc3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.aarch64.rpm",
+        "checksum": "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnftnl-1.2.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7bc35d9fda6ebfe33a63cf1093a2c64b03da111461fce2b213f4fc5e91519eaa",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpciaccess",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpciaccess-0.16-5.fc35.aarch64.rpm",
+        "checksum": "sha256:69e19b20bc15ca446f218e1106357f6ee2fbe78fccfe4eb7100a9eafd91cce23",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.aarch64.rpm",
+        "checksum": "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
+        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+        "check_gpg": true
+      },
+      {
+        "name": "liburing",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm",
+        "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.aarch64.rpm",
+        "checksum": "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm",
+        "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcb",
+        "epoch": 0,
+        "version": "1.13.1",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxcb-1.13.1-8.fc35.aarch64.rpm",
+        "checksum": "sha256:9da9f25dfdfb817d5ed99288c9bec5a6547dfe388c156e9dd83f10c0a04204ae",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm",
+        "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm",
+        "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.aarch64.rpm",
+        "checksum": "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.aarch64.rpm",
+        "checksum": "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
+        "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs78",
+        "epoch": 0,
+        "version": "78.15.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+        "check_gpg": true
+      },
+      {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.60.20160912git.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/net-tools-2.0-0.60.20160912git.fc35.aarch64.rpm",
+        "checksum": "sha256:fccda302546302309788e451ccaa2fb2abba72fa7b4184e82e1ff89830d8e306",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nftables-1.0.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:717d52dab884a42e0c346dd8d2b6f5bcb80b85703c7a208df04ff96ec4114f6f",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm",
+        "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm",
+        "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm",
+        "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/parted-3.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.aarch64.rpm",
+        "checksum": "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm",
+        "checksum": "sha256:07fd0548f64b358ffd9ce32e885b7b91dc7e6208171d7efb9874923aead0fa5c",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-core-libs-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm",
+        "checksum": "sha256:6c5f9498b18f3634aff99c8c07148876906a35357a86d473ff62f1073059a7aa",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-scripts-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm",
+        "checksum": "sha256:97c959173adc41a960200043e95347cb2ef9035dd7eec79d5489b11e3332a23d",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-attrs",
+        "epoch": 0,
+        "version": "21.2.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-attrs-21.2.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-audit-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5702b6d62b7efb235cf49b6174288053d345236107a43de33d6c80d9784d7140",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-babel",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-babel-2.9.1-4.fc35.noarch.rpm",
+        "checksum": "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cffi",
+        "epoch": 0,
+        "version": "1.14.6",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cffi-1.14.6-2.fc35.aarch64.rpm",
+        "checksum": "sha256:baf6082e248e7e84f3cb5ec2695f0dc9afeca615b3f39c60283902ab06d3f564",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-charset-normalizer",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-charset-normalizer-2.0.4-1.fc35.noarch.rpm",
+        "checksum": "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-configobj",
+        "epoch": 0,
+        "version": "5.0.6",
+        "release": "25.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-configobj-5.0.6-25.fc35.noarch.rpm",
+        "checksum": "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cryptography",
+        "epoch": 0,
+        "version": "3.4.7",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cryptography-3.4.7-5.fc35.aarch64.rpm",
+        "checksum": "sha256:b30f029f856c7ff5a9ef7c71b4f8d0858b96962c5523ee7c7bcc6313b13a3b0c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "7.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm",
+        "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.aarch64.rpm",
+        "checksum": "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-firewall-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-gobject-base-3.42.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:501d1c9a812d927bc37ec65f11d818fef9f0647d711f132c91c1718124c32dc4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-idna-3.2-1.fc35.noarch.rpm",
+        "checksum": "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jinja2",
+        "epoch": 0,
+        "version": "3.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jinja2-3.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpointer",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonpointer-2.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonschema",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonschema-3.2.0-12.fc35.noarch.rpm",
+        "checksum": "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt+crypto",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt+crypto-2.1.0-2.fc35.noarch.rpm",
+        "checksum": "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt-2.1.0-2.fc35.noarch.rpm",
+        "checksum": "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-markupsafe-2.0.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:375b89f3a452a62f3a02ada8971b14e854fa95b0d4cb9efb0449e5f85d6959c6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-nftables-1.0.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:31e3038cdc752f890970d60653b510eb815e56be7854ba627ef7843b4c760ec9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib+signedtoken",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "11.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch.rpm",
+        "checksum": "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "11.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib-3.0.2-11.fc35.noarch.rpm",
+        "checksum": "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ply",
+        "epoch": 0,
+        "version": "3.11",
+        "release": "13.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-ply-3.11-13.fc35.noarch.rpm",
+        "checksum": "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "27.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-prettytable-0.7.2-27.fc35.noarch.rpm",
+        "checksum": "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pycparser",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pycparser-2.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyserial",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyserial-3.4-12.fc35.noarch.rpm",
+        "checksum": "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "11.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pysocks-1.7.1-11.fc35.noarch.rpm",
+        "checksum": "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyyaml-5.4.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:469ec3ace1ffa4e3153c772d5ec5a65f8cb6e98d07405134c6b06545796e31c2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.4.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setools-4.4.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9605b7a0fbfb73c13a99ae45476c02cf3a0cde1b7edf137e90f8006863519a83",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setuptools-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "30.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm",
+        "checksum": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm",
+        "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.4",
+        "release": "5",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/shim-aa64-15.4-5.aarch64.rpm",
+        "checksum": "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280",
+        "check_gpg": true
+      },
+      {
+        "name": "spice-vdagent",
+        "epoch": 0,
+        "version": "0.21.0",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/spice-vdagent-0.21.0-5.fc35.aarch64.rpm",
+        "checksum": "sha256:10190a125e7f12c0fb5c138b041c1c3625c43be574b1a42a845217cf2737cd88",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm",
+        "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.12.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xfsprogs-5.12.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:fe1323e767bb5941d49d5b6565750614a2f649d5d34453e5ace10b3012b7a413",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+        "check_gpg": true
+      },
+      {
+        "name": "yajl",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "17.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yajl-2.1.0-17.fc35.aarch64.rpm",
+        "checksum": "sha256:d9101cea75c34b8380bc5474b987316e776cdb52d7247aa10f449e8fb70a4eb2",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm",
+        "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.aarch64.rpm",
+        "checksum": "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f",
+        "check_gpg": true
+      },
+      {
+        "name": "alsa-lib",
+        "epoch": 0,
+        "version": "1.2.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/a/alsa-lib-1.2.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:02f5457be9eac8a6ae4b19950895850da94f62a9c5e5f390a68a590092096c96",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/checkpolicy-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:50d0b3571e271cce3c9f314f3fab80485b706c347cb6e9c710c28cf552c07ec5",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.70.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-langpack-en",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:5437317aa8a5d94a9de9cd15d58399146783b4b96ee52a0a134c09b79933a8b0",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+        "check_gpg": true
+      },
+      {
+        "name": "hwdata",
+        "epoch": 0,
+        "version": "0.355",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/h/hwdata-0.355-1.fc35.noarch.rpm",
+        "checksum": "sha256:5969e69eb5d24f65384e616513a940894f570a0423469dbcdead3d3b3d6c0b7f",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/less-590-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97",
+        "check_gpg": true
+      },
+      {
+        "name": "libX11",
+        "epoch": 0,
+        "version": "1.7.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libX11-1.7.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:aca22d55edba0d7f60f4d6f8f5c064ce64df4561af9c44e592fa842d1b83110c",
+        "check_gpg": true
+      },
+      {
+        "name": "libX11-common",
+        "epoch": 0,
+        "version": "1.7.3.1",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libX11-common-1.7.3.1-1.fc35.noarch.rpm",
+        "checksum": "sha256:4c728458d61305c022946aa7199e2b462ac4449f04303def895923581b05d8c2",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-python3-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:01c4eedbedec34f5413a98f2dae6a84466270a71aceb647206e84e64b452ed96",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libdrm",
+        "epoch": 0,
+        "version": "2.4.109",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libdrm-2.4.109-1.fc35.aarch64.rpm",
+        "checksum": "sha256:3f7252d59a6cafd37c6ce4851ba6ab13a0594e0a435bce4d8c392485888278a5",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-atm-libs",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.aarch64.rpm",
+        "checksum": "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.5.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/mokutil-0.5.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.4.36",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm",
+        "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpatch",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "18.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-jsonpatch-1.21-18.fc35.noarch.rpm",
+        "checksum": "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b98735362bb79e3def6794fa863fe09a1c3690c8c7880e83f572c20860ba25ba",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9593a8e47f980af2a61700947cf6da75b409621598029854c05f1a4f5749d1cb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-policycoreutils-3.3-1.fc35.noarch.rpm",
+        "checksum": "sha256:22a906074aaab00a9c1bac318f9d10323566670fc7772c61e196574dfc63ee9b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyrsistent",
+        "epoch": 0,
+        "version": "0.18.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.18.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:fc05e6abb02bcb99462711686ddfc47783c0a5575bdb451a7fce641a3b809e8e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pytz",
+        "epoch": 0,
+        "version": "2021.3",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc35.noarch.rpm",
+        "checksum": "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.27.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-requests-2.27.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.7",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.26.7-2.fc35.noarch.rpm",
+        "checksum": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
+        "check_gpg": true
+      },
+      {
+        "name": "qemu-guest-agent",
+        "epoch": 2,
+        "version": "6.1.0",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-guest-agent-6.1.0-10.fc35.aarch64.rpm",
+        "checksum": "sha256:137e82364adba68a95cf5af5369af68318afe9fea740c5deb6cd40f71727db34",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm",
+        "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm",
+        "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm",
+        "checksum": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f",
+        "check_gpg": true
+      },
+      {
+        "name": "xen-libs",
+        "epoch": 0,
+        "version": "4.15.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/x/xen-libs-4.15.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:fdb23c2568785740578c8c2aef40f717f37cac51f71a8e2fc27c0ffd83bc7884",
+        "check_gpg": true
+      },
+      {
+        "name": "xen-licenses",
+        "epoch": 0,
+        "version": "4.15.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/x/xen-licenses-4.15.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:cd38bc0d85c3664d68bc57e006a9b0d31abec2a71a56e0a5a11a81a673f90a2a",
+        "check_gpg": true
+      }
+    ]
+  },
+  "image-info": {
+    "/etc/resolv.conf": [],
+    "boot-environment": {
+      "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+    },
+    "bootloader": "unknown",
+    "bootmenu": [
+      {
+        "grub_arg": "--unrestricted",
+        "grub_class": "fedora",
+        "grub_users": "$grub_users",
+        "initrd": "/boot/initramfs-5.15.13-200.fc35.aarch64.img",
+        "linux": "/boot/vmlinuz-5.15.13-200.fc35.aarch64",
+        "options": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8",
+        "title": "Fedora Linux (5.15.13-200.fc35.aarch64) 35 (Thirty Five)",
+        "version": "5.15.13-200.fc35.aarch64"
+      }
+    ],
+    "chrony": {
+      "leapsectz": [
+        "right/UTC"
+      ],
+      "pool": [
+        "2.fedora.pool.ntp.org iburst"
+      ]
+    },
+    "cloud-init": {
+      "/etc/cloud": {
+        "cloud.cfg": {
+          "cloud_config_modules": [
+            "ssh-import-id",
+            "locale",
+            "set-passwords",
+            "spacewalk",
+            "yum-add-repo",
+            "ntp",
+            "timezone",
+            "disable-ec2-metadata",
+            "runcmd"
+          ],
+          "cloud_final_modules": [
+            "package-update-upgrade-install",
+            "puppet",
+            "chef",
+            "mcollective",
+            "salt-minion",
+            "reset_rmc",
+            "refresh_rmc_and_interface",
+            "rightscale_userdata",
+            "scripts-vendor",
+            "scripts-per-once",
+            "scripts-per-boot",
+            "scripts-per-instance",
+            "scripts-user",
+            "ssh-authkey-fingerprints",
+            "keys-to-console",
+            "phone-home",
+            "final-message",
+            "power-state-change"
+          ],
+          "cloud_init_modules": [
+            "migrator",
+            "seed_random",
+            "bootcmd",
+            "write-files",
+            "growpart",
+            "resizefs",
+            "disk_setup",
+            "mounts",
+            "set_hostname",
+            "update_hostname",
+            "update_etc_hosts",
+            "ca-certs",
+            "rsyslog",
+            "users-groups",
+            "ssh"
+          ],
+          "disable_root": true,
+          "mount_default_fields": [
+            null,
+            null,
+            "auto",
+            "defaults,nofail",
+            "0",
+            "2"
+          ],
+          "preserve_hostname": false,
+          "resize_rootfs_tmp": "/dev",
+          "ssh_pwauth": 0,
+          "system_info": {
+            "default_user": {
+              "gecos": "fedora Cloud User",
+              "groups": [
+                "wheel",
+                "adm",
+                "systemd-journal"
+              ],
+              "lock_passwd": true,
+              "name": "fedora",
+              "shell": "/bin/bash",
+              "sudo": [
+                "ALL=(ALL) NOPASSWD:ALL"
+              ]
+            },
+            "distro": "fedora",
+            "paths": {
+              "cloud_dir": "/var/lib/cloud/",
+              "templates_dir": "/etc/cloud/templates/"
+            },
+            "ssh_svcname": "sshd"
+          },
+          "users": [
+            "default"
+          ]
+        }
+      },
+      "/etc/cloud/cloud.cfg.d": {
+        "05_logging.cfg": {
+          "_log": [
+            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
+            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
+          ],
+          "log_cfgs": [
+            [
+              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
+            ]
+          ],
+          "output": {
+            "all": "| tee -a /var/log/cloud-init-output.log"
+          }
+        }
+      }
+    },
+    "default-target": "graphical.target",
+    "dracut": {
+      "/usr/lib/dracut/dracut.conf.d": {
+        "01-dist.conf": {
+          "dbus": "/usr/share/dbus-1",
+          "dbusconfdir": "/etc/dbus-1",
+          "dbusinterfaces": "/usr/share/dbus-1/interfaces",
+          "dbusinterfacesconfdir": "/etc/dbus-1/interfaces",
+          "dbusservices": "/usr/share/dbus-1/services",
+          "dbusservicesconfdir": "/etc/dbus-1/services",
+          "dbussession": "/usr/share/dbus-1/session.d",
+          "dbussessionconfdir": "/etc/dbus-1/session.d",
+          "dbussystem": "confdir/etc/dbus-1/system.d",
+          "dbussystemservices": "/usr/share/dbus-1/system-services",
+          "dbussystemservicesconfdir": "/etc/dbus-1/system-services",
+          "early_microcode": "yes",
+          "environment": "/usr/lib/environment.d",
+          "environmentconfdir": "/etc/environment.d",
+          "hostonly": "yes",
+          "hostonly_cmdline": "no",
+          "i18n_default_font": "eurlatgr",
+          "i18n_install_all": "yes",
+          "i18n_vars": "/etc/sysconfig/keyboard:KEYTABLE-KEYMAP /etc/sysconfig/i18n:SYSFONT-FONT,FONTACM-FONT_MAP,FONT_UNIMAP",
+          "install_optional_items": " vi /etc/virc ps grep cat rm ",
+          "prefix": "/",
+          "reproducible": "yes",
+          "stdloglvl": "3",
+          "sysctlconfdir": "/etc/sysctl.d",
+          "sysctld": "/usr/lib/sysctl.d",
+          "sysloglvl": "5",
+          "systemdcatalog": "/usr/lib/systemd/catalog",
+          "systemdntpunits": "/usr/lib/systemd/ntp-units.d",
+          "systemdntpunitsconfdir": "/etc/systemd/ntp-units.d",
+          "systemdportable": "/usr/lib/systemd/portable",
+          "systemdportableconfdir": "/etc/systemd/portable",
+          "systemdsystemconfdir": "/etc/systemd/system",
+          "systemdsystemunitdir": "/usr/lib/systemd/system",
+          "systemduser": "/usr/lib/systemd/user",
+          "systemduserconfdir": "/etc/systemd/user",
+          "systemdutilconfdir": "/etc/systemd",
+          "systemdutildir": "/usr/lib/systemd",
+          "sysusers": "/usr/lib/sysusers.d",
+          "sysusersconfdir": "/etc/sysusers.d",
+          "udevdir": "/usr/lib/udev"
+        },
+        "02-generic-image.conf": {
+          "hostonly": "no"
+        }
+      }
+    },
+    "firewall-enabled": [
+      "ssh",
+      "mdns",
+      "dhcpv6-client"
+    ],
+    "fstab": [
+      [
+        "UUID=46BB-8120",
+        "/boot/efi",
+        "vfat",
+        "umask=0077,shortname=winnt",
+        "0",
+        "2"
+      ],
+      [
+        "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+        "/",
+        "ext4",
+        "defaults",
+        "1",
+        "1"
+      ]
+    ],
+    "groups": [
+      "adm:x:4:",
+      "audio:x:63:",
+      "bin:x:1:",
+      "cdrom:x:11:",
+      "chrony:x:993:",
+      "daemon:x:2:",
+      "dbus:x:81:",
+      "dialout:x:18:",
+      "disk:x:6:",
+      "floppy:x:19:",
+      "ftp:x:50:",
+      "games:x:20:",
+      "input:x:104:",
+      "kmem:x:9:",
+      "kvm:x:36:",
+      "lock:x:54:",
+      "lp:x:7:",
+      "mail:x:12:",
+      "man:x:15:",
+      "mem:x:8:",
+      "nobody:x:65534:",
+      "polkitd:x:994:",
+      "redhat:x:1000:",
+      "render:x:105:",
+      "root:x:0:",
+      "sgx:x:106:",
+      "ssh_keys:x:996:",
+      "sshd:x:74:",
+      "sys:x:3:",
+      "systemd-coredump:x:997:",
+      "systemd-journal:x:190:",
+      "systemd-network:x:192:",
+      "systemd-oom:x:999:",
+      "systemd-resolve:x:193:",
+      "systemd-timesync:x:998:",
+      "tape:x:33:",
+      "tss:x:59:",
+      "tty:x:5:",
+      "unbound:x:995:",
+      "users:x:100:",
+      "utempter:x:35:",
+      "utmp:x:22:",
+      "video:x:39:",
+      "wheel:x:10:"
+    ],
+    "hostname": "localhost.localdomain",
+    "hosts": [
+      "127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4",
+      "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
+    ],
+    "image-format": {
+      "compat": "1.1",
+      "type": "qcow2"
+    },
+    "locale": {
+      "LANG": "en_US"
+    },
+    "machine-id": "",
+    "modprobe": {
+      "/usr/lib/modprobe.d": {
+        "dist-blacklist.conf": {
+          "blacklist": [
+            "chsc_sch"
+          ]
+        }
+      }
+    },
+    "os-release": {
+      "ANSI_COLOR": "0;38;2;60;110;180",
+      "BUG_REPORT_URL": "https://bugzilla.redhat.com/",
+      "CPE_NAME": "cpe:/o:fedoraproject:fedora:35",
+      "DOCUMENTATION_URL": "https://docs.fedoraproject.org/en-US/fedora/f35/system-administrators-guide/",
+      "HOME_URL": "https://fedoraproject.org/",
+      "ID": "fedora",
+      "LOGO": "fedora-logo-icon",
+      "NAME": "Fedora Linux",
+      "PLATFORM_ID": "platform:f35",
+      "PRETTY_NAME": "Fedora Linux 35 (Thirty Five)",
+      "PRIVACY_POLICY_URL": "https://fedoraproject.org/wiki/Legal:PrivacyPolicy",
+      "REDHAT_BUGZILLA_PRODUCT": "Fedora",
+      "REDHAT_BUGZILLA_PRODUCT_VERSION": "35",
+      "REDHAT_SUPPORT_PRODUCT": "Fedora",
+      "REDHAT_SUPPORT_PRODUCT_VERSION": "35",
+      "SUPPORT_URL": "https://ask.fedoraproject.org/",
+      "VERSION": "35 (Thirty Five)",
+      "VERSION_CODENAME": "",
+      "VERSION_ID": "35"
+    },
+    "packages": [
+      "NetworkManager-1.32.12-2.fc35.aarch64",
+      "NetworkManager-libnm-1.32.12-2.fc35.aarch64",
+      "acl-2.3.1-2.fc35.aarch64",
+      "alsa-lib-1.2.6.1-3.fc35.aarch64",
+      "alternatives-1.19-1.fc35.aarch64",
+      "audit-3.0.6-1.fc35.aarch64",
+      "audit-libs-3.0.6-1.fc35.aarch64",
+      "basesystem-11-12.fc35.noarch",
+      "bash-5.1.8-2.fc35.aarch64",
+      "bzip2-libs-1.0.8-9.fc35.aarch64",
+      "c-ares-1.17.2-1.fc35.aarch64",
+      "ca-certificates-2021.2.52-1.0.fc35.noarch",
+      "checkpolicy-3.3-1.fc35.aarch64",
+      "chkconfig-1.19-1.fc35.aarch64",
+      "chrony-4.1-3.fc35.aarch64",
+      "cloud-init-20.4-7.fc35.noarch",
+      "coreutils-8.32-31.fc35.aarch64",
+      "coreutils-common-8.32-31.fc35.aarch64",
+      "cpio-2.13-11.fc35.aarch64",
+      "cracklib-2.9.6-27.fc35.aarch64",
+      "cracklib-dicts-2.9.6-27.fc35.aarch64",
+      "crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch",
+      "crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch",
+      "cryptsetup-libs-2.4.2-1.fc35.aarch64",
+      "curl-7.79.1-1.fc35.aarch64",
+      "cyrus-sasl-lib-2.1.27-13.fc35.aarch64",
+      "dbus-1.12.20-5.fc35.aarch64",
+      "dbus-broker-29-4.fc35.aarch64",
+      "dbus-common-1.12.20-5.fc35.noarch",
+      "dbus-libs-1.12.20-5.fc35.aarch64",
+      "dejavu-sans-fonts-2.37-17.fc35.noarch",
+      "deltarpm-3.6.2-10.fc35.aarch64",
+      "device-mapper-1.02.175-6.fc35.aarch64",
+      "device-mapper-libs-1.02.175-6.fc35.aarch64",
+      "dhcp-client-4.4.2-16.b1.fc35.aarch64",
+      "dhcp-common-4.4.2-16.b1.fc35.noarch",
+      "diffutils-3.8-1.fc35.aarch64",
+      "dnf-4.9.0-1.fc35.noarch",
+      "dnf-data-4.9.0-1.fc35.noarch",
+      "dnf-plugins-core-4.0.24-1.fc35.noarch",
+      "dracut-055-6.fc35.aarch64",
+      "dracut-config-generic-055-6.fc35.aarch64",
+      "e2fsprogs-1.46.3-1.fc35.aarch64",
+      "e2fsprogs-libs-1.46.3-1.fc35.aarch64",
+      "efi-filesystem-5-4.fc35.noarch",
+      "efibootmgr-16-11.fc35.aarch64",
+      "efivar-libs-37-17.fc35.aarch64",
+      "elfutils-debuginfod-client-0.186-1.fc35.aarch64",
+      "elfutils-default-yama-scope-0.186-1.fc35.noarch",
+      "elfutils-libelf-0.186-1.fc35.aarch64",
+      "elfutils-libs-0.186-1.fc35.aarch64",
+      "expat-2.4.1-2.fc35.aarch64",
+      "fedora-gpg-keys-35-1.noarch",
+      "fedora-release-35-36.noarch",
+      "fedora-release-common-35-36.noarch",
+      "fedora-release-identity-basic-35-36.noarch",
+      "fedora-repos-35-1.noarch",
+      "fedora-repos-modular-35-1.noarch",
+      "file-5.40-9.fc35.aarch64",
+      "file-libs-5.40-9.fc35.aarch64",
+      "filesystem-3.14-7.fc35.aarch64",
+      "findutils-4.8.0-4.fc35.aarch64",
+      "firewalld-1.0.1-2.fc35.noarch",
+      "firewalld-filesystem-1.0.1-2.fc35.noarch",
+      "fonts-filesystem-2.0.5-6.fc35.noarch",
+      "fuse-libs-2.9.9-13.fc35.aarch64",
+      "gawk-5.1.0-4.fc35.aarch64",
+      "gawk-all-langpacks-5.1.0-4.fc35.aarch64",
+      "gdbm-libs-1.22-1.fc35.aarch64",
+      "gettext-0.21-8.fc35.aarch64",
+      "gettext-libs-0.21-8.fc35.aarch64",
+      "glib2-2.70.2-1.fc35.aarch64",
+      "glibc-2.34-11.fc35.aarch64",
+      "glibc-common-2.34-11.fc35.aarch64",
+      "glibc-gconv-extra-2.34-11.fc35.aarch64",
+      "glibc-langpack-en-2.34-11.fc35.aarch64",
+      "gmp-6.2.0-7.fc35.aarch64",
+      "gnupg2-2.3.4-1.fc35.aarch64",
+      "gnupg2-smime-2.3.4-1.fc35.aarch64",
+      "gnutls-3.7.2-2.fc35.aarch64",
+      "gobject-introspection-1.70.0-1.fc35.aarch64",
+      "gpg-pubkey-9867c58f-601c49ca",
+      "gpgme-1.15.1-6.fc35.aarch64",
+      "grep-3.6-4.fc35.aarch64",
+      "groff-base-1.22.4-8.fc35.aarch64",
+      "grub2-common-2.06-10.fc35.noarch",
+      "grub2-efi-aa64-2.06-10.fc35.aarch64",
+      "grub2-tools-2.06-10.fc35.aarch64",
+      "grub2-tools-minimal-2.06-10.fc35.aarch64",
+      "grubby-8.40-55.fc35.aarch64",
+      "gzip-1.10-5.fc35.aarch64",
+      "hostname-3.23-5.fc35.aarch64",
+      "hunspell-1.7.0-11.fc35.aarch64",
+      "hunspell-en-0.20140811.1-20.fc35.noarch",
+      "hunspell-en-GB-0.20140811.1-20.fc35.noarch",
+      "hunspell-en-US-0.20140811.1-20.fc35.noarch",
+      "hunspell-filesystem-1.7.0-11.fc35.aarch64",
+      "hwdata-0.355-1.fc35.noarch",
+      "ima-evm-utils-1.3.2-3.fc35.aarch64",
+      "inih-49-4.fc35.aarch64",
+      "initscripts-10.11-1.fc35.aarch64",
+      "initscripts-service-10.11-1.fc35.noarch",
+      "ipcalc-1.0.1-2.fc35.aarch64",
+      "iproute-5.13.0-2.fc35.aarch64",
+      "iproute-tc-5.13.0-2.fc35.aarch64",
+      "ipset-7.15-1.fc35.aarch64",
+      "ipset-libs-7.15-1.fc35.aarch64",
+      "iptables-legacy-libs-1.8.7-13.fc35.aarch64",
+      "iptables-libs-1.8.7-13.fc35.aarch64",
+      "iptables-nft-1.8.7-13.fc35.aarch64",
+      "iputils-20210722-1.fc35.aarch64",
+      "jansson-2.13.1-3.fc35.aarch64",
+      "json-c-0.15-2.fc35.aarch64",
+      "kbd-2.4.0-8.fc35.aarch64",
+      "kbd-misc-2.4.0-8.fc35.noarch",
+      "kernel-5.15.13-200.fc35.aarch64",
+      "kernel-core-5.15.13-200.fc35.aarch64",
+      "kernel-modules-5.15.13-200.fc35.aarch64",
+      "keyutils-libs-1.6.1-3.fc35.aarch64",
+      "kmod-29-4.fc35.aarch64",
+      "kmod-libs-29-4.fc35.aarch64",
+      "kpartx-0.8.6-5.fc35.aarch64",
+      "krb5-libs-1.19.2-2.fc35.aarch64",
+      "langpacks-core-en-3.0-15.fc35.noarch",
+      "langpacks-core-font-en-3.0-15.fc35.noarch",
+      "langpacks-en-3.0-15.fc35.noarch",
+      "less-590-2.fc35.aarch64",
+      "libX11-1.7.3.1-1.fc35.aarch64",
+      "libX11-common-1.7.3.1-1.fc35.noarch",
+      "libXau-1.0.9-7.fc35.aarch64",
+      "libXext-1.3.4-7.fc35.aarch64",
+      "libXfixes-6.0.0-2.fc35.aarch64",
+      "libXinerama-1.1.4-9.fc35.aarch64",
+      "libXrandr-1.5.2-7.fc35.aarch64",
+      "libXrender-0.9.10-15.fc35.aarch64",
+      "libacl-2.3.1-2.fc35.aarch64",
+      "libarchive-3.5.2-2.fc35.aarch64",
+      "libargon2-20171227-7.fc35.aarch64",
+      "libassuan-2.5.5-3.fc35.aarch64",
+      "libattr-2.5.1-3.fc35.aarch64",
+      "libbasicobjects-0.1.1-48.fc35.aarch64",
+      "libblkid-2.37.2-1.fc35.aarch64",
+      "libbrotli-1.0.9-6.fc35.aarch64",
+      "libcap-2.48-3.fc35.aarch64",
+      "libcap-ng-0.8.2-8.fc35.aarch64",
+      "libcap-ng-python3-0.8.2-8.fc35.aarch64",
+      "libcbor-0.7.0-4.fc35.aarch64",
+      "libcollection-0.7.0-48.fc35.aarch64",
+      "libcom_err-1.46.3-1.fc35.aarch64",
+      "libcomps-0.1.18-1.fc35.aarch64",
+      "libcurl-7.79.1-1.fc35.aarch64",
+      "libdb-5.3.28-50.fc35.aarch64",
+      "libdhash-0.5.0-48.fc35.aarch64",
+      "libdnf-0.64.0-1.fc35.aarch64",
+      "libdrm-2.4.109-1.fc35.aarch64",
+      "libeconf-0.4.0-2.fc35.aarch64",
+      "libedit-3.1-40.20210910cvs.fc35.aarch64",
+      "libevent-2.1.12-4.fc35.aarch64",
+      "libfdisk-2.37.2-1.fc35.aarch64",
+      "libfdt-1.6.1-2.fc35.aarch64",
+      "libffi-3.1-29.fc35.aarch64",
+      "libfido2-1.8.0-1.fc35.aarch64",
+      "libfsverity-1.4-6.fc35.aarch64",
+      "libgcc-11.2.1-7.fc35.aarch64",
+      "libgcrypt-1.9.4-1.fc35.aarch64",
+      "libgomp-11.2.1-7.fc35.aarch64",
+      "libgpg-error-1.43-1.fc35.aarch64",
+      "libibverbs-38.0-1.fc35.aarch64",
+      "libidn2-2.3.2-3.fc35.aarch64",
+      "libini_config-1.3.1-48.fc35.aarch64",
+      "libkcapi-1.3.1-3.fc35.aarch64",
+      "libkcapi-hmaccalc-1.3.1-3.fc35.aarch64",
+      "libksba-1.6.0-2.fc35.aarch64",
+      "libldb-2.4.1-1.fc35.aarch64",
+      "libmaxminddb-1.6.0-1.fc35.aarch64",
+      "libmnl-1.0.4-14.fc35.aarch64",
+      "libmodulemd-2.13.0-3.fc35.aarch64",
+      "libmount-2.37.2-1.fc35.aarch64",
+      "libndp-1.8-2.fc35.aarch64",
+      "libnetfilter_conntrack-1.0.8-3.fc35.aarch64",
+      "libnfnetlink-1.0.1-20.fc35.aarch64",
+      "libnfsidmap-2.5.4-2.rc3.fc35.aarch64",
+      "libnftnl-1.2.0-2.fc35.aarch64",
+      "libnghttp2-1.45.1-1.fc35.aarch64",
+      "libnl3-3.5.0-8.fc35.aarch64",
+      "libnsl2-1.3.0-4.fc35.aarch64",
+      "libpath_utils-0.2.1-48.fc35.aarch64",
+      "libpcap-1.10.1-2.fc35.aarch64",
+      "libpciaccess-0.16-5.fc35.aarch64",
+      "libpipeline-1.5.3-3.fc35.aarch64",
+      "libpsl-0.21.1-4.fc35.aarch64",
+      "libpwquality-1.4.4-6.fc35.aarch64",
+      "libref_array-0.1.5-48.fc35.aarch64",
+      "librepo-1.14.2-1.fc35.aarch64",
+      "libreport-filesystem-2.15.2-6.fc35.noarch",
+      "libseccomp-2.5.3-1.fc35.aarch64",
+      "libsecret-0.20.4-3.fc35.aarch64",
+      "libselinux-3.3-1.fc35.aarch64",
+      "libselinux-utils-3.3-1.fc35.aarch64",
+      "libsemanage-3.3-1.fc35.aarch64",
+      "libsepol-3.3-2.fc35.aarch64",
+      "libsigsegv-2.13-3.fc35.aarch64",
+      "libsmartcols-2.37.2-1.fc35.aarch64",
+      "libsolv-0.7.19-3.fc35.aarch64",
+      "libss-1.46.3-1.fc35.aarch64",
+      "libssh-0.9.6-1.fc35.aarch64",
+      "libssh-config-0.9.6-1.fc35.noarch",
+      "libsss_autofs-2.6.1-1.fc35.aarch64",
+      "libsss_certmap-2.6.1-1.fc35.aarch64",
+      "libsss_idmap-2.6.1-1.fc35.aarch64",
+      "libsss_nss_idmap-2.6.1-1.fc35.aarch64",
+      "libsss_sudo-2.6.1-1.fc35.aarch64",
+      "libstdc++-11.2.1-7.fc35.aarch64",
+      "libtalloc-2.3.3-2.fc35.aarch64",
+      "libtasn1-4.16.0-6.fc35.aarch64",
+      "libtdb-1.4.4-3.fc35.aarch64",
+      "libtevent-0.11.0-1.fc35.aarch64",
+      "libtirpc-1.3.2-1.fc35.aarch64",
+      "libunistring-0.9.10-14.fc35.aarch64",
+      "liburing-2.0-2.fc35.aarch64",
+      "libusb1-1.0.24-4.fc35.aarch64",
+      "libuser-0.63-7.fc35.aarch64",
+      "libutempter-1.2.1-5.fc35.aarch64",
+      "libuuid-2.37.2-1.fc35.aarch64",
+      "libverto-0.3.2-2.fc35.aarch64",
+      "libxcb-1.13.1-8.fc35.aarch64",
+      "libxcrypt-4.4.27-1.fc35.aarch64",
+      "libxkbcommon-1.3.1-1.fc35.aarch64",
+      "libxml2-2.9.12-6.fc35.aarch64",
+      "libyaml-0.2.5-6.fc35.aarch64",
+      "libzstd-1.5.1-4.fc35.aarch64",
+      "linux-atm-libs-2.5.1-30.fc35.aarch64",
+      "linux-firmware-20211216-127.fc35.noarch",
+      "linux-firmware-whence-20211216-127.fc35.noarch",
+      "lmdb-libs-0.9.29-2.fc35.aarch64",
+      "lua-libs-5.4.3-2.fc35.aarch64",
+      "lz4-libs-1.9.3-3.fc35.aarch64",
+      "man-db-2.9.4-2.fc35.aarch64",
+      "memstrack-0.2.4-1.fc35.aarch64",
+      "mkpasswd-5.5.10-2.fc35.aarch64",
+      "mokutil-0.5.0-1.fc35.aarch64",
+      "mozjs78-78.15.0-1.fc35.aarch64",
+      "mpdecimal-2.5.1-2.fc35.aarch64",
+      "mpfr-4.1.0-8.fc35.aarch64",
+      "ncurses-6.2-8.20210508.fc35.aarch64",
+      "ncurses-base-6.2-8.20210508.fc35.noarch",
+      "ncurses-libs-6.2-8.20210508.fc35.aarch64",
+      "net-tools-2.0-0.60.20160912git.fc35.aarch64",
+      "nettle-3.7.3-2.fc35.aarch64",
+      "nftables-1.0.0-1.fc35.aarch64",
+      "npth-1.6-7.fc35.aarch64",
+      "openldap-2.4.59-3.fc35.aarch64",
+      "openssh-8.7p1-3.fc35.aarch64",
+      "openssh-clients-8.7p1-3.fc35.aarch64",
+      "openssh-server-8.7p1-3.fc35.aarch64",
+      "openssl-libs-1.1.1l-2.fc35.aarch64",
+      "openssl-pkcs11-0.4.11-4.fc35.aarch64",
+      "os-prober-1.77-8.fc35.aarch64",
+      "p11-kit-0.23.22-4.fc35.aarch64",
+      "p11-kit-trust-0.23.22-4.fc35.aarch64",
+      "pam-1.5.2-5.fc35.aarch64",
+      "parted-3.4-6.fc35.aarch64",
+      "passwd-0.80-11.fc35.aarch64",
+      "pcre-8.45-1.fc35.aarch64",
+      "pcre2-10.37-4.fc35.aarch64",
+      "pcre2-syntax-10.37-4.fc35.noarch",
+      "pcsc-lite-1.9.5-1.fc35.aarch64",
+      "pcsc-lite-ccid-1.4.36-2.fc35.aarch64",
+      "pcsc-lite-libs-1.9.5-1.fc35.aarch64",
+      "pigz-2.5-2.fc35.aarch64",
+      "pinentry-1.2.0-1.fc35.aarch64",
+      "plymouth-0.9.5-3.20210331git1ea1020.fc35.aarch64",
+      "plymouth-core-libs-0.9.5-3.20210331git1ea1020.fc35.aarch64",
+      "plymouth-scripts-0.9.5-3.20210331git1ea1020.fc35.aarch64",
+      "policycoreutils-3.3-1.fc35.aarch64",
+      "polkit-0.120-1.fc35.aarch64",
+      "polkit-libs-0.120-1.fc35.aarch64",
+      "polkit-pkla-compat-0.1-20.fc35.aarch64",
+      "popt-1.18-6.fc35.aarch64",
+      "procps-ng-3.3.17-3.fc35.aarch64",
+      "protobuf-c-1.4.0-1.fc35.aarch64",
+      "psmisc-23.4-2.fc35.aarch64",
+      "publicsuffix-list-dafsa-20210518-2.fc35.noarch",
+      "python-pip-wheel-21.2.3-4.fc35.noarch",
+      "python-setuptools-wheel-57.4.0-1.fc35.noarch",
+      "python-unversioned-command-3.10.1-2.fc35.noarch",
+      "python3-3.10.1-2.fc35.aarch64",
+      "python3-attrs-21.2.0-4.fc35.noarch",
+      "python3-audit-3.0.6-1.fc35.aarch64",
+      "python3-babel-2.9.1-4.fc35.noarch",
+      "python3-cffi-1.14.6-2.fc35.aarch64",
+      "python3-charset-normalizer-2.0.4-1.fc35.noarch",
+      "python3-configobj-5.0.6-25.fc35.noarch",
+      "python3-cryptography-3.4.7-5.fc35.aarch64",
+      "python3-dateutil-2.8.1-7.fc35.noarch",
+      "python3-dbus-1.2.18-2.fc35.aarch64",
+      "python3-distro-1.6.0-1.fc35.noarch",
+      "python3-dnf-4.9.0-1.fc35.noarch",
+      "python3-dnf-plugins-core-4.0.24-1.fc35.noarch",
+      "python3-firewall-1.0.1-2.fc35.noarch",
+      "python3-gobject-base-3.42.0-1.fc35.aarch64",
+      "python3-gpg-1.15.1-6.fc35.aarch64",
+      "python3-hawkey-0.64.0-1.fc35.aarch64",
+      "python3-idna-3.2-1.fc35.noarch",
+      "python3-jinja2-3.0.1-2.fc35.noarch",
+      "python3-jsonpatch-1.21-18.fc35.noarch",
+      "python3-jsonpointer-2.0-4.fc35.noarch",
+      "python3-jsonschema-3.2.0-12.fc35.noarch",
+      "python3-jwt+crypto-2.1.0-2.fc35.noarch",
+      "python3-jwt-2.1.0-2.fc35.noarch",
+      "python3-libcomps-0.1.18-1.fc35.aarch64",
+      "python3-libdnf-0.64.0-1.fc35.aarch64",
+      "python3-libs-3.10.1-2.fc35.aarch64",
+      "python3-libselinux-3.3-1.fc35.aarch64",
+      "python3-libsemanage-3.3-1.fc35.aarch64",
+      "python3-markupsafe-2.0.0-2.fc35.aarch64",
+      "python3-nftables-1.0.0-1.fc35.aarch64",
+      "python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch",
+      "python3-oauthlib-3.0.2-11.fc35.noarch",
+      "python3-ply-3.11-13.fc35.noarch",
+      "python3-policycoreutils-3.3-1.fc35.noarch",
+      "python3-prettytable-0.7.2-27.fc35.noarch",
+      "python3-pycparser-2.20-5.fc35.noarch",
+      "python3-pyrsistent-0.18.0-8.fc35.aarch64",
+      "python3-pyserial-3.4-12.fc35.noarch",
+      "python3-pysocks-1.7.1-11.fc35.noarch",
+      "python3-pytz-2021.3-1.fc35.noarch",
+      "python3-pyyaml-5.4.1-4.fc35.aarch64",
+      "python3-requests-2.27.0-1.fc35.noarch",
+      "python3-rpm-4.17.0-1.fc35.aarch64",
+      "python3-setools-4.4.0-3.fc35.aarch64",
+      "python3-setuptools-57.4.0-1.fc35.noarch",
+      "python3-six-1.16.0-4.fc35.noarch",
+      "python3-unbound-1.13.2-1.fc35.aarch64",
+      "python3-urllib3-1.26.7-2.fc35.noarch",
+      "qemu-guest-agent-6.1.0-10.fc35.aarch64",
+      "qrencode-libs-4.1.1-1.fc35.aarch64",
+      "readline-8.1-3.fc35.aarch64",
+      "rootfiles-8.1-30.fc35.noarch",
+      "rpm-4.17.0-1.fc35.aarch64",
+      "rpm-build-libs-4.17.0-1.fc35.aarch64",
+      "rpm-libs-4.17.0-1.fc35.aarch64",
+      "rpm-plugin-selinux-4.17.0-1.fc35.aarch64",
+      "rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64",
+      "rpm-sign-libs-4.17.0-1.fc35.aarch64",
+      "sed-4.8-8.fc35.aarch64",
+      "selinux-policy-35.8-1.fc35.noarch",
+      "selinux-policy-targeted-35.8-1.fc35.noarch",
+      "setup-2.13.9.1-2.fc35.noarch",
+      "shadow-utils-4.9-8.fc35.aarch64",
+      "shim-aa64-15.4-5.aarch64",
+      "spice-vdagent-0.21.0-5.fc35.aarch64",
+      "sqlite-libs-3.36.0-3.fc35.aarch64",
+      "sssd-client-2.6.1-1.fc35.aarch64",
+      "sssd-common-2.6.1-1.fc35.aarch64",
+      "sssd-kcm-2.6.1-1.fc35.aarch64",
+      "sssd-nfs-idmap-2.6.1-1.fc35.aarch64",
+      "sudo-1.9.7p2-2.fc35.aarch64",
+      "sudo-python-plugin-1.9.7p2-2.fc35.aarch64",
+      "systemd-249.7-2.fc35.aarch64",
+      "systemd-libs-249.7-2.fc35.aarch64",
+      "systemd-networkd-249.7-2.fc35.aarch64",
+      "systemd-oomd-defaults-249.7-2.fc35.noarch",
+      "systemd-pam-249.7-2.fc35.aarch64",
+      "systemd-resolved-249.7-2.fc35.aarch64",
+      "systemd-udev-249.7-2.fc35.aarch64",
+      "tpm2-tss-3.1.0-3.fc35.aarch64",
+      "trousers-0.3.15-4.fc35.aarch64",
+      "trousers-lib-0.3.15-4.fc35.aarch64",
+      "tzdata-2021e-1.fc35.noarch",
+      "unbound-libs-1.13.2-1.fc35.aarch64",
+      "util-linux-2.37.2-1.fc35.aarch64",
+      "util-linux-core-2.37.2-1.fc35.aarch64",
+      "vim-data-8.2.4006-1.fc35.noarch",
+      "vim-minimal-8.2.4006-1.fc35.aarch64",
+      "which-2.21-27.fc35.aarch64",
+      "whois-nls-5.5.10-2.fc35.noarch",
+      "xen-libs-4.15.1-4.fc35.aarch64",
+      "xen-licenses-4.15.1-4.fc35.aarch64",
+      "xfsprogs-5.12.0-2.fc35.aarch64",
+      "xkeyboard-config-2.33-2.fc35.noarch",
+      "xz-5.2.5-7.fc35.aarch64",
+      "xz-libs-5.2.5-7.fc35.aarch64",
+      "yajl-2.1.0-17.fc35.aarch64",
+      "yum-4.9.0-1.fc35.noarch",
+      "zchunk-libs-1.1.15-2.fc35.aarch64",
+      "zlib-1.2.11-30.fc35.aarch64"
+    ],
+    "partition-table": "gpt",
+    "partition-table-id": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
+    "partitions": [
+      {
+        "bootable": false,
+        "fstype": "vfat",
+        "label": "EFI-SYSTEM",
+        "partuuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
+        "size": 498073600,
+        "start": 1048576,
+        "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+        "uuid": "46BB-8120"
+      },
+      {
+        "bootable": false,
+        "fstype": "ext4",
+        "label": null,
+        "partuuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
+        "size": 1647296000,
+        "start": 500170752,
+        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+        "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+      }
+    ],
+    "passwd": [
+      "adm:x:3:4:adm:/var/adm:/sbin/nologin",
+      "bin:x:1:1:bin:/bin:/sbin/nologin",
+      "chrony:x:994:993::/var/lib/chrony:/sbin/nologin",
+      "daemon:x:2:2:daemon:/sbin:/sbin/nologin",
+      "dbus:x:81:81:System message bus:/:/sbin/nologin",
+      "ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin",
+      "games:x:12:100:games:/usr/games:/sbin/nologin",
+      "halt:x:7:0:halt:/sbin:/sbin/halt",
+      "lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin",
+      "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
+      "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
+      "operator:x:11:0:operator:/root:/sbin/nologin",
+      "polkitd:x:995:994:User for polkitd:/:/sbin/nologin",
+      "redhat:x:1000:1000::/home/redhat:/bin/bash",
+      "root:x:0:0:root:/root:/bin/bash",
+      "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
+      "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
+      "sync:x:5:0:sync:/sbin:/bin/sync",
+      "systemd-coredump:x:997:997:systemd Core Dumper:/:/usr/sbin/nologin",
+      "systemd-network:x:192:192:systemd Network Management:/:/usr/sbin/nologin",
+      "systemd-oom:x:999:999:systemd Userspace OOM Killer:/:/usr/sbin/nologin",
+      "systemd-resolve:x:193:193:systemd Resolver:/:/usr/sbin/nologin",
+      "systemd-timesync:x:998:998:systemd Time Synchronization:/:/usr/sbin/nologin",
+      "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
+      "unbound:x:996:995:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
+    ],
+    "rpm-verify": {
+      "changed": {
+        "/boot/efi/EFI": ".M.......",
+        "/boot/efi/EFI/BOOT/BOOTAA64.EFI": ".......T.",
+        "/boot/efi/EFI/BOOT/fbaa64.efi": ".......T.",
+        "/boot/efi/EFI/fedora/BOOTAA64.CSV": ".......T.",
+        "/boot/efi/EFI/fedora/grubaa64.efi": ".......T.",
+        "/boot/efi/EFI/fedora/mmaa64.efi": ".......T.",
+        "/boot/efi/EFI/fedora/shim.efi": ".......T.",
+        "/boot/efi/EFI/fedora/shimaa64.efi": ".......T.",
+        "/etc/machine-id": ".M.......",
+        "/etc/udev/hwdb.bin": ".M.......",
+        "/proc": ".M.......",
+        "/sys": ".M.......",
+        "/var/log/lastlog": ".M....G.."
+      },
+      "missing": []
+    },
+    "selinux": {
+      "context-mismatch": [
+        {
+          "actual": "system_u:object_r:unlabeled_t:s0",
+          "expected": "system_u:object_r:lost_found_t:s0",
+          "filename": "/lost+found"
+        }
+      ],
+      "policy": {
+        "SELINUX": "enforcing",
+        "SELINUXTYPE": "targeted"
+      }
+    },
+    "services-disabled": [
+      "arp-ethers.service",
+      "chrony-wait.service",
+      "console-getty.service",
+      "debug-shell.service",
+      "exit.target",
+      "halt.target",
+      "kexec.target",
+      "loadmodules.service",
+      "man-db-restart-cache-update.service",
+      "nftables.service",
+      "nis-domainname.service",
+      "poweroff.target",
+      "proc-sys-fs-binfmt_misc.mount",
+      "rdisc.service",
+      "remote-cryptsetup.target",
+      "remote-veritysetup.target",
+      "runlevel0.target",
+      "selinux-check-proper-disable.service",
+      "serial-getty@.service",
+      "sshd-keygen@.service",
+      "sshd.socket",
+      "sssd-autofs.socket",
+      "sssd-nss.socket",
+      "sssd-pac.socket",
+      "sssd-pam-priv.socket",
+      "sssd-pam.socket",
+      "sssd-ssh.socket",
+      "sssd-sudo.socket",
+      "systemd-boot-check-no-failures.service",
+      "systemd-network-generator.service",
+      "systemd-networkd-wait-online.service",
+      "systemd-networkd.service",
+      "systemd-networkd.socket",
+      "systemd-pstore.service",
+      "systemd-sysext.service",
+      "systemd-time-wait-sync.service",
+      "systemd-timesyncd.service",
+      "tcsd.service"
+    ],
+    "services-enabled": [
+      "NetworkManager-dispatcher.service",
+      "NetworkManager-wait-online.service",
+      "NetworkManager.service",
+      "auditd.service",
+      "autovt@.service",
+      "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
+      "ctrl-alt-del.target",
+      "dbus-broker.service",
+      "dbus-org.fedoraproject.FirewallD1.service",
+      "dbus-org.freedesktop.home1.service",
+      "dbus-org.freedesktop.nm-dispatcher.service",
+      "dbus-org.freedesktop.oom1.service",
+      "dbus-org.freedesktop.resolve1.service",
+      "dbus.service",
+      "dbus.socket",
+      "dnf-makecache.timer",
+      "firewalld.service",
+      "fstrim.timer",
+      "getty@.service",
+      "import-state.service",
+      "pcscd.socket",
+      "qemu-guest-agent.service",
+      "reboot.target",
+      "remote-fs.target",
+      "rpmdb-rebuild.service",
+      "runlevel6.target",
+      "selinux-autorelabel-mark.service",
+      "sshd.service",
+      "sssd-kcm.socket",
+      "sssd.service",
+      "systemd-homed-activate.service",
+      "systemd-homed.service",
+      "systemd-oomd.service",
+      "systemd-resolved.service",
+      "systemd-userdbd.socket",
+      "unbound-anchor.timer"
+    ],
+    "sudoers": {
+      "/etc/sudoers": [
+        "Defaults   !visiblepw",
+        "Defaults    always_set_home",
+        "Defaults    match_group_by_gid",
+        "Defaults    always_query_group_plugin",
+        "Defaults    env_reset",
+        "Defaults    env_keep =  \"COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS\"",
+        "Defaults    env_keep += \"MAIL QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE\"",
+        "Defaults    env_keep += \"LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES\"",
+        "Defaults    env_keep += \"LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE\"",
+        "Defaults    env_keep += \"LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY\"",
+        "Defaults    secure_path = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+        "root\tALL=(ALL) \tALL",
+        "%wheel\tALL=(ALL)\tALL"
+      ]
+    },
+    "sysctl.d": {
+      "/usr/lib/sysctl.d": {
+        "10-default-yama-scope.conf": [
+          "kernel.yama.ptrace_scope = 0"
+        ],
+        "50-coredump.conf": [
+          "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h",
+          "kernel.core_pipe_limit=16",
+          "fs.suid_dumpable=2"
+        ],
+        "50-default.conf": [
+          "kernel.sysrq = 16",
+          "kernel.core_uses_pid = 1",
+          "net.ipv4.conf.default.rp_filter = 2",
+          "net.ipv4.conf.*.rp_filter = 2",
+          "-net.ipv4.conf.all.rp_filter",
+          "net.ipv4.conf.default.accept_source_route = 0",
+          "net.ipv4.conf.*.accept_source_route = 0",
+          "-net.ipv4.conf.all.accept_source_route",
+          "net.ipv4.conf.default.promote_secondaries = 1",
+          "net.ipv4.conf.*.promote_secondaries = 1",
+          "-net.ipv4.conf.all.promote_secondaries",
+          "-net.ipv4.ping_group_range = 0 2147483647",
+          "-net.core.default_qdisc = fq_codel",
+          "fs.protected_hardlinks = 1",
+          "fs.protected_symlinks = 1",
+          "fs.protected_regular = 1",
+          "fs.protected_fifos = 1"
+        ],
+        "50-libkcapi-optmem_max.conf": [
+          "net.core.optmem_max = 81920"
+        ],
+        "50-pid-max.conf": [
+          "kernel.pid_max = 4194304"
+        ]
+      }
+    },
+    "systemd-service-dropins": {
+      "/usr/lib/systemd/system": {
+        "systemd-hostnamed.service.d": {
+          "Service": {
+            "PrivateDevices": "no"
+          }
+        },
+        "systemd-logind.service.d": {
+          "Service": {
+            "Environment": "SYSTEMD_REBOOT_TO_BOOT_LOADER_MENU=true"
+          }
+        },
+        "systemd-udev-trigger.service.d": {
+          "Unit": {
+            "RefuseManualStop": "true"
+          }
+        },
+        "user@.service.d": {
+          "Service": {
+            "ManagedOOMMemoryPressure": "kill",
+            "ManagedOOMMemoryPressureLimit": "50%"
+          }
+        }
+      }
+    },
+    "timezone": "UTC",
+    "tmpfiles.d": {
+      "/usr/lib/tmpfiles.d": {
+        "cloud-init.conf": [
+          "d /run/cloud-init 0700 root root - -"
+        ],
+        "cryptsetup.conf": [
+          "d /run/cryptsetup 0700 root root -"
+        ],
+        "dnf.conf": [
+          "R /var/tmp/dnf*/locks/*",
+          "r /var/cache/dnf/download_lock.pid",
+          "r /var/cache/dnf/metadata_lock.pid",
+          "r /var/lib/dnf/rpmdb_lock.pid",
+          "r /var/log/log_lock.pid"
+        ],
+        "etc.conf": [
+          "L /etc/os-release - - - - ../usr/lib/os-release",
+          "L+ /etc/mtab - - - - ../proc/self/mounts",
+          "L! /etc/resolv.conf - - - - ../run/systemd/resolve/stub-resolv.conf",
+          "C! /etc/nsswitch.conf - - - -",
+          "C! /etc/pam.d - - - -",
+          "C! /etc/issue - - - -"
+        ],
+        "home.conf": [
+          "Q /home 0755 - - -",
+          "q /srv 0755 - - -"
+        ],
+        "journal-nocow.conf": [
+          "h /var/log/journal - - - - +C",
+          "h /var/log/journal/%m - - - - +C",
+          "h /var/log/journal/remote - - - - +C"
+        ],
+        "legacy.conf": [
+          "d /run/lock 0755 root root -",
+          "L /var/lock - - - - ../run/lock",
+          "d /run/lock/subsys 0755 root root -",
+          "r! /forcefsck",
+          "r! /fastboot",
+          "r! /forcequotacheck"
+        ],
+        "libselinux.conf": [
+          "d /run/setrans 0755 root root"
+        ],
+        "man-db.conf": [
+          "d /var/cache/man 0755 root root 1w"
+        ],
+        "pam.conf": [
+          "d /run/console 0755 root root -",
+          "d /run/faillock 0755 root root -",
+          "d /run/sepermit 0755 root root -",
+          "d /run/motd.d 0755 root root -",
+          "f /var/log/tallylog 0600 root root -"
+        ],
+        "portables.conf": [
+          "Q /var/lib/portables 0700"
+        ],
+        "selinux-policy.conf": [
+          "z /sys/devices/system/cpu/online - - -",
+          "Z /sys/class/net - - -",
+          "z /sys/kernel/uevent_helper - - -",
+          "w /sys/fs/selinux/checkreqprot - - - - 0"
+        ],
+        "setup.conf": [
+          "f /run/motd 0644 root root -",
+          "d /run/motd.d 0755 root root -"
+        ],
+        "spice-vdagentd.conf": [
+          "d /run/spice-vdagentd 0755 root root -"
+        ],
+        "static-nodes-permissions.conf": [
+          "z /dev/snd/seq      0660 - audio -",
+          "z /dev/snd/timer    0660 - audio -",
+          "z /dev/loop-control 0660 - disk  -",
+          "z /dev/net/tun      0666 - -     -",
+          "z /dev/fuse         0666 - -     -",
+          "z /dev/kvm          0666 - kvm -",
+          "z /dev/vhost-net    0666 - kvm -",
+          "z /dev/vhost-vsock  0666 - kvm -"
+        ],
+        "sudo.conf": [
+          "d /run/sudo 0711 root root",
+          "D /run/sudo/ts 0700 root root"
+        ],
+        "systemd-nologin.conf": [
+          "F! /run/nologin 0644 - - - \"System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8).\""
+        ],
+        "systemd-pstore.conf": [
+          "d /var/lib/systemd/pstore 0755 root root 14d"
+        ],
+        "systemd-tmp.conf": [
+          "x /tmp/systemd-private-%b-*",
+          "X /tmp/systemd-private-%b-*/tmp",
+          "x /var/tmp/systemd-private-%b-*",
+          "X /var/tmp/systemd-private-%b-*/tmp",
+          "R! /tmp/systemd-private-*",
+          "R! /var/tmp/systemd-private-*",
+          "x  /var/lib/systemd/coredump/.#core*.%b*",
+          "r! /var/lib/systemd/coredump/.#*"
+        ],
+        "systemd.conf": [
+          "d /run/user 0755 root root -",
+          "F! /run/utmp 0664 root utmp -",
+          "d /run/systemd/ask-password 0755 root root -",
+          "d /run/systemd/seats 0755 root root -",
+          "d /run/systemd/sessions 0755 root root -",
+          "d /run/systemd/users 0755 root root -",
+          "d /run/systemd/machines 0755 root root -",
+          "d /run/systemd/shutdown 0755 root root -",
+          "d /run/systemd/netif 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/links 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/leases 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/lldp 0755 systemd-network systemd-network -",
+          "d /run/log 0755 root root -",
+          "z /run/log/journal 2755 root systemd-journal - -",
+          "Z /run/log/journal/%m ~2750 root systemd-journal - -",
+          "a+ /run/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m/*.journal* - - - - group:adm:r--,group:wheel:r--",
+          "z /var/log/journal 2755 root systemd-journal - -",
+          "z /var/log/journal/%m 2755 root systemd-journal - -",
+          "z /var/log/journal/%m/system.journal 0640 root systemd-journal - -",
+          "a+ /var/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m/system.journal - - - - group:adm:r--,group:wheel:r--",
+          "d /var/lib/systemd 0755 root root -",
+          "d /var/lib/systemd/coredump 0755 root root 3d",
+          "d /var/lib/private 0700 root root -",
+          "d /var/log/private 0700 root root -",
+          "d /var/cache/private 0700 root root -"
+        ],
+        "tmp.conf": [
+          "q /tmp 1777 root root 10d",
+          "q /var/tmp 1777 root root 30d"
+        ],
+        "tpm2-tss-fapi.conf": [
+          "d       /var/lib/tpm2-tss/system/keystore   2775 tss  tss   -           -",
+          "a+      /var/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx",
+          "d       /run/tpm2-tss/eventlog                2775 tss  tss   -           -",
+          "a+      /run/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx"
+        ],
+        "var.conf": [
+          "q /var 0755 - - -",
+          "L /var/run - - - - ../run",
+          "d /var/log 0755 - - -",
+          "f /var/log/wtmp 0664 root utmp -",
+          "f /var/log/btmp 0660 root utmp -",
+          "f /var/log/lastlog 0664 root utmp -",
+          "d /var/cache 0755 - - -",
+          "d /var/lib 0755 - - -",
+          "d /var/spool 0755 - - -"
+        ],
+        "x11.conf": [
+          "D! /tmp/.X11-unix 1777 root root 10d",
+          "D! /tmp/.ICE-unix 1777 root root 10d",
+          "D! /tmp/.XIM-unix 1777 root root 10d",
+          "D! /tmp/.font-unix 1777 root root 10d",
+          "D! /tmp/.Test-unix 1777 root root 10d",
+          "r! /tmp/.X[0-9]*-lock"
+        ]
+      }
+    }
+  }
+}

--- a/test/data/manifests/fedora_35-aarch64-qcow2-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-qcow2-boot.json
@@ -1,0 +1,10608 @@
+{
+  "compose-request": {
+    "distro": "fedora-35",
+    "arch": "aarch64",
+    "image-type": "qcow2",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-modular-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-modular-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      }
+    ],
+    "filename": "disk.qcow2",
+    "blueprint": {
+      "name": "qcow2-boot-test",
+      "description": "Image for boot test",
+      "packages": [],
+      "modules": [],
+      "groups": [],
+      "customizations": {
+        "user": [
+          {
+            "name": "redhat",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+          }
+        ]
+      }
+    }
+  },
+  "manifest": {
+    "sources": {
+      "org.osbuild.files": {
+        "urls": {
+          "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.aarch64.rpm"
+          },
+          "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm"
+          },
+          "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm"
+          },
+          "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.aarch64.rpm"
+          },
+          "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm"
+          },
+          "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-jsonpatch-1.21-18.fc35.noarch.rpm"
+          },
+          "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm"
+          },
+          "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm"
+          },
+          "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm"
+          },
+          "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm"
+          },
+          "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm"
+          },
+          "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.aarch64.rpm"
+          },
+          "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm"
+          },
+          "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm"
+          },
+          "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-font-en-3.0-15.fc35.noarch.rpm"
+          },
+          "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fonts-filesystem-2.0.5-6.fc35.noarch.rpm"
+          },
+          "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm"
+          },
+          "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm"
+          },
+          "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm"
+          },
+          "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm"
+          },
+          "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm"
+          },
+          "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm"
+          },
+          "sha256:228e6fbe3646a580e871378f374a1d7cebc4c592ea8262600e4b41a5c39b1169": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-motdgen-0.21.2-3.fc35.noarch.rpm"
+          },
+          "sha256:22a906074aaab00a9c1bac318f9d10323566670fc7772c61e196574dfc63ee9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-policycoreutils-3.3-1.fc35.noarch.rpm"
+          },
+          "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:2402ad97f754eb094e4c4f49b3045fdf919e413b6a78582e3c1850ba09ff93f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/freetype-2.11.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm"
+          },
+          "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm"
+          },
+          "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-attrs-21.2.0-4.fc35.noarch.rpm"
+          },
+          "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm"
+          },
+          "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm"
+          },
+          "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efibootmgr-16-11.fc35.aarch64.rpm"
+          },
+          "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm"
+          },
+          "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm"
+          },
+          "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm"
+          },
+          "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.26.7-2.fc35.noarch.rpm"
+          },
+          "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efi-filesystem-5-4.fc35.noarch.rpm"
+          },
+          "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm"
+          },
+          "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-requests-2.27.0-1.fc35.noarch.rpm"
+          },
+          "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm"
+          },
+          "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-ply-3.11-13.fc35.noarch.rpm"
+          },
+          "sha256:360960053a501c11bc407c6c8a2f379b79bd249133b7c0ffaba54068385860e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-cloud-35-36.noarch.rpm"
+          },
+          "sha256:375b89f3a452a62f3a02ada8971b14e854fa95b0d4cb9efb0449e5f85d6959c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-markupsafe-2.0.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/less-590-2.fc35.aarch64.rpm"
+          },
+          "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:39fd9eb8e77b430637602dc7cfce448e1792ace9cc9041c33f957b70d7b205c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/inih-49-4.fc35.aarch64.rpm"
+          },
+          "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm"
+          },
+          "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm"
+          },
+          "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.aarch64.rpm"
+          },
+          "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm"
+          },
+          "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm"
+          },
+          "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:3eecb51a03f9eed59710f6c6cbc5d66aea9bc521940d0b8d73fca835f1402897": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chrony-4.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm"
+          },
+          "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm"
+          },
+          "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm"
+          },
+          "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm"
+          },
+          "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.aarch64.rpm"
+          },
+          "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm"
+          },
+          "sha256:469ec3ace1ffa4e3153c772d5ec5a65f8cb6e98d07405134c6b06545796e31c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyyaml-5.4.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:4a1dbb7d6a22598bc31d917e42759d7332a343670e35e0022db39a2ebb9e5c99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cloud-utils-growpart-0.31-9.fc35.noarch.rpm"
+          },
+          "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/parted-3.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-charset-normalizer-2.0.4-1.fc35.noarch.rpm"
+          },
+          "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm"
+          },
+          "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt-2.1.0-2.fc35.noarch.rpm"
+          },
+          "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4df41f9a100eca994899d304473024c37382220b4e3c0812c69701bfa450aa06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-cloud-35-36.noarch.rpm"
+          },
+          "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.aarch64.rpm"
+          },
+          "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-en-3.0-15.fc35.noarch.rpm"
+          },
+          "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:50d0b3571e271cce3c9f314f3fab80485b706c347cb6e9c710c28cf552c07ec5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/checkpolicy-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm"
+          },
+          "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm"
+          },
+          "sha256:539d9ef12227716ff904a3e4605c765e6204ffd49a7a2d42762ccd5d921b341c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-issuegen-0.21.2-3.fc35.noarch.rpm"
+          },
+          "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.aarch64.rpm"
+          },
+          "sha256:5437317aa8a5d94a9de9cd15d58399146783b4b96ee52a0a134c09b79933a8b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:5702b6d62b7efb235cf49b6174288053d345236107a43de33d6c80d9784d7140": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-audit-3.0.6-1.fc35.aarch64.rpm"
+          },
+          "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm"
+          },
+          "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-configobj-5.0.6-25.fc35.noarch.rpm"
+          },
+          "sha256:58b6c3272af7450868f9b6ee3e15f05e45104751cacaa4a22345983caaea14da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-filesystem-1.7.0-11.fc35.aarch64.rpm"
+          },
+          "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.aarch64.rpm"
+          },
+          "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.aarch64.rpm"
+          },
+          "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm"
+          },
+          "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm"
+          },
+          "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.aarch64.rpm"
+          },
+          "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm"
+          },
+          "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm"
+          },
+          "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pycparser-2.20-5.fc35.noarch.rpm"
+          },
+          "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.aarch64.rpm"
+          },
+          "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm"
+          },
+          "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm"
+          },
+          "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm"
+          },
+          "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm"
+          },
+          "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-en-3.0-15.fc35.noarch.rpm"
+          },
+          "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-GB-0.20140811.1-20.fc35.noarch.rpm"
+          },
+          "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm"
+          },
+          "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efivar-libs-37-17.fc35.aarch64.rpm"
+          },
+          "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm"
+          },
+          "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm"
+          },
+          "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setuptools-57.4.0-1.fc35.noarch.rpm"
+          },
+          "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.aarch64.rpm"
+          },
+          "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm"
+          },
+          "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm"
+          },
+          "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm"
+          },
+          "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm"
+          },
+          "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:77f17b1b61648436b2ceb31f9447ce6b363ac2de62216277fb05b6ff8eb9654c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/graphite2-1.3.14-8.fc35.aarch64.rpm"
+          },
+          "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm"
+          },
+          "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm"
+          },
+          "sha256:7e7205d1d01f5c6e2635f3b80c2efc04440449482ac8024391af00007952c487": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/harfbuzz-2.8.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm"
+          },
+          "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.aarch64.rpm"
+          },
+          "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm"
+          },
+          "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm"
+          },
+          "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-idna-3.2-1.fc35.noarch.rpm"
+          },
+          "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.aarch64.rpm"
+          },
+          "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonschema-3.2.0-12.fc35.noarch.rpm"
+          },
+          "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jinja2-3.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm"
+          },
+          "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib-3.0.2-11.fc35.noarch.rpm"
+          },
+          "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dejavu-sans-fonts-2.37-17.fc35.noarch.rpm"
+          },
+          "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.aarch64.rpm"
+          },
+          "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyserial-3.4-12.fc35.noarch.rpm"
+          },
+          "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm"
+          },
+          "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm"
+          },
+          "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm"
+          },
+          "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm"
+          },
+          "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.aarch64.rpm"
+          },
+          "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm"
+          },
+          "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.aarch64.rpm"
+          },
+          "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm"
+          },
+          "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:9593a8e47f980af2a61700947cf6da75b409621598029854c05f1a4f5749d1cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libsemanage-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:9605b7a0fbfb73c13a99ae45476c02cf3a0cde1b7edf137e90f8006863519a83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setools-4.4.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-babel-2.9.1-4.fc35.noarch.rpm"
+          },
+          "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.aarch64.rpm"
+          },
+          "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm"
+          },
+          "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm"
+          },
+          "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm"
+          },
+          "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm"
+          },
+          "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm"
+          },
+          "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm"
+          },
+          "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm"
+          },
+          "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm"
+          },
+          "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.aarch64.rpm"
+          },
+          "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc35.noarch.rpm"
+          },
+          "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.aarch64.rpm"
+          },
+          "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm"
+          },
+          "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.aarch64.rpm"
+          },
+          "sha256:aa00ac7809f0965b1e09a31862ccbe2cf11753ffc0c7575f2e40c96aa1c162d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpng-1.6.37-11.fc35.aarch64.rpm"
+          },
+          "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm"
+          },
+          "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:ac16154e7ad3440e137a65b0d9bc96942f257651aaf1f41298f15329a216c2c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rsync-3.2.3-8.fc35.aarch64.rpm"
+          },
+          "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm"
+          },
+          "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.aarch64.rpm"
+          },
+          "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.aarch64.rpm"
+          },
+          "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:b30f029f856c7ff5a9ef7c71b4f8d0858b96962c5523ee7c7bcc6313b13a3b0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cryptography-3.4.7-5.fc35.aarch64.rpm"
+          },
+          "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm"
+          },
+          "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm"
+          },
+          "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm"
+          },
+          "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.aarch64.rpm"
+          },
+          "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm"
+          },
+          "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.aarch64.rpm"
+          },
+          "sha256:b98735362bb79e3def6794fa863fe09a1c3690c8c7880e83f572c20860ba25ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libselinux-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:ba4e1520f0409329c8d29839d510c4721f4475e6b17727485c95b634e61a9cb8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-extra-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:baf6082e248e7e84f3cb5ec2695f0dc9afeca615b3f39c60283902ab06d3f564": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cffi-1.14.6-2.fc35.aarch64.rpm"
+          },
+          "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm"
+          },
+          "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.aarch64.rpm"
+          },
+          "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm"
+          },
+          "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm"
+          },
+          "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm"
+          },
+          "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm"
+          },
+          "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm"
+          },
+          "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pysocks-1.7.1-11.fc35.noarch.rpm"
+          },
+          "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cloud-init-20.4-7.fc35.noarch.rpm"
+          },
+          "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.aarch64.rpm"
+          },
+          "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm"
+          },
+          "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.aarch64.rpm"
+          },
+          "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm"
+          },
+          "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/mokutil-0.5.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm"
+          },
+          "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm"
+          },
+          "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch.rpm"
+          },
+          "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm"
+          },
+          "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm"
+          },
+          "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm"
+          },
+          "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm"
+          },
+          "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.aarch64.rpm"
+          },
+          "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm"
+          },
+          "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm"
+          },
+          "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm"
+          },
+          "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm"
+          },
+          "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm"
+          },
+          "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.aarch64.rpm"
+          },
+          "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-0.20140811.1-20.fc35.noarch.rpm"
+          },
+          "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm"
+          },
+          "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt+crypto-2.1.0-2.fc35.noarch.rpm"
+          },
+          "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm"
+          },
+          "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm"
+          },
+          "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm"
+          },
+          "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm"
+          },
+          "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm"
+          },
+          "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm"
+          },
+          "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm"
+          },
+          "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-US-0.20140811.1-20.fc35.noarch.rpm"
+          },
+          "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonpointer-2.0-4.fc35.noarch.rpm"
+          },
+          "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.aarch64.rpm"
+          },
+          "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm"
+          },
+          "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm"
+          },
+          "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/shim-aa64-15.4-5.aarch64.rpm"
+          },
+          "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm"
+          },
+          "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.aarch64.rpm"
+          },
+          "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm"
+          },
+          "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm"
+          },
+          "sha256:ef8f0dbb997b8f1e9a133a85f5e8a6b8579f23e95dbfd0604ac4d4809a759aa9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-profile-0.21.2-3.fc35.noarch.rpm"
+          },
+          "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm"
+          },
+          "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm"
+          },
+          "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm"
+          },
+          "sha256:f4a4e83a8e1a1ba33bbd58ab720d2ba66bc76ef05101dd68d5ccd37a6e4e0b7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-0.21.2-3.fc35.noarch.rpm"
+          },
+          "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-prettytable-0.7.2-27.fc35.noarch.rpm"
+          },
+          "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm"
+          },
+          "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.aarch64.rpm"
+          },
+          "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm"
+          },
+          "sha256:f878dd687438db0e07f2eb571246103ae0e136647242f0bf7f806ddd77e04a91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-1.7.0-11.fc35.aarch64.rpm"
+          },
+          "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.aarch64.rpm"
+          },
+          "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm"
+          },
+          "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm"
+          },
+          "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.aarch64.rpm"
+          },
+          "sha256:fc05e6abb02bcb99462711686ddfc47783c0a5575bdb451a7fce641a3b809e8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.18.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:fccda302546302309788e451ccaa2fb2abba72fa7b4184e82e1ff89830d8e306": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/net-tools-2.0-0.60.20160912git.fc35.aarch64.rpm"
+          },
+          "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:fe1323e767bb5941d49d5b6565750614a2f649d5d34453e5ace10b3012b7a413": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xfsprogs-5.12.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm"
+          },
+          "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm"
+          },
+          "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm"
+          }
+        }
+      }
+    },
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.rpm",
+              "options": {
+                "gpgkeys": [
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+                ],
+                "packages": [
+                  {
+                    "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                    "check_gpg": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "org.osbuild.selinux",
+              "options": {
+                "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+                "labels": {
+                  "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+                }
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.fedora33"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8"
+          }
+        },
+        {
+          "name": "org.osbuild.rpm",
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "packages": [
+              {
+                "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3eecb51a03f9eed59710f6c6cbc5d66aea9bc521940d0b8d73fca835f1402897",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4a1dbb7d6a22598bc31d917e42759d7332a343670e35e0022db39a2ebb9e5c99",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2402ad97f754eb094e4c4f49b3045fdf919e413b6a78582e3c1850ba09ff93f3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:77f17b1b61648436b2ceb31f9447ce6b363ac2de62216277fb05b6ff8eb9654c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7e7205d1d01f5c6e2635f3b80c2efc04440449482ac8024391af00007952c487",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f878dd687438db0e07f2eb571246103ae0e136647242f0bf7f806ddd77e04a91",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:58b6c3272af7450868f9b6ee3e15f05e45104751cacaa4a22345983caaea14da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:39fd9eb8e77b430637602dc7cfce448e1792ace9cc9041c33f957b70d7b205c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aa00ac7809f0965b1e09a31862ccbe2cf11753ffc0c7575f2e40c96aa1c162d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fccda302546302309788e451ccaa2fb2abba72fa7b4184e82e1ff89830d8e306",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5702b6d62b7efb235cf49b6174288053d345236107a43de33d6c80d9784d7140",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:baf6082e248e7e84f3cb5ec2695f0dc9afeca615b3f39c60283902ab06d3f564",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b30f029f856c7ff5a9ef7c71b4f8d0858b96962c5523ee7c7bcc6313b13a3b0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:375b89f3a452a62f3a02ada8971b14e854fa95b0d4cb9efb0449e5f85d6959c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:469ec3ace1ffa4e3153c772d5ec5a65f8cb6e98d07405134c6b06545796e31c2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9605b7a0fbfb73c13a99ae45476c02cf3a0cde1b7edf137e90f8006863519a83",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac16154e7ad3440e137a65b0d9bc96942f257651aaf1f41298f15329a216c2c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fe1323e767bb5941d49d5b6565750614a2f649d5d34453e5ace10b3012b7a413",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:50d0b3571e271cce3c9f314f3fab80485b706c347cb6e9c710c28cf552c07ec5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4a4e83a8e1a1ba33bbd58ab720d2ba66bc76ef05101dd68d5ccd37a6e4e0b7e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:539d9ef12227716ff904a3e4605c765e6204ffd49a7a2d42762ccd5d921b341c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:228e6fbe3646a580e871378f374a1d7cebc4c592ea8262600e4b41a5c39b1169",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ef8f0dbb997b8f1e9a133a85f5e8a6b8579f23e95dbfd0604ac4d4809a759aa9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:360960053a501c11bc407c6c8a2f379b79bd249133b7c0ffaba54068385860e9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4df41f9a100eca994899d304473024c37382220b4e3c0812c69701bfa450aa06",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5437317aa8a5d94a9de9cd15d58399146783b4b96ee52a0a134c09b79933a8b0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ba4e1520f0409329c8d29839d510c4721f4475e6b17727485c95b634e61a9cb8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b98735362bb79e3def6794fa863fe09a1c3690c8c7880e83f572c20860ba25ba",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9593a8e47f980af2a61700947cf6da75b409621598029854c05f1a4f5749d1cb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:22a906074aaab00a9c1bac318f9d10323566670fc7772c61e196574dfc63ee9b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fc05e6abb02bcb99462711686ddfc47783c0a5575bdb451a7fce641a3b809e8e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f",
+                "check_gpg": true
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.hostname",
+          "options": {
+            "hostname": "localhost.localdomain"
+          }
+        },
+        {
+          "name": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "redhat": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              },
+              {
+                "uuid": "46BB-8120",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "umask=0077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "uefi": {
+              "vendor": "fedora"
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
+        "options": {
+          "format": "qcow2",
+          "filename": "disk.qcow2",
+          "size": 2147483648,
+          "ptuuid": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
+          "pttype": "gpt",
+          "partitions": [
+            {
+              "start": 2048,
+              "size": 972800,
+              "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+              "uuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
+              "filesystem": {
+                "type": "vfat",
+                "uuid": "46BB-8120",
+                "label": "EFI-SYSTEM",
+                "mountpoint": "/boot/efi"
+              }
+            },
+            {
+              "start": 976896,
+              "uuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build-packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm",
+        "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm",
+        "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm",
+        "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
+        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
+        "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm",
+        "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm",
+        "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm",
+        "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm",
+        "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "12.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.aarch64.rpm",
+        "checksum": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
+        "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm",
+        "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm",
+        "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm",
+        "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
+        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm",
+        "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
+        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+        "check_gpg": true
+      },
+      {
+        "name": "liburing",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm",
+        "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm",
+        "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm",
+        "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm",
+        "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
+        "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs78",
+        "epoch": 0,
+        "version": "78.15.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm",
+        "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm",
+        "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm",
+        "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm",
+        "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm",
+        "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm",
+        "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm",
+        "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.70.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.4.36",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm",
+        "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+        "check_gpg": true
+      },
+      {
+        "name": "qemu-img",
+        "epoch": 2,
+        "version": "6.1.0",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm",
+        "checksum": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm",
+        "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
+    "packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm",
+        "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65",
+        "check_gpg": true
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75",
+        "check_gpg": true
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chrony-4.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3eecb51a03f9eed59710f6c6cbc5d66aea9bc521940d0b8d73fca835f1402897",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "20.4",
+        "release": "7.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cloud-init-20.4-7.fc35.noarch.rpm",
+        "checksum": "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-utils-growpart",
+        "epoch": 0,
+        "version": "0.31",
+        "release": "9.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cloud-utils-growpart-0.31-9.fc35.noarch.rpm",
+        "checksum": "sha256:4a1dbb7d6a22598bc31d917e42759d7332a343670e35e0022db39a2ebb9e5c99",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm",
+        "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm",
+        "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+        "check_gpg": true
+      },
+      {
+        "name": "dejavu-sans-fonts",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "17.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dejavu-sans-fonts-2.37-17.fc35.noarch.rpm",
+        "checksum": "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
+        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.aarch64.rpm",
+        "checksum": "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm",
+        "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
+        "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efi-filesystem-5-4.fc35.noarch.rpm",
+        "checksum": "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efibootmgr-16-11.fc35.aarch64.rpm",
+        "checksum": "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "37",
+        "release": "17.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efivar-libs-37-17.fc35.aarch64.rpm",
+        "checksum": "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm",
+        "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm",
+        "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+        "check_gpg": true
+      },
+      {
+        "name": "fonts-filesystem",
+        "epoch": 1,
+        "version": "2.0.5",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fonts-filesystem-2.0.5-6.fc35.noarch.rpm",
+        "checksum": "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee",
+        "check_gpg": true
+      },
+      {
+        "name": "freetype",
+        "epoch": 0,
+        "version": "2.11.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/freetype-2.11.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2402ad97f754eb094e4c4f49b3045fdf919e413b6a78582e3c1850ba09ff93f3",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+        "check_gpg": true
+      },
+      {
+        "name": "graphite2",
+        "epoch": 0,
+        "version": "1.3.14",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/graphite2-1.3.14-8.fc35.aarch64.rpm",
+        "checksum": "sha256:77f17b1b61648436b2ceb31f9447ce6b363ac2de62216277fb05b6ff8eb9654c",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm",
+        "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.aarch64.rpm",
+        "checksum": "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm",
+        "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+        "check_gpg": true
+      },
+      {
+        "name": "harfbuzz",
+        "epoch": 0,
+        "version": "2.8.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/harfbuzz-2.8.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7e7205d1d01f5c6e2635f3b80c2efc04440449482ac8024391af00007952c487",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.aarch64.rpm",
+        "checksum": "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell",
+        "epoch": 0,
+        "version": "1.7.0",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-1.7.0-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f878dd687438db0e07f2eb571246103ae0e136647242f0bf7f806ddd77e04a91",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-en",
+        "epoch": 0,
+        "version": "0.20140811.1",
+        "release": "20.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-0.20140811.1-20.fc35.noarch.rpm",
+        "checksum": "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-en-GB",
+        "epoch": 0,
+        "version": "0.20140811.1",
+        "release": "20.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-GB-0.20140811.1-20.fc35.noarch.rpm",
+        "checksum": "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-en-US",
+        "epoch": 0,
+        "version": "0.20140811.1",
+        "release": "20.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-US-0.20140811.1-20.fc35.noarch.rpm",
+        "checksum": "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-filesystem",
+        "epoch": 0,
+        "version": "1.7.0",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-filesystem-1.7.0-11.fc35.aarch64.rpm",
+        "checksum": "sha256:58b6c3272af7450868f9b6ee3e15f05e45104751cacaa4a22345983caaea14da",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "49",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/inih-49-4.fc35.aarch64.rpm",
+        "checksum": "sha256:39fd9eb8e77b430637602dc7cfce448e1792ace9cc9041c33f957b70d7b205c5",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm",
+        "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute-tc",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20210722",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm",
+        "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "15.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-en-3.0-15.fc35.noarch.rpm",
+        "checksum": "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-font-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "15.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-font-en-3.0-15.fc35.noarch.rpm",
+        "checksum": "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "15.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-en-3.0-15.fc35.noarch.rpm",
+        "checksum": "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
+        "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm",
+        "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm",
+        "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.aarch64.rpm",
+        "checksum": "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm",
+        "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.aarch64.rpm",
+        "checksum": "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "40.20210910cvs.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.aarch64.rpm",
+        "checksum": "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
+        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm",
+        "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.aarch64.rpm",
+        "checksum": "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.5.4",
+        "release": "2.rc3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.aarch64.rpm",
+        "checksum": "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libpng",
+        "epoch": 2,
+        "version": "1.6.37",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpng-1.6.37-11.fc35.aarch64.rpm",
+        "checksum": "sha256:aa00ac7809f0965b1e09a31862ccbe2cf11753ffc0c7575f2e40c96aa1c162d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.aarch64.rpm",
+        "checksum": "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
+        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm",
+        "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.aarch64.rpm",
+        "checksum": "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm",
+        "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm",
+        "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm",
+        "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.aarch64.rpm",
+        "checksum": "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.aarch64.rpm",
+        "checksum": "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
+        "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs78",
+        "epoch": 0,
+        "version": "78.15.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+        "check_gpg": true
+      },
+      {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.60.20160912git.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/net-tools-2.0-0.60.20160912git.fc35.aarch64.rpm",
+        "checksum": "sha256:fccda302546302309788e451ccaa2fb2abba72fa7b4184e82e1ff89830d8e306",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm",
+        "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm",
+        "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm",
+        "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/parted-3.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.aarch64.rpm",
+        "checksum": "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-attrs",
+        "epoch": 0,
+        "version": "21.2.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-attrs-21.2.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-audit-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5702b6d62b7efb235cf49b6174288053d345236107a43de33d6c80d9784d7140",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-babel",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-babel-2.9.1-4.fc35.noarch.rpm",
+        "checksum": "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cffi",
+        "epoch": 0,
+        "version": "1.14.6",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cffi-1.14.6-2.fc35.aarch64.rpm",
+        "checksum": "sha256:baf6082e248e7e84f3cb5ec2695f0dc9afeca615b3f39c60283902ab06d3f564",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-charset-normalizer",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-charset-normalizer-2.0.4-1.fc35.noarch.rpm",
+        "checksum": "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-configobj",
+        "epoch": 0,
+        "version": "5.0.6",
+        "release": "25.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-configobj-5.0.6-25.fc35.noarch.rpm",
+        "checksum": "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cryptography",
+        "epoch": 0,
+        "version": "3.4.7",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cryptography-3.4.7-5.fc35.aarch64.rpm",
+        "checksum": "sha256:b30f029f856c7ff5a9ef7c71b4f8d0858b96962c5523ee7c7bcc6313b13a3b0c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "7.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm",
+        "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.aarch64.rpm",
+        "checksum": "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-idna-3.2-1.fc35.noarch.rpm",
+        "checksum": "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jinja2",
+        "epoch": 0,
+        "version": "3.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jinja2-3.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpointer",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonpointer-2.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonschema",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonschema-3.2.0-12.fc35.noarch.rpm",
+        "checksum": "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt+crypto",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt+crypto-2.1.0-2.fc35.noarch.rpm",
+        "checksum": "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt-2.1.0-2.fc35.noarch.rpm",
+        "checksum": "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-markupsafe-2.0.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:375b89f3a452a62f3a02ada8971b14e854fa95b0d4cb9efb0449e5f85d6959c6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib+signedtoken",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "11.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch.rpm",
+        "checksum": "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "11.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib-3.0.2-11.fc35.noarch.rpm",
+        "checksum": "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ply",
+        "epoch": 0,
+        "version": "3.11",
+        "release": "13.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-ply-3.11-13.fc35.noarch.rpm",
+        "checksum": "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "27.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-prettytable-0.7.2-27.fc35.noarch.rpm",
+        "checksum": "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pycparser",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pycparser-2.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyserial",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyserial-3.4-12.fc35.noarch.rpm",
+        "checksum": "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "11.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pysocks-1.7.1-11.fc35.noarch.rpm",
+        "checksum": "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyyaml-5.4.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:469ec3ace1ffa4e3153c772d5ec5a65f8cb6e98d07405134c6b06545796e31c2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.4.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setools-4.4.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9605b7a0fbfb73c13a99ae45476c02cf3a0cde1b7edf137e90f8006863519a83",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setuptools-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "30.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm",
+        "checksum": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+        "check_gpg": true
+      },
+      {
+        "name": "rsync",
+        "epoch": 0,
+        "version": "3.2.3",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rsync-3.2.3-8.fc35.aarch64.rpm",
+        "checksum": "sha256:ac16154e7ad3440e137a65b0d9bc96942f257651aaf1f41298f15329a216c2c6",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm",
+        "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.4",
+        "release": "5",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/shim-aa64-15.4-5.aarch64.rpm",
+        "checksum": "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm",
+        "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm",
+        "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.12.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xfsprogs-5.12.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:fe1323e767bb5941d49d5b6565750614a2f649d5d34453e5ace10b3012b7a413",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm",
+        "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.aarch64.rpm",
+        "checksum": "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/checkpolicy-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:50d0b3571e271cce3c9f314f3fab80485b706c347cb6e9c710c28cf552c07ec5",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-0.21.2-3.fc35.noarch.rpm",
+        "checksum": "sha256:f4a4e83a8e1a1ba33bbd58ab720d2ba66bc76ef05101dd68d5ccd37a6e4e0b7e",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-issuegen",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-issuegen-0.21.2-3.fc35.noarch.rpm",
+        "checksum": "sha256:539d9ef12227716ff904a3e4605c765e6204ffd49a7a2d42762ccd5d921b341c",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-motdgen",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-motdgen-0.21.2-3.fc35.noarch.rpm",
+        "checksum": "sha256:228e6fbe3646a580e871378f374a1d7cebc4c592ea8262600e4b41a5c39b1169",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-profile",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-profile-0.21.2-3.fc35.noarch.rpm",
+        "checksum": "sha256:ef8f0dbb997b8f1e9a133a85f5e8a6b8579f23e95dbfd0604ac4d4809a759aa9",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-cloud",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-cloud-35-36.noarch.rpm",
+        "checksum": "sha256:360960053a501c11bc407c6c8a2f379b79bd249133b7c0ffaba54068385860e9",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-cloud",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-cloud-35-36.noarch.rpm",
+        "checksum": "sha256:4df41f9a100eca994899d304473024c37382220b4e3c0812c69701bfa450aa06",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.70.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-langpack-en",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:5437317aa8a5d94a9de9cd15d58399146783b4b96ee52a0a134c09b79933a8b0",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-extra",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-extra-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:ba4e1520f0409329c8d29839d510c4721f4475e6b17727485c95b634e61a9cb8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/less-590-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-atm-libs",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.aarch64.rpm",
+        "checksum": "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.5.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/mokutil-0.5.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.4.36",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm",
+        "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpatch",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "18.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-jsonpatch-1.21-18.fc35.noarch.rpm",
+        "checksum": "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b98735362bb79e3def6794fa863fe09a1c3690c8c7880e83f572c20860ba25ba",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9593a8e47f980af2a61700947cf6da75b409621598029854c05f1a4f5749d1cb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-policycoreutils-3.3-1.fc35.noarch.rpm",
+        "checksum": "sha256:22a906074aaab00a9c1bac318f9d10323566670fc7772c61e196574dfc63ee9b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyrsistent",
+        "epoch": 0,
+        "version": "0.18.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.18.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:fc05e6abb02bcb99462711686ddfc47783c0a5575bdb451a7fce641a3b809e8e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pytz",
+        "epoch": 0,
+        "version": "2021.3",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc35.noarch.rpm",
+        "checksum": "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.27.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-requests-2.27.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.7",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.26.7-2.fc35.noarch.rpm",
+        "checksum": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm",
+        "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm",
+        "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm",
+        "checksum": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f",
+        "check_gpg": true
+      }
+    ]
+  },
+  "image-info": {
+    "/etc/resolv.conf": [],
+    "boot-environment": {
+      "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+    },
+    "bootloader": "unknown",
+    "bootmenu": [
+      {
+        "grub_arg": "--unrestricted",
+        "grub_class": "fedora",
+        "grub_users": "$grub_users",
+        "initrd": "/boot/initramfs-5.15.13-200.fc35.aarch64.img",
+        "linux": "/boot/vmlinuz-5.15.13-200.fc35.aarch64",
+        "options": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8",
+        "title": "Fedora Linux (5.15.13-200.fc35.aarch64) 35 (Cloud Edition)",
+        "version": "5.15.13-200.fc35.aarch64"
+      }
+    ],
+    "chrony": {
+      "leapsectz": [
+        "right/UTC"
+      ],
+      "pool": [
+        "2.fedora.pool.ntp.org iburst"
+      ]
+    },
+    "cloud-init": {
+      "/etc/cloud": {
+        "cloud.cfg": {
+          "cloud_config_modules": [
+            "ssh-import-id",
+            "locale",
+            "set-passwords",
+            "spacewalk",
+            "yum-add-repo",
+            "ntp",
+            "timezone",
+            "disable-ec2-metadata",
+            "runcmd"
+          ],
+          "cloud_final_modules": [
+            "package-update-upgrade-install",
+            "puppet",
+            "chef",
+            "mcollective",
+            "salt-minion",
+            "reset_rmc",
+            "refresh_rmc_and_interface",
+            "rightscale_userdata",
+            "scripts-vendor",
+            "scripts-per-once",
+            "scripts-per-boot",
+            "scripts-per-instance",
+            "scripts-user",
+            "ssh-authkey-fingerprints",
+            "keys-to-console",
+            "phone-home",
+            "final-message",
+            "power-state-change"
+          ],
+          "cloud_init_modules": [
+            "migrator",
+            "seed_random",
+            "bootcmd",
+            "write-files",
+            "growpart",
+            "resizefs",
+            "disk_setup",
+            "mounts",
+            "set_hostname",
+            "update_hostname",
+            "update_etc_hosts",
+            "ca-certs",
+            "rsyslog",
+            "users-groups",
+            "ssh"
+          ],
+          "disable_root": true,
+          "mount_default_fields": [
+            null,
+            null,
+            "auto",
+            "defaults,nofail",
+            "0",
+            "2"
+          ],
+          "preserve_hostname": false,
+          "resize_rootfs_tmp": "/dev",
+          "ssh_pwauth": 0,
+          "system_info": {
+            "default_user": {
+              "gecos": "fedora Cloud User",
+              "groups": [
+                "wheel",
+                "adm",
+                "systemd-journal"
+              ],
+              "lock_passwd": true,
+              "name": "fedora",
+              "shell": "/bin/bash",
+              "sudo": [
+                "ALL=(ALL) NOPASSWD:ALL"
+              ]
+            },
+            "distro": "fedora",
+            "paths": {
+              "cloud_dir": "/var/lib/cloud/",
+              "templates_dir": "/etc/cloud/templates/"
+            },
+            "ssh_svcname": "sshd"
+          },
+          "users": [
+            "default"
+          ]
+        }
+      },
+      "/etc/cloud/cloud.cfg.d": {
+        "05_logging.cfg": {
+          "_log": [
+            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
+            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
+          ],
+          "log_cfgs": [
+            [
+              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
+            ]
+          ],
+          "output": {
+            "all": "| tee -a /var/log/cloud-init-output.log"
+          }
+        }
+      }
+    },
+    "default-target": "graphical.target",
+    "dracut": {
+      "/usr/lib/dracut/dracut.conf.d": {
+        "01-dist.conf": {
+          "dbus": "/usr/share/dbus-1",
+          "dbusconfdir": "/etc/dbus-1",
+          "dbusinterfaces": "/usr/share/dbus-1/interfaces",
+          "dbusinterfacesconfdir": "/etc/dbus-1/interfaces",
+          "dbusservices": "/usr/share/dbus-1/services",
+          "dbusservicesconfdir": "/etc/dbus-1/services",
+          "dbussession": "/usr/share/dbus-1/session.d",
+          "dbussessionconfdir": "/etc/dbus-1/session.d",
+          "dbussystem": "confdir/etc/dbus-1/system.d",
+          "dbussystemservices": "/usr/share/dbus-1/system-services",
+          "dbussystemservicesconfdir": "/etc/dbus-1/system-services",
+          "early_microcode": "yes",
+          "environment": "/usr/lib/environment.d",
+          "environmentconfdir": "/etc/environment.d",
+          "hostonly": "yes",
+          "hostonly_cmdline": "no",
+          "i18n_default_font": "eurlatgr",
+          "i18n_install_all": "yes",
+          "i18n_vars": "/etc/sysconfig/keyboard:KEYTABLE-KEYMAP /etc/sysconfig/i18n:SYSFONT-FONT,FONTACM-FONT_MAP,FONT_UNIMAP",
+          "install_optional_items": " vi /etc/virc ps grep cat rm ",
+          "prefix": "/",
+          "reproducible": "yes",
+          "stdloglvl": "3",
+          "sysctlconfdir": "/etc/sysctl.d",
+          "sysctld": "/usr/lib/sysctl.d",
+          "sysloglvl": "5",
+          "systemdcatalog": "/usr/lib/systemd/catalog",
+          "systemdntpunits": "/usr/lib/systemd/ntp-units.d",
+          "systemdntpunitsconfdir": "/etc/systemd/ntp-units.d",
+          "systemdportable": "/usr/lib/systemd/portable",
+          "systemdportableconfdir": "/etc/systemd/portable",
+          "systemdsystemconfdir": "/etc/systemd/system",
+          "systemdsystemunitdir": "/usr/lib/systemd/system",
+          "systemduser": "/usr/lib/systemd/user",
+          "systemduserconfdir": "/etc/systemd/user",
+          "systemdutilconfdir": "/etc/systemd",
+          "systemdutildir": "/usr/lib/systemd",
+          "sysusers": "/usr/lib/sysusers.d",
+          "sysusersconfdir": "/etc/sysusers.d",
+          "udevdir": "/usr/lib/udev"
+        },
+        "02-generic-image.conf": {
+          "hostonly": "no"
+        }
+      }
+    },
+    "fstab": [
+      [
+        "UUID=46BB-8120",
+        "/boot/efi",
+        "vfat",
+        "umask=0077,shortname=winnt",
+        "0",
+        "2"
+      ],
+      [
+        "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+        "/",
+        "ext4",
+        "defaults",
+        "1",
+        "1"
+      ]
+    ],
+    "groups": [
+      "adm:x:4:",
+      "audio:x:63:",
+      "bin:x:1:",
+      "cdrom:x:11:",
+      "chrony:x:993:",
+      "daemon:x:2:",
+      "dbus:x:81:",
+      "dialout:x:18:",
+      "disk:x:6:",
+      "floppy:x:19:",
+      "ftp:x:50:",
+      "games:x:20:",
+      "input:x:104:",
+      "kmem:x:9:",
+      "kvm:x:36:",
+      "lock:x:54:",
+      "lp:x:7:",
+      "mail:x:12:",
+      "man:x:15:",
+      "mem:x:8:",
+      "nobody:x:65534:",
+      "polkitd:x:994:",
+      "redhat:x:1000:",
+      "render:x:105:",
+      "root:x:0:",
+      "sgx:x:106:",
+      "ssh_keys:x:996:",
+      "sshd:x:74:",
+      "sys:x:3:",
+      "systemd-coredump:x:997:",
+      "systemd-journal:x:190:",
+      "systemd-network:x:192:",
+      "systemd-oom:x:999:",
+      "systemd-resolve:x:193:",
+      "systemd-timesync:x:998:",
+      "tape:x:33:",
+      "tss:x:59:",
+      "tty:x:5:",
+      "unbound:x:995:",
+      "users:x:100:",
+      "utempter:x:35:",
+      "utmp:x:22:",
+      "video:x:39:",
+      "wheel:x:10:"
+    ],
+    "hostname": "localhost.localdomain",
+    "hosts": [
+      "127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4",
+      "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
+    ],
+    "image-format": {
+      "compat": "1.1",
+      "type": "qcow2"
+    },
+    "locale": {
+      "LANG": "en_US"
+    },
+    "machine-id": "",
+    "os-release": {
+      "ANSI_COLOR": "0;38;2;60;110;180",
+      "BUG_REPORT_URL": "https://bugzilla.redhat.com/",
+      "CPE_NAME": "cpe:/o:fedoraproject:fedora:35",
+      "DOCUMENTATION_URL": "https://docs.fedoraproject.org/en-US/fedora/f35/system-administrators-guide/",
+      "HOME_URL": "https://fedoraproject.org/",
+      "ID": "fedora",
+      "LOGO": "fedora-logo-icon",
+      "NAME": "Fedora Linux",
+      "PLATFORM_ID": "platform:f35",
+      "PRETTY_NAME": "Fedora Linux 35 (Cloud Edition)",
+      "PRIVACY_POLICY_URL": "https://fedoraproject.org/wiki/Legal:PrivacyPolicy",
+      "REDHAT_BUGZILLA_PRODUCT": "Fedora",
+      "REDHAT_BUGZILLA_PRODUCT_VERSION": "35",
+      "REDHAT_SUPPORT_PRODUCT": "Fedora",
+      "REDHAT_SUPPORT_PRODUCT_VERSION": "35",
+      "SUPPORT_URL": "https://ask.fedoraproject.org/",
+      "VARIANT": "Cloud Edition",
+      "VARIANT_ID": "cloud",
+      "VERSION": "35 (Cloud Edition)",
+      "VERSION_CODENAME": "",
+      "VERSION_ID": "35"
+    },
+    "packages": [
+      "NetworkManager-1.32.12-2.fc35.aarch64",
+      "NetworkManager-libnm-1.32.12-2.fc35.aarch64",
+      "acl-2.3.1-2.fc35.aarch64",
+      "alternatives-1.19-1.fc35.aarch64",
+      "audit-3.0.6-1.fc35.aarch64",
+      "audit-libs-3.0.6-1.fc35.aarch64",
+      "basesystem-11-12.fc35.noarch",
+      "bash-5.1.8-2.fc35.aarch64",
+      "bzip2-libs-1.0.8-9.fc35.aarch64",
+      "c-ares-1.17.2-1.fc35.aarch64",
+      "ca-certificates-2021.2.52-1.0.fc35.noarch",
+      "checkpolicy-3.3-1.fc35.aarch64",
+      "chkconfig-1.19-1.fc35.aarch64",
+      "chrony-4.1-3.fc35.aarch64",
+      "cloud-init-20.4-7.fc35.noarch",
+      "cloud-utils-growpart-0.31-9.fc35.noarch",
+      "console-login-helper-messages-0.21.2-3.fc35.noarch",
+      "console-login-helper-messages-issuegen-0.21.2-3.fc35.noarch",
+      "console-login-helper-messages-motdgen-0.21.2-3.fc35.noarch",
+      "console-login-helper-messages-profile-0.21.2-3.fc35.noarch",
+      "coreutils-8.32-31.fc35.aarch64",
+      "coreutils-common-8.32-31.fc35.aarch64",
+      "cpio-2.13-11.fc35.aarch64",
+      "cracklib-2.9.6-27.fc35.aarch64",
+      "cracklib-dicts-2.9.6-27.fc35.aarch64",
+      "crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch",
+      "crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch",
+      "cryptsetup-libs-2.4.2-1.fc35.aarch64",
+      "curl-7.79.1-1.fc35.aarch64",
+      "cyrus-sasl-lib-2.1.27-13.fc35.aarch64",
+      "dbus-1.12.20-5.fc35.aarch64",
+      "dbus-broker-29-4.fc35.aarch64",
+      "dbus-common-1.12.20-5.fc35.noarch",
+      "dbus-libs-1.12.20-5.fc35.aarch64",
+      "dejavu-sans-fonts-2.37-17.fc35.noarch",
+      "deltarpm-3.6.2-10.fc35.aarch64",
+      "device-mapper-1.02.175-6.fc35.aarch64",
+      "device-mapper-libs-1.02.175-6.fc35.aarch64",
+      "dhcp-client-4.4.2-16.b1.fc35.aarch64",
+      "dhcp-common-4.4.2-16.b1.fc35.noarch",
+      "diffutils-3.8-1.fc35.aarch64",
+      "dnf-4.9.0-1.fc35.noarch",
+      "dnf-data-4.9.0-1.fc35.noarch",
+      "dnf-plugins-core-4.0.24-1.fc35.noarch",
+      "dracut-055-6.fc35.aarch64",
+      "dracut-config-generic-055-6.fc35.aarch64",
+      "e2fsprogs-1.46.3-1.fc35.aarch64",
+      "e2fsprogs-libs-1.46.3-1.fc35.aarch64",
+      "efi-filesystem-5-4.fc35.noarch",
+      "efibootmgr-16-11.fc35.aarch64",
+      "efivar-libs-37-17.fc35.aarch64",
+      "elfutils-debuginfod-client-0.186-1.fc35.aarch64",
+      "elfutils-default-yama-scope-0.186-1.fc35.noarch",
+      "elfutils-libelf-0.186-1.fc35.aarch64",
+      "elfutils-libs-0.186-1.fc35.aarch64",
+      "expat-2.4.1-2.fc35.aarch64",
+      "fedora-gpg-keys-35-1.noarch",
+      "fedora-release-cloud-35-36.noarch",
+      "fedora-release-common-35-36.noarch",
+      "fedora-release-identity-cloud-35-36.noarch",
+      "fedora-repos-35-1.noarch",
+      "fedora-repos-modular-35-1.noarch",
+      "file-5.40-9.fc35.aarch64",
+      "file-libs-5.40-9.fc35.aarch64",
+      "filesystem-3.14-7.fc35.aarch64",
+      "findutils-4.8.0-4.fc35.aarch64",
+      "fonts-filesystem-2.0.5-6.fc35.noarch",
+      "freetype-2.11.0-1.fc35.aarch64",
+      "fuse-libs-2.9.9-13.fc35.aarch64",
+      "gawk-5.1.0-4.fc35.aarch64",
+      "gawk-all-langpacks-5.1.0-4.fc35.aarch64",
+      "gdbm-libs-1.22-1.fc35.aarch64",
+      "gettext-0.21-8.fc35.aarch64",
+      "gettext-libs-0.21-8.fc35.aarch64",
+      "glib2-2.70.2-1.fc35.aarch64",
+      "glibc-2.34-11.fc35.aarch64",
+      "glibc-common-2.34-11.fc35.aarch64",
+      "glibc-gconv-extra-2.34-11.fc35.aarch64",
+      "glibc-langpack-en-2.34-11.fc35.aarch64",
+      "gmp-6.2.0-7.fc35.aarch64",
+      "gnupg2-2.3.4-1.fc35.aarch64",
+      "gnupg2-smime-2.3.4-1.fc35.aarch64",
+      "gnutls-3.7.2-2.fc35.aarch64",
+      "gpg-pubkey-9867c58f-601c49ca",
+      "gpgme-1.15.1-6.fc35.aarch64",
+      "graphite2-1.3.14-8.fc35.aarch64",
+      "grep-3.6-4.fc35.aarch64",
+      "groff-base-1.22.4-8.fc35.aarch64",
+      "grub2-common-2.06-10.fc35.noarch",
+      "grub2-efi-aa64-2.06-10.fc35.aarch64",
+      "grub2-tools-2.06-10.fc35.aarch64",
+      "grub2-tools-extra-2.06-10.fc35.aarch64",
+      "grub2-tools-minimal-2.06-10.fc35.aarch64",
+      "grubby-8.40-55.fc35.aarch64",
+      "gzip-1.10-5.fc35.aarch64",
+      "harfbuzz-2.8.2-2.fc35.aarch64",
+      "hostname-3.23-5.fc35.aarch64",
+      "hunspell-1.7.0-11.fc35.aarch64",
+      "hunspell-en-0.20140811.1-20.fc35.noarch",
+      "hunspell-en-GB-0.20140811.1-20.fc35.noarch",
+      "hunspell-en-US-0.20140811.1-20.fc35.noarch",
+      "hunspell-filesystem-1.7.0-11.fc35.aarch64",
+      "ima-evm-utils-1.3.2-3.fc35.aarch64",
+      "inih-49-4.fc35.aarch64",
+      "initscripts-10.11-1.fc35.aarch64",
+      "initscripts-service-10.11-1.fc35.noarch",
+      "ipcalc-1.0.1-2.fc35.aarch64",
+      "iproute-5.13.0-2.fc35.aarch64",
+      "iproute-tc-5.13.0-2.fc35.aarch64",
+      "iptables-legacy-libs-1.8.7-13.fc35.aarch64",
+      "iptables-libs-1.8.7-13.fc35.aarch64",
+      "iputils-20210722-1.fc35.aarch64",
+      "json-c-0.15-2.fc35.aarch64",
+      "kbd-2.4.0-8.fc35.aarch64",
+      "kbd-misc-2.4.0-8.fc35.noarch",
+      "kernel-5.15.13-200.fc35.aarch64",
+      "kernel-core-5.15.13-200.fc35.aarch64",
+      "kernel-modules-5.15.13-200.fc35.aarch64",
+      "keyutils-libs-1.6.1-3.fc35.aarch64",
+      "kmod-29-4.fc35.aarch64",
+      "kmod-libs-29-4.fc35.aarch64",
+      "kpartx-0.8.6-5.fc35.aarch64",
+      "krb5-libs-1.19.2-2.fc35.aarch64",
+      "langpacks-core-en-3.0-15.fc35.noarch",
+      "langpacks-core-font-en-3.0-15.fc35.noarch",
+      "langpacks-en-3.0-15.fc35.noarch",
+      "less-590-2.fc35.aarch64",
+      "libacl-2.3.1-2.fc35.aarch64",
+      "libarchive-3.5.2-2.fc35.aarch64",
+      "libargon2-20171227-7.fc35.aarch64",
+      "libassuan-2.5.5-3.fc35.aarch64",
+      "libattr-2.5.1-3.fc35.aarch64",
+      "libbasicobjects-0.1.1-48.fc35.aarch64",
+      "libblkid-2.37.2-1.fc35.aarch64",
+      "libbrotli-1.0.9-6.fc35.aarch64",
+      "libcap-2.48-3.fc35.aarch64",
+      "libcap-ng-0.8.2-8.fc35.aarch64",
+      "libcbor-0.7.0-4.fc35.aarch64",
+      "libcollection-0.7.0-48.fc35.aarch64",
+      "libcom_err-1.46.3-1.fc35.aarch64",
+      "libcomps-0.1.18-1.fc35.aarch64",
+      "libcurl-7.79.1-1.fc35.aarch64",
+      "libdb-5.3.28-50.fc35.aarch64",
+      "libdhash-0.5.0-48.fc35.aarch64",
+      "libdnf-0.64.0-1.fc35.aarch64",
+      "libeconf-0.4.0-2.fc35.aarch64",
+      "libedit-3.1-40.20210910cvs.fc35.aarch64",
+      "libevent-2.1.12-4.fc35.aarch64",
+      "libfdisk-2.37.2-1.fc35.aarch64",
+      "libffi-3.1-29.fc35.aarch64",
+      "libfido2-1.8.0-1.fc35.aarch64",
+      "libfsverity-1.4-6.fc35.aarch64",
+      "libgcc-11.2.1-7.fc35.aarch64",
+      "libgcrypt-1.9.4-1.fc35.aarch64",
+      "libgomp-11.2.1-7.fc35.aarch64",
+      "libgpg-error-1.43-1.fc35.aarch64",
+      "libibverbs-38.0-1.fc35.aarch64",
+      "libidn2-2.3.2-3.fc35.aarch64",
+      "libini_config-1.3.1-48.fc35.aarch64",
+      "libkcapi-1.3.1-3.fc35.aarch64",
+      "libkcapi-hmaccalc-1.3.1-3.fc35.aarch64",
+      "libksba-1.6.0-2.fc35.aarch64",
+      "libldb-2.4.1-1.fc35.aarch64",
+      "libmaxminddb-1.6.0-1.fc35.aarch64",
+      "libmnl-1.0.4-14.fc35.aarch64",
+      "libmodulemd-2.13.0-3.fc35.aarch64",
+      "libmount-2.37.2-1.fc35.aarch64",
+      "libndp-1.8-2.fc35.aarch64",
+      "libnetfilter_conntrack-1.0.8-3.fc35.aarch64",
+      "libnfnetlink-1.0.1-20.fc35.aarch64",
+      "libnfsidmap-2.5.4-2.rc3.fc35.aarch64",
+      "libnghttp2-1.45.1-1.fc35.aarch64",
+      "libnl3-3.5.0-8.fc35.aarch64",
+      "libnsl2-1.3.0-4.fc35.aarch64",
+      "libpath_utils-0.2.1-48.fc35.aarch64",
+      "libpcap-1.10.1-2.fc35.aarch64",
+      "libpipeline-1.5.3-3.fc35.aarch64",
+      "libpng-1.6.37-11.fc35.aarch64",
+      "libpsl-0.21.1-4.fc35.aarch64",
+      "libpwquality-1.4.4-6.fc35.aarch64",
+      "libref_array-0.1.5-48.fc35.aarch64",
+      "librepo-1.14.2-1.fc35.aarch64",
+      "libreport-filesystem-2.15.2-6.fc35.noarch",
+      "libseccomp-2.5.3-1.fc35.aarch64",
+      "libsecret-0.20.4-3.fc35.aarch64",
+      "libselinux-3.3-1.fc35.aarch64",
+      "libselinux-utils-3.3-1.fc35.aarch64",
+      "libsemanage-3.3-1.fc35.aarch64",
+      "libsepol-3.3-2.fc35.aarch64",
+      "libsigsegv-2.13-3.fc35.aarch64",
+      "libsmartcols-2.37.2-1.fc35.aarch64",
+      "libsolv-0.7.19-3.fc35.aarch64",
+      "libss-1.46.3-1.fc35.aarch64",
+      "libssh-0.9.6-1.fc35.aarch64",
+      "libssh-config-0.9.6-1.fc35.noarch",
+      "libsss_autofs-2.6.1-1.fc35.aarch64",
+      "libsss_certmap-2.6.1-1.fc35.aarch64",
+      "libsss_idmap-2.6.1-1.fc35.aarch64",
+      "libsss_nss_idmap-2.6.1-1.fc35.aarch64",
+      "libsss_sudo-2.6.1-1.fc35.aarch64",
+      "libstdc++-11.2.1-7.fc35.aarch64",
+      "libtalloc-2.3.3-2.fc35.aarch64",
+      "libtasn1-4.16.0-6.fc35.aarch64",
+      "libtdb-1.4.4-3.fc35.aarch64",
+      "libtevent-0.11.0-1.fc35.aarch64",
+      "libtirpc-1.3.2-1.fc35.aarch64",
+      "libunistring-0.9.10-14.fc35.aarch64",
+      "libusb1-1.0.24-4.fc35.aarch64",
+      "libuser-0.63-7.fc35.aarch64",
+      "libutempter-1.2.1-5.fc35.aarch64",
+      "libuuid-2.37.2-1.fc35.aarch64",
+      "libverto-0.3.2-2.fc35.aarch64",
+      "libxcrypt-4.4.27-1.fc35.aarch64",
+      "libxkbcommon-1.3.1-1.fc35.aarch64",
+      "libxml2-2.9.12-6.fc35.aarch64",
+      "libyaml-0.2.5-6.fc35.aarch64",
+      "libzstd-1.5.1-4.fc35.aarch64",
+      "linux-atm-libs-2.5.1-30.fc35.aarch64",
+      "linux-firmware-20211216-127.fc35.noarch",
+      "linux-firmware-whence-20211216-127.fc35.noarch",
+      "lmdb-libs-0.9.29-2.fc35.aarch64",
+      "lua-libs-5.4.3-2.fc35.aarch64",
+      "lz4-libs-1.9.3-3.fc35.aarch64",
+      "man-db-2.9.4-2.fc35.aarch64",
+      "memstrack-0.2.4-1.fc35.aarch64",
+      "mkpasswd-5.5.10-2.fc35.aarch64",
+      "mokutil-0.5.0-1.fc35.aarch64",
+      "mozjs78-78.15.0-1.fc35.aarch64",
+      "mpdecimal-2.5.1-2.fc35.aarch64",
+      "mpfr-4.1.0-8.fc35.aarch64",
+      "ncurses-6.2-8.20210508.fc35.aarch64",
+      "ncurses-base-6.2-8.20210508.fc35.noarch",
+      "ncurses-libs-6.2-8.20210508.fc35.aarch64",
+      "net-tools-2.0-0.60.20160912git.fc35.aarch64",
+      "nettle-3.7.3-2.fc35.aarch64",
+      "npth-1.6-7.fc35.aarch64",
+      "openldap-2.4.59-3.fc35.aarch64",
+      "openssh-8.7p1-3.fc35.aarch64",
+      "openssh-clients-8.7p1-3.fc35.aarch64",
+      "openssh-server-8.7p1-3.fc35.aarch64",
+      "openssl-libs-1.1.1l-2.fc35.aarch64",
+      "openssl-pkcs11-0.4.11-4.fc35.aarch64",
+      "os-prober-1.77-8.fc35.aarch64",
+      "p11-kit-0.23.22-4.fc35.aarch64",
+      "p11-kit-trust-0.23.22-4.fc35.aarch64",
+      "pam-1.5.2-5.fc35.aarch64",
+      "parted-3.4-6.fc35.aarch64",
+      "passwd-0.80-11.fc35.aarch64",
+      "pcre-8.45-1.fc35.aarch64",
+      "pcre2-10.37-4.fc35.aarch64",
+      "pcre2-syntax-10.37-4.fc35.noarch",
+      "pcsc-lite-1.9.5-1.fc35.aarch64",
+      "pcsc-lite-ccid-1.4.36-2.fc35.aarch64",
+      "pcsc-lite-libs-1.9.5-1.fc35.aarch64",
+      "pigz-2.5-2.fc35.aarch64",
+      "pinentry-1.2.0-1.fc35.aarch64",
+      "policycoreutils-3.3-1.fc35.aarch64",
+      "polkit-0.120-1.fc35.aarch64",
+      "polkit-libs-0.120-1.fc35.aarch64",
+      "polkit-pkla-compat-0.1-20.fc35.aarch64",
+      "popt-1.18-6.fc35.aarch64",
+      "procps-ng-3.3.17-3.fc35.aarch64",
+      "protobuf-c-1.4.0-1.fc35.aarch64",
+      "psmisc-23.4-2.fc35.aarch64",
+      "publicsuffix-list-dafsa-20210518-2.fc35.noarch",
+      "python-pip-wheel-21.2.3-4.fc35.noarch",
+      "python-setuptools-wheel-57.4.0-1.fc35.noarch",
+      "python-unversioned-command-3.10.1-2.fc35.noarch",
+      "python3-3.10.1-2.fc35.aarch64",
+      "python3-attrs-21.2.0-4.fc35.noarch",
+      "python3-audit-3.0.6-1.fc35.aarch64",
+      "python3-babel-2.9.1-4.fc35.noarch",
+      "python3-cffi-1.14.6-2.fc35.aarch64",
+      "python3-charset-normalizer-2.0.4-1.fc35.noarch",
+      "python3-configobj-5.0.6-25.fc35.noarch",
+      "python3-cryptography-3.4.7-5.fc35.aarch64",
+      "python3-dateutil-2.8.1-7.fc35.noarch",
+      "python3-dbus-1.2.18-2.fc35.aarch64",
+      "python3-distro-1.6.0-1.fc35.noarch",
+      "python3-dnf-4.9.0-1.fc35.noarch",
+      "python3-dnf-plugins-core-4.0.24-1.fc35.noarch",
+      "python3-gpg-1.15.1-6.fc35.aarch64",
+      "python3-hawkey-0.64.0-1.fc35.aarch64",
+      "python3-idna-3.2-1.fc35.noarch",
+      "python3-jinja2-3.0.1-2.fc35.noarch",
+      "python3-jsonpatch-1.21-18.fc35.noarch",
+      "python3-jsonpointer-2.0-4.fc35.noarch",
+      "python3-jsonschema-3.2.0-12.fc35.noarch",
+      "python3-jwt+crypto-2.1.0-2.fc35.noarch",
+      "python3-jwt-2.1.0-2.fc35.noarch",
+      "python3-libcomps-0.1.18-1.fc35.aarch64",
+      "python3-libdnf-0.64.0-1.fc35.aarch64",
+      "python3-libs-3.10.1-2.fc35.aarch64",
+      "python3-libselinux-3.3-1.fc35.aarch64",
+      "python3-libsemanage-3.3-1.fc35.aarch64",
+      "python3-markupsafe-2.0.0-2.fc35.aarch64",
+      "python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch",
+      "python3-oauthlib-3.0.2-11.fc35.noarch",
+      "python3-ply-3.11-13.fc35.noarch",
+      "python3-policycoreutils-3.3-1.fc35.noarch",
+      "python3-prettytable-0.7.2-27.fc35.noarch",
+      "python3-pycparser-2.20-5.fc35.noarch",
+      "python3-pyrsistent-0.18.0-8.fc35.aarch64",
+      "python3-pyserial-3.4-12.fc35.noarch",
+      "python3-pysocks-1.7.1-11.fc35.noarch",
+      "python3-pytz-2021.3-1.fc35.noarch",
+      "python3-pyyaml-5.4.1-4.fc35.aarch64",
+      "python3-requests-2.27.0-1.fc35.noarch",
+      "python3-rpm-4.17.0-1.fc35.aarch64",
+      "python3-setools-4.4.0-3.fc35.aarch64",
+      "python3-setuptools-57.4.0-1.fc35.noarch",
+      "python3-six-1.16.0-4.fc35.noarch",
+      "python3-unbound-1.13.2-1.fc35.aarch64",
+      "python3-urllib3-1.26.7-2.fc35.noarch",
+      "qrencode-libs-4.1.1-1.fc35.aarch64",
+      "readline-8.1-3.fc35.aarch64",
+      "rootfiles-8.1-30.fc35.noarch",
+      "rpm-4.17.0-1.fc35.aarch64",
+      "rpm-build-libs-4.17.0-1.fc35.aarch64",
+      "rpm-libs-4.17.0-1.fc35.aarch64",
+      "rpm-plugin-selinux-4.17.0-1.fc35.aarch64",
+      "rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64",
+      "rpm-sign-libs-4.17.0-1.fc35.aarch64",
+      "rsync-3.2.3-8.fc35.aarch64",
+      "sed-4.8-8.fc35.aarch64",
+      "selinux-policy-35.8-1.fc35.noarch",
+      "selinux-policy-targeted-35.8-1.fc35.noarch",
+      "setup-2.13.9.1-2.fc35.noarch",
+      "shadow-utils-4.9-8.fc35.aarch64",
+      "shim-aa64-15.4-5.aarch64",
+      "sqlite-libs-3.36.0-3.fc35.aarch64",
+      "sssd-client-2.6.1-1.fc35.aarch64",
+      "sssd-common-2.6.1-1.fc35.aarch64",
+      "sssd-kcm-2.6.1-1.fc35.aarch64",
+      "sssd-nfs-idmap-2.6.1-1.fc35.aarch64",
+      "sudo-1.9.7p2-2.fc35.aarch64",
+      "sudo-python-plugin-1.9.7p2-2.fc35.aarch64",
+      "systemd-249.7-2.fc35.aarch64",
+      "systemd-libs-249.7-2.fc35.aarch64",
+      "systemd-networkd-249.7-2.fc35.aarch64",
+      "systemd-oomd-defaults-249.7-2.fc35.noarch",
+      "systemd-pam-249.7-2.fc35.aarch64",
+      "systemd-resolved-249.7-2.fc35.aarch64",
+      "systemd-udev-249.7-2.fc35.aarch64",
+      "tar-1.34-2.fc35.aarch64",
+      "tpm2-tss-3.1.0-3.fc35.aarch64",
+      "trousers-0.3.15-4.fc35.aarch64",
+      "trousers-lib-0.3.15-4.fc35.aarch64",
+      "tzdata-2021e-1.fc35.noarch",
+      "unbound-libs-1.13.2-1.fc35.aarch64",
+      "util-linux-2.37.2-1.fc35.aarch64",
+      "util-linux-core-2.37.2-1.fc35.aarch64",
+      "vim-data-8.2.4006-1.fc35.noarch",
+      "vim-minimal-8.2.4006-1.fc35.aarch64",
+      "which-2.21-27.fc35.aarch64",
+      "whois-nls-5.5.10-2.fc35.noarch",
+      "xfsprogs-5.12.0-2.fc35.aarch64",
+      "xkeyboard-config-2.33-2.fc35.noarch",
+      "xz-5.2.5-7.fc35.aarch64",
+      "xz-libs-5.2.5-7.fc35.aarch64",
+      "yum-4.9.0-1.fc35.noarch",
+      "zchunk-libs-1.1.15-2.fc35.aarch64",
+      "zlib-1.2.11-30.fc35.aarch64"
+    ],
+    "partition-table": "gpt",
+    "partition-table-id": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
+    "partitions": [
+      {
+        "bootable": false,
+        "fstype": "vfat",
+        "label": "EFI-SYSTEM",
+        "partuuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
+        "size": 498073600,
+        "start": 1048576,
+        "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+        "uuid": "46BB-8120"
+      },
+      {
+        "bootable": false,
+        "fstype": "ext4",
+        "label": null,
+        "partuuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
+        "size": 1647296000,
+        "start": 500170752,
+        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+        "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+      }
+    ],
+    "passwd": [
+      "adm:x:3:4:adm:/var/adm:/sbin/nologin",
+      "bin:x:1:1:bin:/bin:/sbin/nologin",
+      "chrony:x:994:993::/var/lib/chrony:/sbin/nologin",
+      "daemon:x:2:2:daemon:/sbin:/sbin/nologin",
+      "dbus:x:81:81:System message bus:/:/sbin/nologin",
+      "ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin",
+      "games:x:12:100:games:/usr/games:/sbin/nologin",
+      "halt:x:7:0:halt:/sbin:/sbin/halt",
+      "lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin",
+      "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
+      "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
+      "operator:x:11:0:operator:/root:/sbin/nologin",
+      "polkitd:x:995:994:User for polkitd:/:/sbin/nologin",
+      "redhat:x:1000:1000::/home/redhat:/bin/bash",
+      "root:x:0:0:root:/root:/bin/bash",
+      "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
+      "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
+      "sync:x:5:0:sync:/sbin:/bin/sync",
+      "systemd-coredump:x:997:997:systemd Core Dumper:/:/usr/sbin/nologin",
+      "systemd-network:x:192:192:systemd Network Management:/:/usr/sbin/nologin",
+      "systemd-oom:x:999:999:systemd Userspace OOM Killer:/:/usr/sbin/nologin",
+      "systemd-resolve:x:193:193:systemd Resolver:/:/usr/sbin/nologin",
+      "systemd-timesync:x:998:998:systemd Time Synchronization:/:/usr/sbin/nologin",
+      "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
+      "unbound:x:996:995:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
+    ],
+    "rpm-verify": {
+      "changed": {
+        "/boot/efi/EFI": ".M.......",
+        "/boot/efi/EFI/BOOT/BOOTAA64.EFI": ".......T.",
+        "/boot/efi/EFI/BOOT/fbaa64.efi": ".......T.",
+        "/boot/efi/EFI/fedora/BOOTAA64.CSV": ".......T.",
+        "/boot/efi/EFI/fedora/grubaa64.efi": ".......T.",
+        "/boot/efi/EFI/fedora/mmaa64.efi": ".......T.",
+        "/boot/efi/EFI/fedora/shim.efi": ".......T.",
+        "/boot/efi/EFI/fedora/shimaa64.efi": ".......T.",
+        "/etc/machine-id": ".M.......",
+        "/etc/udev/hwdb.bin": ".M.......",
+        "/proc": ".M.......",
+        "/sys": ".M.......",
+        "/var/log/lastlog": ".M....G.."
+      },
+      "missing": []
+    },
+    "selinux": {
+      "context-mismatch": [
+        {
+          "actual": "system_u:object_r:unlabeled_t:s0",
+          "expected": "system_u:object_r:lost_found_t:s0",
+          "filename": "/lost+found"
+        }
+      ],
+      "policy": {
+        "SELINUX": "enforcing",
+        "SELINUXTYPE": "targeted"
+      }
+    },
+    "services-disabled": [
+      "arp-ethers.service",
+      "chrony-wait.service",
+      "console-getty.service",
+      "console-login-helper-messages-gensnippet-os-release.service",
+      "console-login-helper-messages-gensnippet-ssh-keys.service",
+      "debug-shell.service",
+      "exit.target",
+      "halt.target",
+      "kexec.target",
+      "loadmodules.service",
+      "man-db-restart-cache-update.service",
+      "nis-domainname.service",
+      "poweroff.target",
+      "proc-sys-fs-binfmt_misc.mount",
+      "rdisc.service",
+      "remote-cryptsetup.target",
+      "remote-veritysetup.target",
+      "runlevel0.target",
+      "selinux-check-proper-disable.service",
+      "serial-getty@.service",
+      "sshd-keygen@.service",
+      "sshd.socket",
+      "sssd-autofs.socket",
+      "sssd-nss.socket",
+      "sssd-pac.socket",
+      "sssd-pam-priv.socket",
+      "sssd-pam.socket",
+      "sssd-ssh.socket",
+      "sssd-sudo.socket",
+      "systemd-boot-check-no-failures.service",
+      "systemd-network-generator.service",
+      "systemd-networkd-wait-online.service",
+      "systemd-networkd.service",
+      "systemd-networkd.socket",
+      "systemd-pstore.service",
+      "systemd-sysext.service",
+      "systemd-time-wait-sync.service",
+      "systemd-timesyncd.service",
+      "tcsd.service"
+    ],
+    "services-enabled": [
+      "NetworkManager-dispatcher.service",
+      "NetworkManager-wait-online.service",
+      "NetworkManager.service",
+      "auditd.service",
+      "autovt@.service",
+      "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
+      "ctrl-alt-del.target",
+      "dbus-broker.service",
+      "dbus-org.freedesktop.home1.service",
+      "dbus-org.freedesktop.nm-dispatcher.service",
+      "dbus-org.freedesktop.oom1.service",
+      "dbus-org.freedesktop.resolve1.service",
+      "dbus.service",
+      "dbus.socket",
+      "dnf-makecache.timer",
+      "fstrim.timer",
+      "getty@.service",
+      "import-state.service",
+      "pcscd.socket",
+      "reboot.target",
+      "remote-fs.target",
+      "rpmdb-rebuild.service",
+      "runlevel6.target",
+      "selinux-autorelabel-mark.service",
+      "sshd.service",
+      "sssd-kcm.socket",
+      "sssd.service",
+      "systemd-homed-activate.service",
+      "systemd-homed.service",
+      "systemd-oomd.service",
+      "systemd-resolved.service",
+      "systemd-userdbd.socket",
+      "unbound-anchor.timer"
+    ],
+    "sudoers": {
+      "/etc/sudoers": [
+        "Defaults   !visiblepw",
+        "Defaults    always_set_home",
+        "Defaults    match_group_by_gid",
+        "Defaults    always_query_group_plugin",
+        "Defaults    env_reset",
+        "Defaults    env_keep =  \"COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS\"",
+        "Defaults    env_keep += \"MAIL QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE\"",
+        "Defaults    env_keep += \"LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES\"",
+        "Defaults    env_keep += \"LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE\"",
+        "Defaults    env_keep += \"LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY\"",
+        "Defaults    secure_path = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+        "root\tALL=(ALL) \tALL",
+        "%wheel\tALL=(ALL)\tALL"
+      ]
+    },
+    "sysctl.d": {
+      "/usr/lib/sysctl.d": {
+        "10-default-yama-scope.conf": [
+          "kernel.yama.ptrace_scope = 0"
+        ],
+        "50-coredump.conf": [
+          "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h",
+          "kernel.core_pipe_limit=16",
+          "fs.suid_dumpable=2"
+        ],
+        "50-default.conf": [
+          "kernel.sysrq = 16",
+          "kernel.core_uses_pid = 1",
+          "net.ipv4.conf.default.rp_filter = 2",
+          "net.ipv4.conf.*.rp_filter = 2",
+          "-net.ipv4.conf.all.rp_filter",
+          "net.ipv4.conf.default.accept_source_route = 0",
+          "net.ipv4.conf.*.accept_source_route = 0",
+          "-net.ipv4.conf.all.accept_source_route",
+          "net.ipv4.conf.default.promote_secondaries = 1",
+          "net.ipv4.conf.*.promote_secondaries = 1",
+          "-net.ipv4.conf.all.promote_secondaries",
+          "-net.ipv4.ping_group_range = 0 2147483647",
+          "-net.core.default_qdisc = fq_codel",
+          "fs.protected_hardlinks = 1",
+          "fs.protected_symlinks = 1",
+          "fs.protected_regular = 1",
+          "fs.protected_fifos = 1"
+        ],
+        "50-libkcapi-optmem_max.conf": [
+          "net.core.optmem_max = 81920"
+        ],
+        "50-pid-max.conf": [
+          "kernel.pid_max = 4194304"
+        ]
+      }
+    },
+    "systemd-service-dropins": {
+      "/usr/lib/systemd/system": {
+        "systemd-hostnamed.service.d": {
+          "Service": {
+            "PrivateDevices": "no"
+          }
+        },
+        "systemd-logind.service.d": {
+          "Service": {
+            "Environment": "SYSTEMD_REBOOT_TO_BOOT_LOADER_MENU=true"
+          }
+        },
+        "systemd-udev-trigger.service.d": {
+          "Unit": {
+            "RefuseManualStop": "true"
+          }
+        },
+        "user@.service.d": {
+          "Service": {
+            "ManagedOOMMemoryPressure": "kill",
+            "ManagedOOMMemoryPressureLimit": "50%"
+          }
+        }
+      }
+    },
+    "timezone": "UTC",
+    "tmpfiles.d": {
+      "/usr/lib/tmpfiles.d": {
+        "cloud-init.conf": [
+          "d /run/cloud-init 0700 root root - -"
+        ],
+        "console-login-helper-messages-issuegen.conf": [
+          "r /etc/issue.d/*_clhm_*.issue - - - - -"
+        ],
+        "console-login-helper-messages-motdgen.conf": [
+          "d /run/motd.d - - - - -"
+        ],
+        "console-login-helper-messages-profile.conf": [
+          "L /etc/profile.d/console-login-helper-messages-profile.sh - - - - ../../usr/share/console-login-helper-messages/profile.sh"
+        ],
+        "console-login-helper-messages.conf": [
+          "d /run/console-login-helper-messages - - - - -"
+        ],
+        "cryptsetup.conf": [
+          "d /run/cryptsetup 0700 root root -"
+        ],
+        "dnf.conf": [
+          "R /var/tmp/dnf*/locks/*",
+          "r /var/cache/dnf/download_lock.pid",
+          "r /var/cache/dnf/metadata_lock.pid",
+          "r /var/lib/dnf/rpmdb_lock.pid",
+          "r /var/log/log_lock.pid"
+        ],
+        "etc.conf": [
+          "L /etc/os-release - - - - ../usr/lib/os-release",
+          "L+ /etc/mtab - - - - ../proc/self/mounts",
+          "L! /etc/resolv.conf - - - - ../run/systemd/resolve/stub-resolv.conf",
+          "C! /etc/nsswitch.conf - - - -",
+          "C! /etc/pam.d - - - -",
+          "C! /etc/issue - - - -"
+        ],
+        "home.conf": [
+          "Q /home 0755 - - -",
+          "q /srv 0755 - - -"
+        ],
+        "journal-nocow.conf": [
+          "h /var/log/journal - - - - +C",
+          "h /var/log/journal/%m - - - - +C",
+          "h /var/log/journal/remote - - - - +C"
+        ],
+        "legacy.conf": [
+          "d /run/lock 0755 root root -",
+          "L /var/lock - - - - ../run/lock",
+          "d /run/lock/subsys 0755 root root -",
+          "r! /forcefsck",
+          "r! /fastboot",
+          "r! /forcequotacheck"
+        ],
+        "libselinux.conf": [
+          "d /run/setrans 0755 root root"
+        ],
+        "man-db.conf": [
+          "d /var/cache/man 0755 root root 1w"
+        ],
+        "pam.conf": [
+          "d /run/console 0755 root root -",
+          "d /run/faillock 0755 root root -",
+          "d /run/sepermit 0755 root root -",
+          "d /run/motd.d 0755 root root -",
+          "f /var/log/tallylog 0600 root root -"
+        ],
+        "portables.conf": [
+          "Q /var/lib/portables 0700"
+        ],
+        "selinux-policy.conf": [
+          "z /sys/devices/system/cpu/online - - -",
+          "Z /sys/class/net - - -",
+          "z /sys/kernel/uevent_helper - - -",
+          "w /sys/fs/selinux/checkreqprot - - - - 0"
+        ],
+        "setup.conf": [
+          "f /run/motd 0644 root root -",
+          "d /run/motd.d 0755 root root -"
+        ],
+        "static-nodes-permissions.conf": [
+          "z /dev/snd/seq      0660 - audio -",
+          "z /dev/snd/timer    0660 - audio -",
+          "z /dev/loop-control 0660 - disk  -",
+          "z /dev/net/tun      0666 - -     -",
+          "z /dev/fuse         0666 - -     -",
+          "z /dev/kvm          0666 - kvm -",
+          "z /dev/vhost-net    0666 - kvm -",
+          "z /dev/vhost-vsock  0666 - kvm -"
+        ],
+        "sudo.conf": [
+          "d /run/sudo 0711 root root",
+          "D /run/sudo/ts 0700 root root"
+        ],
+        "systemd-nologin.conf": [
+          "F! /run/nologin 0644 - - - \"System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8).\""
+        ],
+        "systemd-pstore.conf": [
+          "d /var/lib/systemd/pstore 0755 root root 14d"
+        ],
+        "systemd-tmp.conf": [
+          "x /tmp/systemd-private-%b-*",
+          "X /tmp/systemd-private-%b-*/tmp",
+          "x /var/tmp/systemd-private-%b-*",
+          "X /var/tmp/systemd-private-%b-*/tmp",
+          "R! /tmp/systemd-private-*",
+          "R! /var/tmp/systemd-private-*",
+          "x  /var/lib/systemd/coredump/.#core*.%b*",
+          "r! /var/lib/systemd/coredump/.#*"
+        ],
+        "systemd.conf": [
+          "d /run/user 0755 root root -",
+          "F! /run/utmp 0664 root utmp -",
+          "d /run/systemd/ask-password 0755 root root -",
+          "d /run/systemd/seats 0755 root root -",
+          "d /run/systemd/sessions 0755 root root -",
+          "d /run/systemd/users 0755 root root -",
+          "d /run/systemd/machines 0755 root root -",
+          "d /run/systemd/shutdown 0755 root root -",
+          "d /run/systemd/netif 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/links 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/leases 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/lldp 0755 systemd-network systemd-network -",
+          "d /run/log 0755 root root -",
+          "z /run/log/journal 2755 root systemd-journal - -",
+          "Z /run/log/journal/%m ~2750 root systemd-journal - -",
+          "a+ /run/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m/*.journal* - - - - group:adm:r--,group:wheel:r--",
+          "z /var/log/journal 2755 root systemd-journal - -",
+          "z /var/log/journal/%m 2755 root systemd-journal - -",
+          "z /var/log/journal/%m/system.journal 0640 root systemd-journal - -",
+          "a+ /var/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m/system.journal - - - - group:adm:r--,group:wheel:r--",
+          "d /var/lib/systemd 0755 root root -",
+          "d /var/lib/systemd/coredump 0755 root root 3d",
+          "d /var/lib/private 0700 root root -",
+          "d /var/log/private 0700 root root -",
+          "d /var/cache/private 0700 root root -"
+        ],
+        "tmp.conf": [
+          "q /tmp 1777 root root 10d",
+          "q /var/tmp 1777 root root 30d"
+        ],
+        "tpm2-tss-fapi.conf": [
+          "d       /var/lib/tpm2-tss/system/keystore   2775 tss  tss   -           -",
+          "a+      /var/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx",
+          "d       /run/tpm2-tss/eventlog                2775 tss  tss   -           -",
+          "a+      /run/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx"
+        ],
+        "var.conf": [
+          "q /var 0755 - - -",
+          "L /var/run - - - - ../run",
+          "d /var/log 0755 - - -",
+          "f /var/log/wtmp 0664 root utmp -",
+          "f /var/log/btmp 0660 root utmp -",
+          "f /var/log/lastlog 0664 root utmp -",
+          "d /var/cache 0755 - - -",
+          "d /var/lib 0755 - - -",
+          "d /var/spool 0755 - - -"
+        ],
+        "x11.conf": [
+          "D! /tmp/.X11-unix 1777 root root 10d",
+          "D! /tmp/.ICE-unix 1777 root root 10d",
+          "D! /tmp/.XIM-unix 1777 root root 10d",
+          "D! /tmp/.font-unix 1777 root root 10d",
+          "D! /tmp/.Test-unix 1777 root root 10d",
+          "r! /tmp/.X[0-9]*-lock"
+        ]
+      }
+    }
+  }
+}

--- a/test/data/manifests/fedora_35-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-qcow2_customize-boot.json
@@ -1,0 +1,10721 @@
+{
+  "compose-request": {
+    "distro": "fedora-35",
+    "arch": "aarch64",
+    "image-type": "qcow2",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-modular-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-modular-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      }
+    ],
+    "filename": "disk.qcow2",
+    "blueprint": {
+      "name": "qcow2-customize-boot-test",
+      "description": "Image for boot test",
+      "packages": [
+        {
+          "name": "bash",
+          "version": "*"
+        }
+      ],
+      "modules": [],
+      "groups": [
+        {
+          "name": "core"
+        }
+      ],
+      "customizations": {
+        "hostname": "my-host",
+        "kernel": {
+          "append": "debug"
+        },
+        "sshkey": [
+          {
+            "user": "user1",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+          }
+        ],
+        "user": [
+          {
+            "name": "user2",
+            "description": "description 2",
+            "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+            "home": "/home/home2",
+            "shell": "/bin/sh",
+            "groups": [
+              "group1"
+            ],
+            "uid": 1020,
+            "gid": 1050
+          }
+        ],
+        "group": [
+          {
+            "name": "group1",
+            "gid": 1030
+          },
+          {
+            "name": "group2",
+            "gid": 1050
+          }
+        ],
+        "timezone": {
+          "timezone": "Europe/London",
+          "ntpservers": [
+            "time.example.com"
+          ]
+        },
+        "locale": {
+          "languages": [
+            "el_CY.UTF-8"
+          ],
+          "keyboard": "dvorak"
+        },
+        "services": {
+          "enabled": [
+            "sshd.socket"
+          ],
+          "disabled": [
+            "bluetooth.service"
+          ]
+        }
+      }
+    }
+  },
+  "manifest": {
+    "sources": {
+      "org.osbuild.files": {
+        "urls": {
+          "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.aarch64.rpm"
+          },
+          "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm"
+          },
+          "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm"
+          },
+          "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.aarch64.rpm"
+          },
+          "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm"
+          },
+          "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-jsonpatch-1.21-18.fc35.noarch.rpm"
+          },
+          "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm"
+          },
+          "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm"
+          },
+          "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm"
+          },
+          "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm"
+          },
+          "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm"
+          },
+          "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.aarch64.rpm"
+          },
+          "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm"
+          },
+          "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm"
+          },
+          "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-font-en-3.0-15.fc35.noarch.rpm"
+          },
+          "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fonts-filesystem-2.0.5-6.fc35.noarch.rpm"
+          },
+          "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm"
+          },
+          "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm"
+          },
+          "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm"
+          },
+          "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm"
+          },
+          "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm"
+          },
+          "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm"
+          },
+          "sha256:228e6fbe3646a580e871378f374a1d7cebc4c592ea8262600e4b41a5c39b1169": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-motdgen-0.21.2-3.fc35.noarch.rpm"
+          },
+          "sha256:22a906074aaab00a9c1bac318f9d10323566670fc7772c61e196574dfc63ee9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-policycoreutils-3.3-1.fc35.noarch.rpm"
+          },
+          "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:2402ad97f754eb094e4c4f49b3045fdf919e413b6a78582e3c1850ba09ff93f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/freetype-2.11.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm"
+          },
+          "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm"
+          },
+          "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-attrs-21.2.0-4.fc35.noarch.rpm"
+          },
+          "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm"
+          },
+          "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm"
+          },
+          "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efibootmgr-16-11.fc35.aarch64.rpm"
+          },
+          "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm"
+          },
+          "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm"
+          },
+          "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm"
+          },
+          "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.26.7-2.fc35.noarch.rpm"
+          },
+          "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efi-filesystem-5-4.fc35.noarch.rpm"
+          },
+          "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm"
+          },
+          "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-requests-2.27.0-1.fc35.noarch.rpm"
+          },
+          "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm"
+          },
+          "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-ply-3.11-13.fc35.noarch.rpm"
+          },
+          "sha256:360960053a501c11bc407c6c8a2f379b79bd249133b7c0ffaba54068385860e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-cloud-35-36.noarch.rpm"
+          },
+          "sha256:375b89f3a452a62f3a02ada8971b14e854fa95b0d4cb9efb0449e5f85d6959c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-markupsafe-2.0.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/less-590-2.fc35.aarch64.rpm"
+          },
+          "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:39fd9eb8e77b430637602dc7cfce448e1792ace9cc9041c33f957b70d7b205c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/inih-49-4.fc35.aarch64.rpm"
+          },
+          "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm"
+          },
+          "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm"
+          },
+          "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.aarch64.rpm"
+          },
+          "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm"
+          },
+          "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm"
+          },
+          "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:3eecb51a03f9eed59710f6c6cbc5d66aea9bc521940d0b8d73fca835f1402897": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chrony-4.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm"
+          },
+          "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm"
+          },
+          "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm"
+          },
+          "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm"
+          },
+          "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.aarch64.rpm"
+          },
+          "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm"
+          },
+          "sha256:469ec3ace1ffa4e3153c772d5ec5a65f8cb6e98d07405134c6b06545796e31c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyyaml-5.4.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:4a1dbb7d6a22598bc31d917e42759d7332a343670e35e0022db39a2ebb9e5c99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cloud-utils-growpart-0.31-9.fc35.noarch.rpm"
+          },
+          "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/parted-3.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-charset-normalizer-2.0.4-1.fc35.noarch.rpm"
+          },
+          "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm"
+          },
+          "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt-2.1.0-2.fc35.noarch.rpm"
+          },
+          "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4df41f9a100eca994899d304473024c37382220b4e3c0812c69701bfa450aa06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-cloud-35-36.noarch.rpm"
+          },
+          "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.aarch64.rpm"
+          },
+          "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-en-3.0-15.fc35.noarch.rpm"
+          },
+          "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:50d0b3571e271cce3c9f314f3fab80485b706c347cb6e9c710c28cf552c07ec5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/checkpolicy-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm"
+          },
+          "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm"
+          },
+          "sha256:539d9ef12227716ff904a3e4605c765e6204ffd49a7a2d42762ccd5d921b341c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-issuegen-0.21.2-3.fc35.noarch.rpm"
+          },
+          "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.aarch64.rpm"
+          },
+          "sha256:5437317aa8a5d94a9de9cd15d58399146783b4b96ee52a0a134c09b79933a8b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:5702b6d62b7efb235cf49b6174288053d345236107a43de33d6c80d9784d7140": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-audit-3.0.6-1.fc35.aarch64.rpm"
+          },
+          "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm"
+          },
+          "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-configobj-5.0.6-25.fc35.noarch.rpm"
+          },
+          "sha256:58b6c3272af7450868f9b6ee3e15f05e45104751cacaa4a22345983caaea14da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-filesystem-1.7.0-11.fc35.aarch64.rpm"
+          },
+          "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.aarch64.rpm"
+          },
+          "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.aarch64.rpm"
+          },
+          "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm"
+          },
+          "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm"
+          },
+          "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.aarch64.rpm"
+          },
+          "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm"
+          },
+          "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm"
+          },
+          "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pycparser-2.20-5.fc35.noarch.rpm"
+          },
+          "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.aarch64.rpm"
+          },
+          "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm"
+          },
+          "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm"
+          },
+          "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm"
+          },
+          "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm"
+          },
+          "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-en-3.0-15.fc35.noarch.rpm"
+          },
+          "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-GB-0.20140811.1-20.fc35.noarch.rpm"
+          },
+          "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm"
+          },
+          "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efivar-libs-37-17.fc35.aarch64.rpm"
+          },
+          "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm"
+          },
+          "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm"
+          },
+          "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setuptools-57.4.0-1.fc35.noarch.rpm"
+          },
+          "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.aarch64.rpm"
+          },
+          "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm"
+          },
+          "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm"
+          },
+          "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm"
+          },
+          "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm"
+          },
+          "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:77f17b1b61648436b2ceb31f9447ce6b363ac2de62216277fb05b6ff8eb9654c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/graphite2-1.3.14-8.fc35.aarch64.rpm"
+          },
+          "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm"
+          },
+          "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm"
+          },
+          "sha256:7e7205d1d01f5c6e2635f3b80c2efc04440449482ac8024391af00007952c487": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/harfbuzz-2.8.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm"
+          },
+          "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.aarch64.rpm"
+          },
+          "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm"
+          },
+          "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm"
+          },
+          "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-idna-3.2-1.fc35.noarch.rpm"
+          },
+          "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.aarch64.rpm"
+          },
+          "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonschema-3.2.0-12.fc35.noarch.rpm"
+          },
+          "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jinja2-3.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm"
+          },
+          "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib-3.0.2-11.fc35.noarch.rpm"
+          },
+          "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dejavu-sans-fonts-2.37-17.fc35.noarch.rpm"
+          },
+          "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.aarch64.rpm"
+          },
+          "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyserial-3.4-12.fc35.noarch.rpm"
+          },
+          "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm"
+          },
+          "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm"
+          },
+          "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm"
+          },
+          "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm"
+          },
+          "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.aarch64.rpm"
+          },
+          "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm"
+          },
+          "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.aarch64.rpm"
+          },
+          "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm"
+          },
+          "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:9593a8e47f980af2a61700947cf6da75b409621598029854c05f1a4f5749d1cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libsemanage-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:9605b7a0fbfb73c13a99ae45476c02cf3a0cde1b7edf137e90f8006863519a83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setools-4.4.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-babel-2.9.1-4.fc35.noarch.rpm"
+          },
+          "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.aarch64.rpm"
+          },
+          "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm"
+          },
+          "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm"
+          },
+          "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm"
+          },
+          "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm"
+          },
+          "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm"
+          },
+          "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm"
+          },
+          "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm"
+          },
+          "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm"
+          },
+          "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.aarch64.rpm"
+          },
+          "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc35.noarch.rpm"
+          },
+          "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.aarch64.rpm"
+          },
+          "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm"
+          },
+          "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.aarch64.rpm"
+          },
+          "sha256:aa00ac7809f0965b1e09a31862ccbe2cf11753ffc0c7575f2e40c96aa1c162d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpng-1.6.37-11.fc35.aarch64.rpm"
+          },
+          "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm"
+          },
+          "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:ac16154e7ad3440e137a65b0d9bc96942f257651aaf1f41298f15329a216c2c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rsync-3.2.3-8.fc35.aarch64.rpm"
+          },
+          "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm"
+          },
+          "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.aarch64.rpm"
+          },
+          "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.aarch64.rpm"
+          },
+          "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:b30f029f856c7ff5a9ef7c71b4f8d0858b96962c5523ee7c7bcc6313b13a3b0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cryptography-3.4.7-5.fc35.aarch64.rpm"
+          },
+          "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm"
+          },
+          "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm"
+          },
+          "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm"
+          },
+          "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.aarch64.rpm"
+          },
+          "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm"
+          },
+          "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.aarch64.rpm"
+          },
+          "sha256:b98735362bb79e3def6794fa863fe09a1c3690c8c7880e83f572c20860ba25ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libselinux-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:ba4e1520f0409329c8d29839d510c4721f4475e6b17727485c95b634e61a9cb8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-extra-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:baf6082e248e7e84f3cb5ec2695f0dc9afeca615b3f39c60283902ab06d3f564": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cffi-1.14.6-2.fc35.aarch64.rpm"
+          },
+          "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm"
+          },
+          "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.aarch64.rpm"
+          },
+          "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm"
+          },
+          "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm"
+          },
+          "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm"
+          },
+          "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm"
+          },
+          "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm"
+          },
+          "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pysocks-1.7.1-11.fc35.noarch.rpm"
+          },
+          "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cloud-init-20.4-7.fc35.noarch.rpm"
+          },
+          "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.aarch64.rpm"
+          },
+          "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm"
+          },
+          "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.aarch64.rpm"
+          },
+          "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm"
+          },
+          "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/mokutil-0.5.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm"
+          },
+          "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm"
+          },
+          "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch.rpm"
+          },
+          "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm"
+          },
+          "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm"
+          },
+          "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm"
+          },
+          "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm"
+          },
+          "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.aarch64.rpm"
+          },
+          "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm"
+          },
+          "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm"
+          },
+          "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm"
+          },
+          "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm"
+          },
+          "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm"
+          },
+          "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.aarch64.rpm"
+          },
+          "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-0.20140811.1-20.fc35.noarch.rpm"
+          },
+          "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm"
+          },
+          "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt+crypto-2.1.0-2.fc35.noarch.rpm"
+          },
+          "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm"
+          },
+          "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm"
+          },
+          "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm"
+          },
+          "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm"
+          },
+          "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm"
+          },
+          "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm"
+          },
+          "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm"
+          },
+          "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-US-0.20140811.1-20.fc35.noarch.rpm"
+          },
+          "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonpointer-2.0-4.fc35.noarch.rpm"
+          },
+          "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.aarch64.rpm"
+          },
+          "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm"
+          },
+          "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm"
+          },
+          "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/shim-aa64-15.4-5.aarch64.rpm"
+          },
+          "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm"
+          },
+          "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.aarch64.rpm"
+          },
+          "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm"
+          },
+          "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm"
+          },
+          "sha256:ef8f0dbb997b8f1e9a133a85f5e8a6b8579f23e95dbfd0604ac4d4809a759aa9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-profile-0.21.2-3.fc35.noarch.rpm"
+          },
+          "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm"
+          },
+          "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm"
+          },
+          "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm"
+          },
+          "sha256:f4a4e83a8e1a1ba33bbd58ab720d2ba66bc76ef05101dd68d5ccd37a6e4e0b7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-0.21.2-3.fc35.noarch.rpm"
+          },
+          "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-prettytable-0.7.2-27.fc35.noarch.rpm"
+          },
+          "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm"
+          },
+          "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.aarch64.rpm"
+          },
+          "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm"
+          },
+          "sha256:f878dd687438db0e07f2eb571246103ae0e136647242f0bf7f806ddd77e04a91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-1.7.0-11.fc35.aarch64.rpm"
+          },
+          "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.aarch64.rpm"
+          },
+          "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm"
+          },
+          "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm"
+          },
+          "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.aarch64.rpm"
+          },
+          "sha256:fc05e6abb02bcb99462711686ddfc47783c0a5575bdb451a7fce641a3b809e8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.18.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:fccda302546302309788e451ccaa2fb2abba72fa7b4184e82e1ff89830d8e306": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/net-tools-2.0-0.60.20160912git.fc35.aarch64.rpm"
+          },
+          "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:fe1323e767bb5941d49d5b6565750614a2f649d5d34453e5ace10b3012b7a413": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xfsprogs-5.12.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm"
+          },
+          "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm"
+          },
+          "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm"
+          }
+        }
+      }
+    },
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.rpm",
+              "options": {
+                "gpgkeys": [
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+                ],
+                "packages": [
+                  {
+                    "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                    "check_gpg": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "org.osbuild.selinux",
+              "options": {
+                "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+                "labels": {
+                  "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+                }
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.fedora33"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8"
+          }
+        },
+        {
+          "name": "org.osbuild.rpm",
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "packages": [
+              {
+                "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3eecb51a03f9eed59710f6c6cbc5d66aea9bc521940d0b8d73fca835f1402897",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4a1dbb7d6a22598bc31d917e42759d7332a343670e35e0022db39a2ebb9e5c99",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2402ad97f754eb094e4c4f49b3045fdf919e413b6a78582e3c1850ba09ff93f3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:77f17b1b61648436b2ceb31f9447ce6b363ac2de62216277fb05b6ff8eb9654c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7e7205d1d01f5c6e2635f3b80c2efc04440449482ac8024391af00007952c487",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f878dd687438db0e07f2eb571246103ae0e136647242f0bf7f806ddd77e04a91",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:58b6c3272af7450868f9b6ee3e15f05e45104751cacaa4a22345983caaea14da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:39fd9eb8e77b430637602dc7cfce448e1792ace9cc9041c33f957b70d7b205c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aa00ac7809f0965b1e09a31862ccbe2cf11753ffc0c7575f2e40c96aa1c162d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fccda302546302309788e451ccaa2fb2abba72fa7b4184e82e1ff89830d8e306",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5702b6d62b7efb235cf49b6174288053d345236107a43de33d6c80d9784d7140",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:baf6082e248e7e84f3cb5ec2695f0dc9afeca615b3f39c60283902ab06d3f564",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b30f029f856c7ff5a9ef7c71b4f8d0858b96962c5523ee7c7bcc6313b13a3b0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:375b89f3a452a62f3a02ada8971b14e854fa95b0d4cb9efb0449e5f85d6959c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:469ec3ace1ffa4e3153c772d5ec5a65f8cb6e98d07405134c6b06545796e31c2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9605b7a0fbfb73c13a99ae45476c02cf3a0cde1b7edf137e90f8006863519a83",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac16154e7ad3440e137a65b0d9bc96942f257651aaf1f41298f15329a216c2c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fe1323e767bb5941d49d5b6565750614a2f649d5d34453e5ace10b3012b7a413",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:50d0b3571e271cce3c9f314f3fab80485b706c347cb6e9c710c28cf552c07ec5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4a4e83a8e1a1ba33bbd58ab720d2ba66bc76ef05101dd68d5ccd37a6e4e0b7e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:539d9ef12227716ff904a3e4605c765e6204ffd49a7a2d42762ccd5d921b341c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:228e6fbe3646a580e871378f374a1d7cebc4c592ea8262600e4b41a5c39b1169",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ef8f0dbb997b8f1e9a133a85f5e8a6b8579f23e95dbfd0604ac4d4809a759aa9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:360960053a501c11bc407c6c8a2f379b79bd249133b7c0ffaba54068385860e9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4df41f9a100eca994899d304473024c37382220b4e3c0812c69701bfa450aa06",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5437317aa8a5d94a9de9cd15d58399146783b4b96ee52a0a134c09b79933a8b0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ba4e1520f0409329c8d29839d510c4721f4475e6b17727485c95b634e61a9cb8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b98735362bb79e3def6794fa863fe09a1c3690c8c7880e83f572c20860ba25ba",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9593a8e47f980af2a61700947cf6da75b409621598029854c05f1a4f5749d1cb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:22a906074aaab00a9c1bac318f9d10323566670fc7772c61e196574dfc63ee9b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fc05e6abb02bcb99462711686ddfc47783c0a5575bdb451a7fce641a3b809e8e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f",
+                "check_gpg": true
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "el_CY.UTF-8"
+          }
+        },
+        {
+          "name": "org.osbuild.keymap",
+          "options": {
+            "keymap": "dvorak"
+          }
+        },
+        {
+          "name": "org.osbuild.hostname",
+          "options": {
+            "hostname": "my-host"
+          }
+        },
+        {
+          "name": "org.osbuild.timezone",
+          "options": {
+            "zone": "Europe/London"
+          }
+        },
+        {
+          "name": "org.osbuild.chrony",
+          "options": {
+            "timeservers": [
+              "time.example.com"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.groups",
+          "options": {
+            "groups": {
+              "group1": {
+                "name": "group1",
+                "gid": 1030
+              },
+              "group2": {
+                "name": "group2",
+                "gid": 1050
+              }
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.users",
+          "options": {
+            "users": {
+              "user1": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              },
+              "user2": {
+                "uid": 1020,
+                "gid": 1050,
+                "groups": [
+                  "group1"
+                ],
+                "description": "description 2",
+                "home": "/home/home2",
+                "shell": "/bin/sh",
+                "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              },
+              {
+                "uuid": "46BB-8120",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "umask=0077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": " debug",
+            "uefi": {
+              "vendor": "fedora"
+            }
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service",
+              "sshd.socket"
+            ],
+            "disabled_services": [
+              "bluetooth.service"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
+        "options": {
+          "format": "qcow2",
+          "filename": "disk.qcow2",
+          "size": 2147483648,
+          "ptuuid": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
+          "pttype": "gpt",
+          "partitions": [
+            {
+              "start": 2048,
+              "size": 972800,
+              "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+              "uuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
+              "filesystem": {
+                "type": "vfat",
+                "uuid": "46BB-8120",
+                "label": "EFI-SYSTEM",
+                "mountpoint": "/boot/efi"
+              }
+            },
+            {
+              "start": 976896,
+              "uuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build-packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm",
+        "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm",
+        "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm",
+        "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
+        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
+        "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm",
+        "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm",
+        "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm",
+        "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm",
+        "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "12.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.aarch64.rpm",
+        "checksum": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
+        "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm",
+        "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm",
+        "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm",
+        "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
+        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm",
+        "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
+        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+        "check_gpg": true
+      },
+      {
+        "name": "liburing",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm",
+        "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm",
+        "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm",
+        "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm",
+        "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
+        "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs78",
+        "epoch": 0,
+        "version": "78.15.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm",
+        "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm",
+        "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm",
+        "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm",
+        "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm",
+        "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm",
+        "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm",
+        "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.70.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.4.36",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm",
+        "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+        "check_gpg": true
+      },
+      {
+        "name": "qemu-img",
+        "epoch": 2,
+        "version": "6.1.0",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm",
+        "checksum": "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm",
+        "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
+    "packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm",
+        "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65",
+        "check_gpg": true
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75",
+        "check_gpg": true
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chrony-4.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3eecb51a03f9eed59710f6c6cbc5d66aea9bc521940d0b8d73fca835f1402897",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "20.4",
+        "release": "7.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cloud-init-20.4-7.fc35.noarch.rpm",
+        "checksum": "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-utils-growpart",
+        "epoch": 0,
+        "version": "0.31",
+        "release": "9.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cloud-utils-growpart-0.31-9.fc35.noarch.rpm",
+        "checksum": "sha256:4a1dbb7d6a22598bc31d917e42759d7332a343670e35e0022db39a2ebb9e5c99",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm",
+        "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm",
+        "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+        "check_gpg": true
+      },
+      {
+        "name": "dejavu-sans-fonts",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "17.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dejavu-sans-fonts-2.37-17.fc35.noarch.rpm",
+        "checksum": "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
+        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.aarch64.rpm",
+        "checksum": "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm",
+        "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
+        "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efi-filesystem-5-4.fc35.noarch.rpm",
+        "checksum": "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efibootmgr-16-11.fc35.aarch64.rpm",
+        "checksum": "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "37",
+        "release": "17.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efivar-libs-37-17.fc35.aarch64.rpm",
+        "checksum": "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm",
+        "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm",
+        "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+        "check_gpg": true
+      },
+      {
+        "name": "fonts-filesystem",
+        "epoch": 1,
+        "version": "2.0.5",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fonts-filesystem-2.0.5-6.fc35.noarch.rpm",
+        "checksum": "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee",
+        "check_gpg": true
+      },
+      {
+        "name": "freetype",
+        "epoch": 0,
+        "version": "2.11.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/freetype-2.11.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2402ad97f754eb094e4c4f49b3045fdf919e413b6a78582e3c1850ba09ff93f3",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+        "check_gpg": true
+      },
+      {
+        "name": "graphite2",
+        "epoch": 0,
+        "version": "1.3.14",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/graphite2-1.3.14-8.fc35.aarch64.rpm",
+        "checksum": "sha256:77f17b1b61648436b2ceb31f9447ce6b363ac2de62216277fb05b6ff8eb9654c",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm",
+        "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.aarch64.rpm",
+        "checksum": "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm",
+        "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+        "check_gpg": true
+      },
+      {
+        "name": "harfbuzz",
+        "epoch": 0,
+        "version": "2.8.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/harfbuzz-2.8.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7e7205d1d01f5c6e2635f3b80c2efc04440449482ac8024391af00007952c487",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.aarch64.rpm",
+        "checksum": "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell",
+        "epoch": 0,
+        "version": "1.7.0",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-1.7.0-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f878dd687438db0e07f2eb571246103ae0e136647242f0bf7f806ddd77e04a91",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-en",
+        "epoch": 0,
+        "version": "0.20140811.1",
+        "release": "20.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-0.20140811.1-20.fc35.noarch.rpm",
+        "checksum": "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-en-GB",
+        "epoch": 0,
+        "version": "0.20140811.1",
+        "release": "20.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-GB-0.20140811.1-20.fc35.noarch.rpm",
+        "checksum": "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-en-US",
+        "epoch": 0,
+        "version": "0.20140811.1",
+        "release": "20.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-US-0.20140811.1-20.fc35.noarch.rpm",
+        "checksum": "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-filesystem",
+        "epoch": 0,
+        "version": "1.7.0",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-filesystem-1.7.0-11.fc35.aarch64.rpm",
+        "checksum": "sha256:58b6c3272af7450868f9b6ee3e15f05e45104751cacaa4a22345983caaea14da",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "49",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/inih-49-4.fc35.aarch64.rpm",
+        "checksum": "sha256:39fd9eb8e77b430637602dc7cfce448e1792ace9cc9041c33f957b70d7b205c5",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm",
+        "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute-tc",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20210722",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm",
+        "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "15.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-en-3.0-15.fc35.noarch.rpm",
+        "checksum": "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-font-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "15.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-font-en-3.0-15.fc35.noarch.rpm",
+        "checksum": "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "15.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-en-3.0-15.fc35.noarch.rpm",
+        "checksum": "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
+        "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm",
+        "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm",
+        "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.aarch64.rpm",
+        "checksum": "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm",
+        "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.aarch64.rpm",
+        "checksum": "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "40.20210910cvs.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.aarch64.rpm",
+        "checksum": "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
+        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm",
+        "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.aarch64.rpm",
+        "checksum": "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.5.4",
+        "release": "2.rc3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.aarch64.rpm",
+        "checksum": "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libpng",
+        "epoch": 2,
+        "version": "1.6.37",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpng-1.6.37-11.fc35.aarch64.rpm",
+        "checksum": "sha256:aa00ac7809f0965b1e09a31862ccbe2cf11753ffc0c7575f2e40c96aa1c162d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.aarch64.rpm",
+        "checksum": "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
+        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm",
+        "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.aarch64.rpm",
+        "checksum": "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm",
+        "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm",
+        "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm",
+        "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.aarch64.rpm",
+        "checksum": "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.aarch64.rpm",
+        "checksum": "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
+        "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs78",
+        "epoch": 0,
+        "version": "78.15.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+        "check_gpg": true
+      },
+      {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.60.20160912git.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/net-tools-2.0-0.60.20160912git.fc35.aarch64.rpm",
+        "checksum": "sha256:fccda302546302309788e451ccaa2fb2abba72fa7b4184e82e1ff89830d8e306",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm",
+        "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm",
+        "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm",
+        "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/parted-3.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.aarch64.rpm",
+        "checksum": "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-attrs",
+        "epoch": 0,
+        "version": "21.2.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-attrs-21.2.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-audit-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5702b6d62b7efb235cf49b6174288053d345236107a43de33d6c80d9784d7140",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-babel",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-babel-2.9.1-4.fc35.noarch.rpm",
+        "checksum": "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cffi",
+        "epoch": 0,
+        "version": "1.14.6",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cffi-1.14.6-2.fc35.aarch64.rpm",
+        "checksum": "sha256:baf6082e248e7e84f3cb5ec2695f0dc9afeca615b3f39c60283902ab06d3f564",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-charset-normalizer",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-charset-normalizer-2.0.4-1.fc35.noarch.rpm",
+        "checksum": "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-configobj",
+        "epoch": 0,
+        "version": "5.0.6",
+        "release": "25.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-configobj-5.0.6-25.fc35.noarch.rpm",
+        "checksum": "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cryptography",
+        "epoch": 0,
+        "version": "3.4.7",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cryptography-3.4.7-5.fc35.aarch64.rpm",
+        "checksum": "sha256:b30f029f856c7ff5a9ef7c71b4f8d0858b96962c5523ee7c7bcc6313b13a3b0c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "7.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm",
+        "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.aarch64.rpm",
+        "checksum": "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-idna-3.2-1.fc35.noarch.rpm",
+        "checksum": "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jinja2",
+        "epoch": 0,
+        "version": "3.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jinja2-3.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpointer",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonpointer-2.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonschema",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonschema-3.2.0-12.fc35.noarch.rpm",
+        "checksum": "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt+crypto",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt+crypto-2.1.0-2.fc35.noarch.rpm",
+        "checksum": "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt-2.1.0-2.fc35.noarch.rpm",
+        "checksum": "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-markupsafe-2.0.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:375b89f3a452a62f3a02ada8971b14e854fa95b0d4cb9efb0449e5f85d6959c6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib+signedtoken",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "11.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch.rpm",
+        "checksum": "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "11.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib-3.0.2-11.fc35.noarch.rpm",
+        "checksum": "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ply",
+        "epoch": 0,
+        "version": "3.11",
+        "release": "13.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-ply-3.11-13.fc35.noarch.rpm",
+        "checksum": "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "27.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-prettytable-0.7.2-27.fc35.noarch.rpm",
+        "checksum": "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pycparser",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pycparser-2.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyserial",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyserial-3.4-12.fc35.noarch.rpm",
+        "checksum": "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "11.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pysocks-1.7.1-11.fc35.noarch.rpm",
+        "checksum": "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyyaml-5.4.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:469ec3ace1ffa4e3153c772d5ec5a65f8cb6e98d07405134c6b06545796e31c2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.4.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setools-4.4.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9605b7a0fbfb73c13a99ae45476c02cf3a0cde1b7edf137e90f8006863519a83",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setuptools-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "30.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm",
+        "checksum": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+        "check_gpg": true
+      },
+      {
+        "name": "rsync",
+        "epoch": 0,
+        "version": "3.2.3",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rsync-3.2.3-8.fc35.aarch64.rpm",
+        "checksum": "sha256:ac16154e7ad3440e137a65b0d9bc96942f257651aaf1f41298f15329a216c2c6",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm",
+        "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.4",
+        "release": "5",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/shim-aa64-15.4-5.aarch64.rpm",
+        "checksum": "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm",
+        "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm",
+        "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.12.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xfsprogs-5.12.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:fe1323e767bb5941d49d5b6565750614a2f649d5d34453e5ace10b3012b7a413",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm",
+        "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.aarch64.rpm",
+        "checksum": "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/checkpolicy-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:50d0b3571e271cce3c9f314f3fab80485b706c347cb6e9c710c28cf552c07ec5",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-0.21.2-3.fc35.noarch.rpm",
+        "checksum": "sha256:f4a4e83a8e1a1ba33bbd58ab720d2ba66bc76ef05101dd68d5ccd37a6e4e0b7e",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-issuegen",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-issuegen-0.21.2-3.fc35.noarch.rpm",
+        "checksum": "sha256:539d9ef12227716ff904a3e4605c765e6204ffd49a7a2d42762ccd5d921b341c",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-motdgen",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-motdgen-0.21.2-3.fc35.noarch.rpm",
+        "checksum": "sha256:228e6fbe3646a580e871378f374a1d7cebc4c592ea8262600e4b41a5c39b1169",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-profile",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/console-login-helper-messages-profile-0.21.2-3.fc35.noarch.rpm",
+        "checksum": "sha256:ef8f0dbb997b8f1e9a133a85f5e8a6b8579f23e95dbfd0604ac4d4809a759aa9",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-cloud",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-cloud-35-36.noarch.rpm",
+        "checksum": "sha256:360960053a501c11bc407c6c8a2f379b79bd249133b7c0ffaba54068385860e9",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-cloud",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-cloud-35-36.noarch.rpm",
+        "checksum": "sha256:4df41f9a100eca994899d304473024c37382220b4e3c0812c69701bfa450aa06",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.70.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-langpack-en",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:5437317aa8a5d94a9de9cd15d58399146783b4b96ee52a0a134c09b79933a8b0",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-extra",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-extra-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:ba4e1520f0409329c8d29839d510c4721f4475e6b17727485c95b634e61a9cb8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/less-590-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-atm-libs",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.aarch64.rpm",
+        "checksum": "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.5.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/mokutil-0.5.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.4.36",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm",
+        "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpatch",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "18.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-jsonpatch-1.21-18.fc35.noarch.rpm",
+        "checksum": "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b98735362bb79e3def6794fa863fe09a1c3690c8c7880e83f572c20860ba25ba",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9593a8e47f980af2a61700947cf6da75b409621598029854c05f1a4f5749d1cb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-policycoreutils-3.3-1.fc35.noarch.rpm",
+        "checksum": "sha256:22a906074aaab00a9c1bac318f9d10323566670fc7772c61e196574dfc63ee9b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyrsistent",
+        "epoch": 0,
+        "version": "0.18.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.18.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:fc05e6abb02bcb99462711686ddfc47783c0a5575bdb451a7fce641a3b809e8e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pytz",
+        "epoch": 0,
+        "version": "2021.3",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc35.noarch.rpm",
+        "checksum": "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.27.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-requests-2.27.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.7",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.26.7-2.fc35.noarch.rpm",
+        "checksum": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm",
+        "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm",
+        "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm",
+        "checksum": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f",
+        "check_gpg": true
+      }
+    ]
+  },
+  "image-info": {
+    "/etc/resolv.conf": [],
+    "boot-environment": {
+      "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac  debug"
+    },
+    "bootloader": "unknown",
+    "bootmenu": [
+      {
+        "grub_arg": "--unrestricted",
+        "grub_class": "fedora",
+        "grub_users": "$grub_users",
+        "initrd": "/boot/initramfs-5.15.13-200.fc35.aarch64.img",
+        "linux": "/boot/vmlinuz-5.15.13-200.fc35.aarch64",
+        "options": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8",
+        "title": "Fedora Linux (5.15.13-200.fc35.aarch64) 35 (Cloud Edition)",
+        "version": "5.15.13-200.fc35.aarch64"
+      }
+    ],
+    "chrony": {
+      "leapsectz": [
+        "right/UTC"
+      ],
+      "server": [
+        "time.example.com iburst"
+      ]
+    },
+    "cloud-init": {
+      "/etc/cloud": {
+        "cloud.cfg": {
+          "cloud_config_modules": [
+            "ssh-import-id",
+            "locale",
+            "set-passwords",
+            "spacewalk",
+            "yum-add-repo",
+            "ntp",
+            "timezone",
+            "disable-ec2-metadata",
+            "runcmd"
+          ],
+          "cloud_final_modules": [
+            "package-update-upgrade-install",
+            "puppet",
+            "chef",
+            "mcollective",
+            "salt-minion",
+            "reset_rmc",
+            "refresh_rmc_and_interface",
+            "rightscale_userdata",
+            "scripts-vendor",
+            "scripts-per-once",
+            "scripts-per-boot",
+            "scripts-per-instance",
+            "scripts-user",
+            "ssh-authkey-fingerprints",
+            "keys-to-console",
+            "phone-home",
+            "final-message",
+            "power-state-change"
+          ],
+          "cloud_init_modules": [
+            "migrator",
+            "seed_random",
+            "bootcmd",
+            "write-files",
+            "growpart",
+            "resizefs",
+            "disk_setup",
+            "mounts",
+            "set_hostname",
+            "update_hostname",
+            "update_etc_hosts",
+            "ca-certs",
+            "rsyslog",
+            "users-groups",
+            "ssh"
+          ],
+          "disable_root": true,
+          "mount_default_fields": [
+            null,
+            null,
+            "auto",
+            "defaults,nofail",
+            "0",
+            "2"
+          ],
+          "preserve_hostname": false,
+          "resize_rootfs_tmp": "/dev",
+          "ssh_pwauth": 0,
+          "system_info": {
+            "default_user": {
+              "gecos": "fedora Cloud User",
+              "groups": [
+                "wheel",
+                "adm",
+                "systemd-journal"
+              ],
+              "lock_passwd": true,
+              "name": "fedora",
+              "shell": "/bin/bash",
+              "sudo": [
+                "ALL=(ALL) NOPASSWD:ALL"
+              ]
+            },
+            "distro": "fedora",
+            "paths": {
+              "cloud_dir": "/var/lib/cloud/",
+              "templates_dir": "/etc/cloud/templates/"
+            },
+            "ssh_svcname": "sshd"
+          },
+          "users": [
+            "default"
+          ]
+        }
+      },
+      "/etc/cloud/cloud.cfg.d": {
+        "05_logging.cfg": {
+          "_log": [
+            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
+            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
+          ],
+          "log_cfgs": [
+            [
+              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
+            ]
+          ],
+          "output": {
+            "all": "| tee -a /var/log/cloud-init-output.log"
+          }
+        }
+      }
+    },
+    "default-target": "graphical.target",
+    "dracut": {
+      "/usr/lib/dracut/dracut.conf.d": {
+        "01-dist.conf": {
+          "dbus": "/usr/share/dbus-1",
+          "dbusconfdir": "/etc/dbus-1",
+          "dbusinterfaces": "/usr/share/dbus-1/interfaces",
+          "dbusinterfacesconfdir": "/etc/dbus-1/interfaces",
+          "dbusservices": "/usr/share/dbus-1/services",
+          "dbusservicesconfdir": "/etc/dbus-1/services",
+          "dbussession": "/usr/share/dbus-1/session.d",
+          "dbussessionconfdir": "/etc/dbus-1/session.d",
+          "dbussystem": "confdir/etc/dbus-1/system.d",
+          "dbussystemservices": "/usr/share/dbus-1/system-services",
+          "dbussystemservicesconfdir": "/etc/dbus-1/system-services",
+          "early_microcode": "yes",
+          "environment": "/usr/lib/environment.d",
+          "environmentconfdir": "/etc/environment.d",
+          "hostonly": "yes",
+          "hostonly_cmdline": "no",
+          "i18n_default_font": "eurlatgr",
+          "i18n_install_all": "yes",
+          "i18n_vars": "/etc/sysconfig/keyboard:KEYTABLE-KEYMAP /etc/sysconfig/i18n:SYSFONT-FONT,FONTACM-FONT_MAP,FONT_UNIMAP",
+          "install_optional_items": " vi /etc/virc ps grep cat rm ",
+          "prefix": "/",
+          "reproducible": "yes",
+          "stdloglvl": "3",
+          "sysctlconfdir": "/etc/sysctl.d",
+          "sysctld": "/usr/lib/sysctl.d",
+          "sysloglvl": "5",
+          "systemdcatalog": "/usr/lib/systemd/catalog",
+          "systemdntpunits": "/usr/lib/systemd/ntp-units.d",
+          "systemdntpunitsconfdir": "/etc/systemd/ntp-units.d",
+          "systemdportable": "/usr/lib/systemd/portable",
+          "systemdportableconfdir": "/etc/systemd/portable",
+          "systemdsystemconfdir": "/etc/systemd/system",
+          "systemdsystemunitdir": "/usr/lib/systemd/system",
+          "systemduser": "/usr/lib/systemd/user",
+          "systemduserconfdir": "/etc/systemd/user",
+          "systemdutilconfdir": "/etc/systemd",
+          "systemdutildir": "/usr/lib/systemd",
+          "sysusers": "/usr/lib/sysusers.d",
+          "sysusersconfdir": "/etc/sysusers.d",
+          "udevdir": "/usr/lib/udev"
+        },
+        "02-generic-image.conf": {
+          "hostonly": "no"
+        }
+      }
+    },
+    "fstab": [
+      [
+        "UUID=46BB-8120",
+        "/boot/efi",
+        "vfat",
+        "umask=0077,shortname=winnt",
+        "0",
+        "2"
+      ],
+      [
+        "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+        "/",
+        "ext4",
+        "defaults",
+        "1",
+        "1"
+      ]
+    ],
+    "groups": [
+      "adm:x:4:",
+      "audio:x:63:",
+      "bin:x:1:",
+      "cdrom:x:11:",
+      "chrony:x:993:",
+      "daemon:x:2:",
+      "dbus:x:81:",
+      "dialout:x:18:",
+      "disk:x:6:",
+      "floppy:x:19:",
+      "ftp:x:50:",
+      "games:x:20:",
+      "group1:x:1030:user2",
+      "group2:x:1050:",
+      "input:x:104:",
+      "kmem:x:9:",
+      "kvm:x:36:",
+      "lock:x:54:",
+      "lp:x:7:",
+      "mail:x:12:",
+      "man:x:15:",
+      "mem:x:8:",
+      "nobody:x:65534:",
+      "polkitd:x:994:",
+      "render:x:105:",
+      "root:x:0:",
+      "sgx:x:106:",
+      "ssh_keys:x:996:",
+      "sshd:x:74:",
+      "sys:x:3:",
+      "systemd-coredump:x:997:",
+      "systemd-journal:x:190:",
+      "systemd-network:x:192:",
+      "systemd-oom:x:999:",
+      "systemd-resolve:x:193:",
+      "systemd-timesync:x:998:",
+      "tape:x:33:",
+      "tss:x:59:",
+      "tty:x:5:",
+      "unbound:x:995:",
+      "user1:x:1000:",
+      "users:x:100:",
+      "utempter:x:35:",
+      "utmp:x:22:",
+      "video:x:39:",
+      "wheel:x:10:"
+    ],
+    "hostname": "my-host",
+    "hosts": [
+      "127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4",
+      "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
+    ],
+    "image-format": {
+      "compat": "1.1",
+      "type": "qcow2"
+    },
+    "keyboard": {
+      "vconsole": {
+        "KEYMAP": "dvorak"
+      }
+    },
+    "locale": {
+      "LANG": "el_CY.UTF-8"
+    },
+    "machine-id": "",
+    "os-release": {
+      "ANSI_COLOR": "0;38;2;60;110;180",
+      "BUG_REPORT_URL": "https://bugzilla.redhat.com/",
+      "CPE_NAME": "cpe:/o:fedoraproject:fedora:35",
+      "DOCUMENTATION_URL": "https://docs.fedoraproject.org/en-US/fedora/f35/system-administrators-guide/",
+      "HOME_URL": "https://fedoraproject.org/",
+      "ID": "fedora",
+      "LOGO": "fedora-logo-icon",
+      "NAME": "Fedora Linux",
+      "PLATFORM_ID": "platform:f35",
+      "PRETTY_NAME": "Fedora Linux 35 (Cloud Edition)",
+      "PRIVACY_POLICY_URL": "https://fedoraproject.org/wiki/Legal:PrivacyPolicy",
+      "REDHAT_BUGZILLA_PRODUCT": "Fedora",
+      "REDHAT_BUGZILLA_PRODUCT_VERSION": "35",
+      "REDHAT_SUPPORT_PRODUCT": "Fedora",
+      "REDHAT_SUPPORT_PRODUCT_VERSION": "35",
+      "SUPPORT_URL": "https://ask.fedoraproject.org/",
+      "VARIANT": "Cloud Edition",
+      "VARIANT_ID": "cloud",
+      "VERSION": "35 (Cloud Edition)",
+      "VERSION_CODENAME": "",
+      "VERSION_ID": "35"
+    },
+    "packages": [
+      "NetworkManager-1.32.12-2.fc35.aarch64",
+      "NetworkManager-libnm-1.32.12-2.fc35.aarch64",
+      "acl-2.3.1-2.fc35.aarch64",
+      "alternatives-1.19-1.fc35.aarch64",
+      "audit-3.0.6-1.fc35.aarch64",
+      "audit-libs-3.0.6-1.fc35.aarch64",
+      "basesystem-11-12.fc35.noarch",
+      "bash-5.1.8-2.fc35.aarch64",
+      "bzip2-libs-1.0.8-9.fc35.aarch64",
+      "c-ares-1.17.2-1.fc35.aarch64",
+      "ca-certificates-2021.2.52-1.0.fc35.noarch",
+      "checkpolicy-3.3-1.fc35.aarch64",
+      "chkconfig-1.19-1.fc35.aarch64",
+      "chrony-4.1-3.fc35.aarch64",
+      "cloud-init-20.4-7.fc35.noarch",
+      "cloud-utils-growpart-0.31-9.fc35.noarch",
+      "console-login-helper-messages-0.21.2-3.fc35.noarch",
+      "console-login-helper-messages-issuegen-0.21.2-3.fc35.noarch",
+      "console-login-helper-messages-motdgen-0.21.2-3.fc35.noarch",
+      "console-login-helper-messages-profile-0.21.2-3.fc35.noarch",
+      "coreutils-8.32-31.fc35.aarch64",
+      "coreutils-common-8.32-31.fc35.aarch64",
+      "cpio-2.13-11.fc35.aarch64",
+      "cracklib-2.9.6-27.fc35.aarch64",
+      "cracklib-dicts-2.9.6-27.fc35.aarch64",
+      "crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch",
+      "crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch",
+      "cryptsetup-libs-2.4.2-1.fc35.aarch64",
+      "curl-7.79.1-1.fc35.aarch64",
+      "cyrus-sasl-lib-2.1.27-13.fc35.aarch64",
+      "dbus-1.12.20-5.fc35.aarch64",
+      "dbus-broker-29-4.fc35.aarch64",
+      "dbus-common-1.12.20-5.fc35.noarch",
+      "dbus-libs-1.12.20-5.fc35.aarch64",
+      "dejavu-sans-fonts-2.37-17.fc35.noarch",
+      "deltarpm-3.6.2-10.fc35.aarch64",
+      "device-mapper-1.02.175-6.fc35.aarch64",
+      "device-mapper-libs-1.02.175-6.fc35.aarch64",
+      "dhcp-client-4.4.2-16.b1.fc35.aarch64",
+      "dhcp-common-4.4.2-16.b1.fc35.noarch",
+      "diffutils-3.8-1.fc35.aarch64",
+      "dnf-4.9.0-1.fc35.noarch",
+      "dnf-data-4.9.0-1.fc35.noarch",
+      "dnf-plugins-core-4.0.24-1.fc35.noarch",
+      "dracut-055-6.fc35.aarch64",
+      "dracut-config-generic-055-6.fc35.aarch64",
+      "e2fsprogs-1.46.3-1.fc35.aarch64",
+      "e2fsprogs-libs-1.46.3-1.fc35.aarch64",
+      "efi-filesystem-5-4.fc35.noarch",
+      "efibootmgr-16-11.fc35.aarch64",
+      "efivar-libs-37-17.fc35.aarch64",
+      "elfutils-debuginfod-client-0.186-1.fc35.aarch64",
+      "elfutils-default-yama-scope-0.186-1.fc35.noarch",
+      "elfutils-libelf-0.186-1.fc35.aarch64",
+      "elfutils-libs-0.186-1.fc35.aarch64",
+      "expat-2.4.1-2.fc35.aarch64",
+      "fedora-gpg-keys-35-1.noarch",
+      "fedora-release-cloud-35-36.noarch",
+      "fedora-release-common-35-36.noarch",
+      "fedora-release-identity-cloud-35-36.noarch",
+      "fedora-repos-35-1.noarch",
+      "fedora-repos-modular-35-1.noarch",
+      "file-5.40-9.fc35.aarch64",
+      "file-libs-5.40-9.fc35.aarch64",
+      "filesystem-3.14-7.fc35.aarch64",
+      "findutils-4.8.0-4.fc35.aarch64",
+      "fonts-filesystem-2.0.5-6.fc35.noarch",
+      "freetype-2.11.0-1.fc35.aarch64",
+      "fuse-libs-2.9.9-13.fc35.aarch64",
+      "gawk-5.1.0-4.fc35.aarch64",
+      "gawk-all-langpacks-5.1.0-4.fc35.aarch64",
+      "gdbm-libs-1.22-1.fc35.aarch64",
+      "gettext-0.21-8.fc35.aarch64",
+      "gettext-libs-0.21-8.fc35.aarch64",
+      "glib2-2.70.2-1.fc35.aarch64",
+      "glibc-2.34-11.fc35.aarch64",
+      "glibc-common-2.34-11.fc35.aarch64",
+      "glibc-gconv-extra-2.34-11.fc35.aarch64",
+      "glibc-langpack-en-2.34-11.fc35.aarch64",
+      "gmp-6.2.0-7.fc35.aarch64",
+      "gnupg2-2.3.4-1.fc35.aarch64",
+      "gnupg2-smime-2.3.4-1.fc35.aarch64",
+      "gnutls-3.7.2-2.fc35.aarch64",
+      "gpg-pubkey-9867c58f-601c49ca",
+      "gpgme-1.15.1-6.fc35.aarch64",
+      "graphite2-1.3.14-8.fc35.aarch64",
+      "grep-3.6-4.fc35.aarch64",
+      "groff-base-1.22.4-8.fc35.aarch64",
+      "grub2-common-2.06-10.fc35.noarch",
+      "grub2-efi-aa64-2.06-10.fc35.aarch64",
+      "grub2-tools-2.06-10.fc35.aarch64",
+      "grub2-tools-extra-2.06-10.fc35.aarch64",
+      "grub2-tools-minimal-2.06-10.fc35.aarch64",
+      "grubby-8.40-55.fc35.aarch64",
+      "gzip-1.10-5.fc35.aarch64",
+      "harfbuzz-2.8.2-2.fc35.aarch64",
+      "hostname-3.23-5.fc35.aarch64",
+      "hunspell-1.7.0-11.fc35.aarch64",
+      "hunspell-en-0.20140811.1-20.fc35.noarch",
+      "hunspell-en-GB-0.20140811.1-20.fc35.noarch",
+      "hunspell-en-US-0.20140811.1-20.fc35.noarch",
+      "hunspell-filesystem-1.7.0-11.fc35.aarch64",
+      "ima-evm-utils-1.3.2-3.fc35.aarch64",
+      "inih-49-4.fc35.aarch64",
+      "initscripts-10.11-1.fc35.aarch64",
+      "initscripts-service-10.11-1.fc35.noarch",
+      "ipcalc-1.0.1-2.fc35.aarch64",
+      "iproute-5.13.0-2.fc35.aarch64",
+      "iproute-tc-5.13.0-2.fc35.aarch64",
+      "iptables-legacy-libs-1.8.7-13.fc35.aarch64",
+      "iptables-libs-1.8.7-13.fc35.aarch64",
+      "iputils-20210722-1.fc35.aarch64",
+      "json-c-0.15-2.fc35.aarch64",
+      "kbd-2.4.0-8.fc35.aarch64",
+      "kbd-misc-2.4.0-8.fc35.noarch",
+      "kernel-5.15.13-200.fc35.aarch64",
+      "kernel-core-5.15.13-200.fc35.aarch64",
+      "kernel-modules-5.15.13-200.fc35.aarch64",
+      "keyutils-libs-1.6.1-3.fc35.aarch64",
+      "kmod-29-4.fc35.aarch64",
+      "kmod-libs-29-4.fc35.aarch64",
+      "kpartx-0.8.6-5.fc35.aarch64",
+      "krb5-libs-1.19.2-2.fc35.aarch64",
+      "langpacks-core-en-3.0-15.fc35.noarch",
+      "langpacks-core-font-en-3.0-15.fc35.noarch",
+      "langpacks-en-3.0-15.fc35.noarch",
+      "less-590-2.fc35.aarch64",
+      "libacl-2.3.1-2.fc35.aarch64",
+      "libarchive-3.5.2-2.fc35.aarch64",
+      "libargon2-20171227-7.fc35.aarch64",
+      "libassuan-2.5.5-3.fc35.aarch64",
+      "libattr-2.5.1-3.fc35.aarch64",
+      "libbasicobjects-0.1.1-48.fc35.aarch64",
+      "libblkid-2.37.2-1.fc35.aarch64",
+      "libbrotli-1.0.9-6.fc35.aarch64",
+      "libcap-2.48-3.fc35.aarch64",
+      "libcap-ng-0.8.2-8.fc35.aarch64",
+      "libcbor-0.7.0-4.fc35.aarch64",
+      "libcollection-0.7.0-48.fc35.aarch64",
+      "libcom_err-1.46.3-1.fc35.aarch64",
+      "libcomps-0.1.18-1.fc35.aarch64",
+      "libcurl-7.79.1-1.fc35.aarch64",
+      "libdb-5.3.28-50.fc35.aarch64",
+      "libdhash-0.5.0-48.fc35.aarch64",
+      "libdnf-0.64.0-1.fc35.aarch64",
+      "libeconf-0.4.0-2.fc35.aarch64",
+      "libedit-3.1-40.20210910cvs.fc35.aarch64",
+      "libevent-2.1.12-4.fc35.aarch64",
+      "libfdisk-2.37.2-1.fc35.aarch64",
+      "libffi-3.1-29.fc35.aarch64",
+      "libfido2-1.8.0-1.fc35.aarch64",
+      "libfsverity-1.4-6.fc35.aarch64",
+      "libgcc-11.2.1-7.fc35.aarch64",
+      "libgcrypt-1.9.4-1.fc35.aarch64",
+      "libgomp-11.2.1-7.fc35.aarch64",
+      "libgpg-error-1.43-1.fc35.aarch64",
+      "libibverbs-38.0-1.fc35.aarch64",
+      "libidn2-2.3.2-3.fc35.aarch64",
+      "libini_config-1.3.1-48.fc35.aarch64",
+      "libkcapi-1.3.1-3.fc35.aarch64",
+      "libkcapi-hmaccalc-1.3.1-3.fc35.aarch64",
+      "libksba-1.6.0-2.fc35.aarch64",
+      "libldb-2.4.1-1.fc35.aarch64",
+      "libmaxminddb-1.6.0-1.fc35.aarch64",
+      "libmnl-1.0.4-14.fc35.aarch64",
+      "libmodulemd-2.13.0-3.fc35.aarch64",
+      "libmount-2.37.2-1.fc35.aarch64",
+      "libndp-1.8-2.fc35.aarch64",
+      "libnetfilter_conntrack-1.0.8-3.fc35.aarch64",
+      "libnfnetlink-1.0.1-20.fc35.aarch64",
+      "libnfsidmap-2.5.4-2.rc3.fc35.aarch64",
+      "libnghttp2-1.45.1-1.fc35.aarch64",
+      "libnl3-3.5.0-8.fc35.aarch64",
+      "libnsl2-1.3.0-4.fc35.aarch64",
+      "libpath_utils-0.2.1-48.fc35.aarch64",
+      "libpcap-1.10.1-2.fc35.aarch64",
+      "libpipeline-1.5.3-3.fc35.aarch64",
+      "libpng-1.6.37-11.fc35.aarch64",
+      "libpsl-0.21.1-4.fc35.aarch64",
+      "libpwquality-1.4.4-6.fc35.aarch64",
+      "libref_array-0.1.5-48.fc35.aarch64",
+      "librepo-1.14.2-1.fc35.aarch64",
+      "libreport-filesystem-2.15.2-6.fc35.noarch",
+      "libseccomp-2.5.3-1.fc35.aarch64",
+      "libsecret-0.20.4-3.fc35.aarch64",
+      "libselinux-3.3-1.fc35.aarch64",
+      "libselinux-utils-3.3-1.fc35.aarch64",
+      "libsemanage-3.3-1.fc35.aarch64",
+      "libsepol-3.3-2.fc35.aarch64",
+      "libsigsegv-2.13-3.fc35.aarch64",
+      "libsmartcols-2.37.2-1.fc35.aarch64",
+      "libsolv-0.7.19-3.fc35.aarch64",
+      "libss-1.46.3-1.fc35.aarch64",
+      "libssh-0.9.6-1.fc35.aarch64",
+      "libssh-config-0.9.6-1.fc35.noarch",
+      "libsss_autofs-2.6.1-1.fc35.aarch64",
+      "libsss_certmap-2.6.1-1.fc35.aarch64",
+      "libsss_idmap-2.6.1-1.fc35.aarch64",
+      "libsss_nss_idmap-2.6.1-1.fc35.aarch64",
+      "libsss_sudo-2.6.1-1.fc35.aarch64",
+      "libstdc++-11.2.1-7.fc35.aarch64",
+      "libtalloc-2.3.3-2.fc35.aarch64",
+      "libtasn1-4.16.0-6.fc35.aarch64",
+      "libtdb-1.4.4-3.fc35.aarch64",
+      "libtevent-0.11.0-1.fc35.aarch64",
+      "libtirpc-1.3.2-1.fc35.aarch64",
+      "libunistring-0.9.10-14.fc35.aarch64",
+      "libusb1-1.0.24-4.fc35.aarch64",
+      "libuser-0.63-7.fc35.aarch64",
+      "libutempter-1.2.1-5.fc35.aarch64",
+      "libuuid-2.37.2-1.fc35.aarch64",
+      "libverto-0.3.2-2.fc35.aarch64",
+      "libxcrypt-4.4.27-1.fc35.aarch64",
+      "libxkbcommon-1.3.1-1.fc35.aarch64",
+      "libxml2-2.9.12-6.fc35.aarch64",
+      "libyaml-0.2.5-6.fc35.aarch64",
+      "libzstd-1.5.1-4.fc35.aarch64",
+      "linux-atm-libs-2.5.1-30.fc35.aarch64",
+      "linux-firmware-20211216-127.fc35.noarch",
+      "linux-firmware-whence-20211216-127.fc35.noarch",
+      "lmdb-libs-0.9.29-2.fc35.aarch64",
+      "lua-libs-5.4.3-2.fc35.aarch64",
+      "lz4-libs-1.9.3-3.fc35.aarch64",
+      "man-db-2.9.4-2.fc35.aarch64",
+      "memstrack-0.2.4-1.fc35.aarch64",
+      "mkpasswd-5.5.10-2.fc35.aarch64",
+      "mokutil-0.5.0-1.fc35.aarch64",
+      "mozjs78-78.15.0-1.fc35.aarch64",
+      "mpdecimal-2.5.1-2.fc35.aarch64",
+      "mpfr-4.1.0-8.fc35.aarch64",
+      "ncurses-6.2-8.20210508.fc35.aarch64",
+      "ncurses-base-6.2-8.20210508.fc35.noarch",
+      "ncurses-libs-6.2-8.20210508.fc35.aarch64",
+      "net-tools-2.0-0.60.20160912git.fc35.aarch64",
+      "nettle-3.7.3-2.fc35.aarch64",
+      "npth-1.6-7.fc35.aarch64",
+      "openldap-2.4.59-3.fc35.aarch64",
+      "openssh-8.7p1-3.fc35.aarch64",
+      "openssh-clients-8.7p1-3.fc35.aarch64",
+      "openssh-server-8.7p1-3.fc35.aarch64",
+      "openssl-libs-1.1.1l-2.fc35.aarch64",
+      "openssl-pkcs11-0.4.11-4.fc35.aarch64",
+      "os-prober-1.77-8.fc35.aarch64",
+      "p11-kit-0.23.22-4.fc35.aarch64",
+      "p11-kit-trust-0.23.22-4.fc35.aarch64",
+      "pam-1.5.2-5.fc35.aarch64",
+      "parted-3.4-6.fc35.aarch64",
+      "passwd-0.80-11.fc35.aarch64",
+      "pcre-8.45-1.fc35.aarch64",
+      "pcre2-10.37-4.fc35.aarch64",
+      "pcre2-syntax-10.37-4.fc35.noarch",
+      "pcsc-lite-1.9.5-1.fc35.aarch64",
+      "pcsc-lite-ccid-1.4.36-2.fc35.aarch64",
+      "pcsc-lite-libs-1.9.5-1.fc35.aarch64",
+      "pigz-2.5-2.fc35.aarch64",
+      "pinentry-1.2.0-1.fc35.aarch64",
+      "policycoreutils-3.3-1.fc35.aarch64",
+      "polkit-0.120-1.fc35.aarch64",
+      "polkit-libs-0.120-1.fc35.aarch64",
+      "polkit-pkla-compat-0.1-20.fc35.aarch64",
+      "popt-1.18-6.fc35.aarch64",
+      "procps-ng-3.3.17-3.fc35.aarch64",
+      "protobuf-c-1.4.0-1.fc35.aarch64",
+      "psmisc-23.4-2.fc35.aarch64",
+      "publicsuffix-list-dafsa-20210518-2.fc35.noarch",
+      "python-pip-wheel-21.2.3-4.fc35.noarch",
+      "python-setuptools-wheel-57.4.0-1.fc35.noarch",
+      "python-unversioned-command-3.10.1-2.fc35.noarch",
+      "python3-3.10.1-2.fc35.aarch64",
+      "python3-attrs-21.2.0-4.fc35.noarch",
+      "python3-audit-3.0.6-1.fc35.aarch64",
+      "python3-babel-2.9.1-4.fc35.noarch",
+      "python3-cffi-1.14.6-2.fc35.aarch64",
+      "python3-charset-normalizer-2.0.4-1.fc35.noarch",
+      "python3-configobj-5.0.6-25.fc35.noarch",
+      "python3-cryptography-3.4.7-5.fc35.aarch64",
+      "python3-dateutil-2.8.1-7.fc35.noarch",
+      "python3-dbus-1.2.18-2.fc35.aarch64",
+      "python3-distro-1.6.0-1.fc35.noarch",
+      "python3-dnf-4.9.0-1.fc35.noarch",
+      "python3-dnf-plugins-core-4.0.24-1.fc35.noarch",
+      "python3-gpg-1.15.1-6.fc35.aarch64",
+      "python3-hawkey-0.64.0-1.fc35.aarch64",
+      "python3-idna-3.2-1.fc35.noarch",
+      "python3-jinja2-3.0.1-2.fc35.noarch",
+      "python3-jsonpatch-1.21-18.fc35.noarch",
+      "python3-jsonpointer-2.0-4.fc35.noarch",
+      "python3-jsonschema-3.2.0-12.fc35.noarch",
+      "python3-jwt+crypto-2.1.0-2.fc35.noarch",
+      "python3-jwt-2.1.0-2.fc35.noarch",
+      "python3-libcomps-0.1.18-1.fc35.aarch64",
+      "python3-libdnf-0.64.0-1.fc35.aarch64",
+      "python3-libs-3.10.1-2.fc35.aarch64",
+      "python3-libselinux-3.3-1.fc35.aarch64",
+      "python3-libsemanage-3.3-1.fc35.aarch64",
+      "python3-markupsafe-2.0.0-2.fc35.aarch64",
+      "python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch",
+      "python3-oauthlib-3.0.2-11.fc35.noarch",
+      "python3-ply-3.11-13.fc35.noarch",
+      "python3-policycoreutils-3.3-1.fc35.noarch",
+      "python3-prettytable-0.7.2-27.fc35.noarch",
+      "python3-pycparser-2.20-5.fc35.noarch",
+      "python3-pyrsistent-0.18.0-8.fc35.aarch64",
+      "python3-pyserial-3.4-12.fc35.noarch",
+      "python3-pysocks-1.7.1-11.fc35.noarch",
+      "python3-pytz-2021.3-1.fc35.noarch",
+      "python3-pyyaml-5.4.1-4.fc35.aarch64",
+      "python3-requests-2.27.0-1.fc35.noarch",
+      "python3-rpm-4.17.0-1.fc35.aarch64",
+      "python3-setools-4.4.0-3.fc35.aarch64",
+      "python3-setuptools-57.4.0-1.fc35.noarch",
+      "python3-six-1.16.0-4.fc35.noarch",
+      "python3-unbound-1.13.2-1.fc35.aarch64",
+      "python3-urllib3-1.26.7-2.fc35.noarch",
+      "qrencode-libs-4.1.1-1.fc35.aarch64",
+      "readline-8.1-3.fc35.aarch64",
+      "rootfiles-8.1-30.fc35.noarch",
+      "rpm-4.17.0-1.fc35.aarch64",
+      "rpm-build-libs-4.17.0-1.fc35.aarch64",
+      "rpm-libs-4.17.0-1.fc35.aarch64",
+      "rpm-plugin-selinux-4.17.0-1.fc35.aarch64",
+      "rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64",
+      "rpm-sign-libs-4.17.0-1.fc35.aarch64",
+      "rsync-3.2.3-8.fc35.aarch64",
+      "sed-4.8-8.fc35.aarch64",
+      "selinux-policy-35.8-1.fc35.noarch",
+      "selinux-policy-targeted-35.8-1.fc35.noarch",
+      "setup-2.13.9.1-2.fc35.noarch",
+      "shadow-utils-4.9-8.fc35.aarch64",
+      "shim-aa64-15.4-5.aarch64",
+      "sqlite-libs-3.36.0-3.fc35.aarch64",
+      "sssd-client-2.6.1-1.fc35.aarch64",
+      "sssd-common-2.6.1-1.fc35.aarch64",
+      "sssd-kcm-2.6.1-1.fc35.aarch64",
+      "sssd-nfs-idmap-2.6.1-1.fc35.aarch64",
+      "sudo-1.9.7p2-2.fc35.aarch64",
+      "sudo-python-plugin-1.9.7p2-2.fc35.aarch64",
+      "systemd-249.7-2.fc35.aarch64",
+      "systemd-libs-249.7-2.fc35.aarch64",
+      "systemd-networkd-249.7-2.fc35.aarch64",
+      "systemd-oomd-defaults-249.7-2.fc35.noarch",
+      "systemd-pam-249.7-2.fc35.aarch64",
+      "systemd-resolved-249.7-2.fc35.aarch64",
+      "systemd-udev-249.7-2.fc35.aarch64",
+      "tar-1.34-2.fc35.aarch64",
+      "tpm2-tss-3.1.0-3.fc35.aarch64",
+      "trousers-0.3.15-4.fc35.aarch64",
+      "trousers-lib-0.3.15-4.fc35.aarch64",
+      "tzdata-2021e-1.fc35.noarch",
+      "unbound-libs-1.13.2-1.fc35.aarch64",
+      "util-linux-2.37.2-1.fc35.aarch64",
+      "util-linux-core-2.37.2-1.fc35.aarch64",
+      "vim-data-8.2.4006-1.fc35.noarch",
+      "vim-minimal-8.2.4006-1.fc35.aarch64",
+      "which-2.21-27.fc35.aarch64",
+      "whois-nls-5.5.10-2.fc35.noarch",
+      "xfsprogs-5.12.0-2.fc35.aarch64",
+      "xkeyboard-config-2.33-2.fc35.noarch",
+      "xz-5.2.5-7.fc35.aarch64",
+      "xz-libs-5.2.5-7.fc35.aarch64",
+      "yum-4.9.0-1.fc35.noarch",
+      "zchunk-libs-1.1.15-2.fc35.aarch64",
+      "zlib-1.2.11-30.fc35.aarch64"
+    ],
+    "partition-table": "gpt",
+    "partition-table-id": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
+    "partitions": [
+      {
+        "bootable": false,
+        "fstype": "vfat",
+        "label": "EFI-SYSTEM",
+        "partuuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
+        "size": 498073600,
+        "start": 1048576,
+        "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+        "uuid": "46BB-8120"
+      },
+      {
+        "bootable": false,
+        "fstype": "ext4",
+        "label": null,
+        "partuuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
+        "size": 1647296000,
+        "start": 500170752,
+        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+        "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+      }
+    ],
+    "passwd": [
+      "adm:x:3:4:adm:/var/adm:/sbin/nologin",
+      "bin:x:1:1:bin:/bin:/sbin/nologin",
+      "chrony:x:994:993::/var/lib/chrony:/sbin/nologin",
+      "daemon:x:2:2:daemon:/sbin:/sbin/nologin",
+      "dbus:x:81:81:System message bus:/:/sbin/nologin",
+      "ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin",
+      "games:x:12:100:games:/usr/games:/sbin/nologin",
+      "halt:x:7:0:halt:/sbin:/sbin/halt",
+      "lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin",
+      "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
+      "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
+      "operator:x:11:0:operator:/root:/sbin/nologin",
+      "polkitd:x:995:994:User for polkitd:/:/sbin/nologin",
+      "root:x:0:0:root:/root:/bin/bash",
+      "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
+      "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
+      "sync:x:5:0:sync:/sbin:/bin/sync",
+      "systemd-coredump:x:997:997:systemd Core Dumper:/:/usr/sbin/nologin",
+      "systemd-network:x:192:192:systemd Network Management:/:/usr/sbin/nologin",
+      "systemd-oom:x:999:999:systemd Userspace OOM Killer:/:/usr/sbin/nologin",
+      "systemd-resolve:x:193:193:systemd Resolver:/:/usr/sbin/nologin",
+      "systemd-timesync:x:998:998:systemd Time Synchronization:/:/usr/sbin/nologin",
+      "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
+      "unbound:x:996:995:Unbound DNS resolver:/etc/unbound:/sbin/nologin",
+      "user1:x:1000:1000::/home/user1:/bin/bash",
+      "user2:x:1020:1050:description 2:/home/home2:/bin/sh"
+    ],
+    "rpm-verify": {
+      "changed": {
+        "/boot/efi/EFI": ".M.......",
+        "/boot/efi/EFI/BOOT/BOOTAA64.EFI": ".......T.",
+        "/boot/efi/EFI/BOOT/fbaa64.efi": ".......T.",
+        "/boot/efi/EFI/fedora/BOOTAA64.CSV": ".......T.",
+        "/boot/efi/EFI/fedora/grubaa64.efi": ".......T.",
+        "/boot/efi/EFI/fedora/mmaa64.efi": ".......T.",
+        "/boot/efi/EFI/fedora/shim.efi": ".......T.",
+        "/boot/efi/EFI/fedora/shimaa64.efi": ".......T.",
+        "/etc/chrony.conf": "S.5....T.",
+        "/etc/machine-id": ".M.......",
+        "/etc/udev/hwdb.bin": ".M.......",
+        "/proc": ".M.......",
+        "/sys": ".M.......",
+        "/var/log/lastlog": ".M....G.."
+      },
+      "missing": []
+    },
+    "selinux": {
+      "context-mismatch": [
+        {
+          "actual": "system_u:object_r:unlabeled_t:s0",
+          "expected": "system_u:object_r:lost_found_t:s0",
+          "filename": "/lost+found"
+        }
+      ],
+      "policy": {
+        "SELINUX": "enforcing",
+        "SELINUXTYPE": "targeted"
+      }
+    },
+    "services-disabled": [
+      "arp-ethers.service",
+      "chrony-wait.service",
+      "console-getty.service",
+      "console-login-helper-messages-gensnippet-os-release.service",
+      "console-login-helper-messages-gensnippet-ssh-keys.service",
+      "debug-shell.service",
+      "exit.target",
+      "halt.target",
+      "kexec.target",
+      "loadmodules.service",
+      "man-db-restart-cache-update.service",
+      "nis-domainname.service",
+      "poweroff.target",
+      "proc-sys-fs-binfmt_misc.mount",
+      "rdisc.service",
+      "remote-cryptsetup.target",
+      "remote-veritysetup.target",
+      "runlevel0.target",
+      "selinux-check-proper-disable.service",
+      "serial-getty@.service",
+      "sshd-keygen@.service",
+      "sssd-autofs.socket",
+      "sssd-nss.socket",
+      "sssd-pac.socket",
+      "sssd-pam-priv.socket",
+      "sssd-pam.socket",
+      "sssd-ssh.socket",
+      "sssd-sudo.socket",
+      "systemd-boot-check-no-failures.service",
+      "systemd-network-generator.service",
+      "systemd-networkd-wait-online.service",
+      "systemd-networkd.service",
+      "systemd-networkd.socket",
+      "systemd-pstore.service",
+      "systemd-sysext.service",
+      "systemd-time-wait-sync.service",
+      "systemd-timesyncd.service",
+      "tcsd.service"
+    ],
+    "services-enabled": [
+      "NetworkManager-dispatcher.service",
+      "NetworkManager-wait-online.service",
+      "NetworkManager.service",
+      "auditd.service",
+      "autovt@.service",
+      "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
+      "ctrl-alt-del.target",
+      "dbus-broker.service",
+      "dbus-org.freedesktop.home1.service",
+      "dbus-org.freedesktop.nm-dispatcher.service",
+      "dbus-org.freedesktop.oom1.service",
+      "dbus-org.freedesktop.resolve1.service",
+      "dbus.service",
+      "dbus.socket",
+      "dnf-makecache.timer",
+      "fstrim.timer",
+      "getty@.service",
+      "import-state.service",
+      "pcscd.socket",
+      "reboot.target",
+      "remote-fs.target",
+      "rpmdb-rebuild.service",
+      "runlevel6.target",
+      "selinux-autorelabel-mark.service",
+      "sshd.service",
+      "sshd.socket",
+      "sssd-kcm.socket",
+      "sssd.service",
+      "systemd-homed-activate.service",
+      "systemd-homed.service",
+      "systemd-oomd.service",
+      "systemd-resolved.service",
+      "systemd-userdbd.socket",
+      "unbound-anchor.timer"
+    ],
+    "sudoers": {
+      "/etc/sudoers": [
+        "Defaults   !visiblepw",
+        "Defaults    always_set_home",
+        "Defaults    match_group_by_gid",
+        "Defaults    always_query_group_plugin",
+        "Defaults    env_reset",
+        "Defaults    env_keep =  \"COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS\"",
+        "Defaults    env_keep += \"MAIL QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE\"",
+        "Defaults    env_keep += \"LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES\"",
+        "Defaults    env_keep += \"LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE\"",
+        "Defaults    env_keep += \"LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY\"",
+        "Defaults    secure_path = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+        "root\tALL=(ALL) \tALL",
+        "%wheel\tALL=(ALL)\tALL"
+      ]
+    },
+    "sysctl.d": {
+      "/usr/lib/sysctl.d": {
+        "10-default-yama-scope.conf": [
+          "kernel.yama.ptrace_scope = 0"
+        ],
+        "50-coredump.conf": [
+          "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h",
+          "kernel.core_pipe_limit=16",
+          "fs.suid_dumpable=2"
+        ],
+        "50-default.conf": [
+          "kernel.sysrq = 16",
+          "kernel.core_uses_pid = 1",
+          "net.ipv4.conf.default.rp_filter = 2",
+          "net.ipv4.conf.*.rp_filter = 2",
+          "-net.ipv4.conf.all.rp_filter",
+          "net.ipv4.conf.default.accept_source_route = 0",
+          "net.ipv4.conf.*.accept_source_route = 0",
+          "-net.ipv4.conf.all.accept_source_route",
+          "net.ipv4.conf.default.promote_secondaries = 1",
+          "net.ipv4.conf.*.promote_secondaries = 1",
+          "-net.ipv4.conf.all.promote_secondaries",
+          "-net.ipv4.ping_group_range = 0 2147483647",
+          "-net.core.default_qdisc = fq_codel",
+          "fs.protected_hardlinks = 1",
+          "fs.protected_symlinks = 1",
+          "fs.protected_regular = 1",
+          "fs.protected_fifos = 1"
+        ],
+        "50-libkcapi-optmem_max.conf": [
+          "net.core.optmem_max = 81920"
+        ],
+        "50-pid-max.conf": [
+          "kernel.pid_max = 4194304"
+        ]
+      }
+    },
+    "systemd-service-dropins": {
+      "/usr/lib/systemd/system": {
+        "systemd-hostnamed.service.d": {
+          "Service": {
+            "PrivateDevices": "no"
+          }
+        },
+        "systemd-logind.service.d": {
+          "Service": {
+            "Environment": "SYSTEMD_REBOOT_TO_BOOT_LOADER_MENU=true"
+          }
+        },
+        "systemd-udev-trigger.service.d": {
+          "Unit": {
+            "RefuseManualStop": "true"
+          }
+        },
+        "user@.service.d": {
+          "Service": {
+            "ManagedOOMMemoryPressure": "kill",
+            "ManagedOOMMemoryPressureLimit": "50%"
+          }
+        }
+      }
+    },
+    "timezone": "London",
+    "tmpfiles.d": {
+      "/usr/lib/tmpfiles.d": {
+        "cloud-init.conf": [
+          "d /run/cloud-init 0700 root root - -"
+        ],
+        "console-login-helper-messages-issuegen.conf": [
+          "r /etc/issue.d/*_clhm_*.issue - - - - -"
+        ],
+        "console-login-helper-messages-motdgen.conf": [
+          "d /run/motd.d - - - - -"
+        ],
+        "console-login-helper-messages-profile.conf": [
+          "L /etc/profile.d/console-login-helper-messages-profile.sh - - - - ../../usr/share/console-login-helper-messages/profile.sh"
+        ],
+        "console-login-helper-messages.conf": [
+          "d /run/console-login-helper-messages - - - - -"
+        ],
+        "cryptsetup.conf": [
+          "d /run/cryptsetup 0700 root root -"
+        ],
+        "dnf.conf": [
+          "R /var/tmp/dnf*/locks/*",
+          "r /var/cache/dnf/download_lock.pid",
+          "r /var/cache/dnf/metadata_lock.pid",
+          "r /var/lib/dnf/rpmdb_lock.pid",
+          "r /var/log/log_lock.pid"
+        ],
+        "etc.conf": [
+          "L /etc/os-release - - - - ../usr/lib/os-release",
+          "L+ /etc/mtab - - - - ../proc/self/mounts",
+          "L! /etc/resolv.conf - - - - ../run/systemd/resolve/stub-resolv.conf",
+          "C! /etc/nsswitch.conf - - - -",
+          "C! /etc/pam.d - - - -",
+          "C! /etc/issue - - - -"
+        ],
+        "home.conf": [
+          "Q /home 0755 - - -",
+          "q /srv 0755 - - -"
+        ],
+        "journal-nocow.conf": [
+          "h /var/log/journal - - - - +C",
+          "h /var/log/journal/%m - - - - +C",
+          "h /var/log/journal/remote - - - - +C"
+        ],
+        "legacy.conf": [
+          "d /run/lock 0755 root root -",
+          "L /var/lock - - - - ../run/lock",
+          "d /run/lock/subsys 0755 root root -",
+          "r! /forcefsck",
+          "r! /fastboot",
+          "r! /forcequotacheck"
+        ],
+        "libselinux.conf": [
+          "d /run/setrans 0755 root root"
+        ],
+        "man-db.conf": [
+          "d /var/cache/man 0755 root root 1w"
+        ],
+        "pam.conf": [
+          "d /run/console 0755 root root -",
+          "d /run/faillock 0755 root root -",
+          "d /run/sepermit 0755 root root -",
+          "d /run/motd.d 0755 root root -",
+          "f /var/log/tallylog 0600 root root -"
+        ],
+        "portables.conf": [
+          "Q /var/lib/portables 0700"
+        ],
+        "selinux-policy.conf": [
+          "z /sys/devices/system/cpu/online - - -",
+          "Z /sys/class/net - - -",
+          "z /sys/kernel/uevent_helper - - -",
+          "w /sys/fs/selinux/checkreqprot - - - - 0"
+        ],
+        "setup.conf": [
+          "f /run/motd 0644 root root -",
+          "d /run/motd.d 0755 root root -"
+        ],
+        "static-nodes-permissions.conf": [
+          "z /dev/snd/seq      0660 - audio -",
+          "z /dev/snd/timer    0660 - audio -",
+          "z /dev/loop-control 0660 - disk  -",
+          "z /dev/net/tun      0666 - -     -",
+          "z /dev/fuse         0666 - -     -",
+          "z /dev/kvm          0666 - kvm -",
+          "z /dev/vhost-net    0666 - kvm -",
+          "z /dev/vhost-vsock  0666 - kvm -"
+        ],
+        "sudo.conf": [
+          "d /run/sudo 0711 root root",
+          "D /run/sudo/ts 0700 root root"
+        ],
+        "systemd-nologin.conf": [
+          "F! /run/nologin 0644 - - - \"System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8).\""
+        ],
+        "systemd-pstore.conf": [
+          "d /var/lib/systemd/pstore 0755 root root 14d"
+        ],
+        "systemd-tmp.conf": [
+          "x /tmp/systemd-private-%b-*",
+          "X /tmp/systemd-private-%b-*/tmp",
+          "x /var/tmp/systemd-private-%b-*",
+          "X /var/tmp/systemd-private-%b-*/tmp",
+          "R! /tmp/systemd-private-*",
+          "R! /var/tmp/systemd-private-*",
+          "x  /var/lib/systemd/coredump/.#core*.%b*",
+          "r! /var/lib/systemd/coredump/.#*"
+        ],
+        "systemd.conf": [
+          "d /run/user 0755 root root -",
+          "F! /run/utmp 0664 root utmp -",
+          "d /run/systemd/ask-password 0755 root root -",
+          "d /run/systemd/seats 0755 root root -",
+          "d /run/systemd/sessions 0755 root root -",
+          "d /run/systemd/users 0755 root root -",
+          "d /run/systemd/machines 0755 root root -",
+          "d /run/systemd/shutdown 0755 root root -",
+          "d /run/systemd/netif 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/links 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/leases 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/lldp 0755 systemd-network systemd-network -",
+          "d /run/log 0755 root root -",
+          "z /run/log/journal 2755 root systemd-journal - -",
+          "Z /run/log/journal/%m ~2750 root systemd-journal - -",
+          "a+ /run/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m/*.journal* - - - - group:adm:r--,group:wheel:r--",
+          "z /var/log/journal 2755 root systemd-journal - -",
+          "z /var/log/journal/%m 2755 root systemd-journal - -",
+          "z /var/log/journal/%m/system.journal 0640 root systemd-journal - -",
+          "a+ /var/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m/system.journal - - - - group:adm:r--,group:wheel:r--",
+          "d /var/lib/systemd 0755 root root -",
+          "d /var/lib/systemd/coredump 0755 root root 3d",
+          "d /var/lib/private 0700 root root -",
+          "d /var/log/private 0700 root root -",
+          "d /var/cache/private 0700 root root -"
+        ],
+        "tmp.conf": [
+          "q /tmp 1777 root root 10d",
+          "q /var/tmp 1777 root root 30d"
+        ],
+        "tpm2-tss-fapi.conf": [
+          "d       /var/lib/tpm2-tss/system/keystore   2775 tss  tss   -           -",
+          "a+      /var/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx",
+          "d       /run/tpm2-tss/eventlog                2775 tss  tss   -           -",
+          "a+      /run/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx"
+        ],
+        "var.conf": [
+          "q /var 0755 - - -",
+          "L /var/run - - - - ../run",
+          "d /var/log 0755 - - -",
+          "f /var/log/wtmp 0664 root utmp -",
+          "f /var/log/btmp 0660 root utmp -",
+          "f /var/log/lastlog 0664 root utmp -",
+          "d /var/cache 0755 - - -",
+          "d /var/lib 0755 - - -",
+          "d /var/spool 0755 - - -"
+        ],
+        "x11.conf": [
+          "D! /tmp/.X11-unix 1777 root root 10d",
+          "D! /tmp/.ICE-unix 1777 root root 10d",
+          "D! /tmp/.XIM-unix 1777 root root 10d",
+          "D! /tmp/.font-unix 1777 root root 10d",
+          "D! /tmp/.Test-unix 1777 root root 10d",
+          "r! /tmp/.X[0-9]*-lock"
+        ]
+      }
+    }
+  }
+}

--- a/test/data/manifests/fedora_35-x86_64-oci-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-oci-boot.json
@@ -1,0 +1,10776 @@
+{
+  "compose-request": {
+    "distro": "fedora-35",
+    "arch": "x86_64",
+    "image-type": "oci",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-modular-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-modular-20220113/",
+        "metadata_expire": "6h",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      }
+    ],
+    "filename": "disk.qcow2",
+    "blueprint": {}
+  },
+  "manifest": {
+    "sources": {
+      "org.osbuild.files": {
+        "urls": {
+          "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.x86_64.rpm"
+          },
+          "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm"
+          },
+          "sha256:01670b269d87e950484589f2751db8f3ef61e1c4098c2fc1aa71a050c9d880fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/shim-x64-15.4-5.x86_64.rpm"
+          },
+          "sha256:01feeac42a5067e0d93d26be4fdfbb9e6b98a0199308e5c6fcca3190ad3083ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.x86_64.rpm"
+          },
+          "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.x86_64.rpm"
+          },
+          "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm"
+          },
+          "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm"
+          },
+          "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm"
+          },
+          "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-jsonpatch-1.21-18.fc35.noarch.rpm"
+          },
+          "sha256:08c5a459c03ba0b3844020ed5683f2856396b43228a9a129fc1e464b61293579": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-efi-ia32-2.06-10.fc35.x86_64.rpm"
+          },
+          "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.x86_64.rpm"
+          },
+          "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm"
+          },
+          "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm"
+          },
+          "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm"
+          },
+          "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm"
+          },
+          "sha256:0e2da626938aaec7c67d507dea9ad22a071abbda428f249ecc4a431078b332de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-cryptography-3.4.7-5.fc35.x86_64.rpm"
+          },
+          "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm"
+          },
+          "sha256:0fe873066939d1c27abc0791379c1002965364b7bd3070eaa057add9f4dd044c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-langpack-en-2.34-11.fc35.x86_64.rpm"
+          },
+          "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm"
+          },
+          "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm"
+          },
+          "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm"
+          },
+          "sha256:1412d2c24a9c40dc9ccb1bd95aee49e4c817a95d2777a456c559d26b8014173b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-cffi-1.14.6-2.fc35.x86_64.rpm"
+          },
+          "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/langpacks-core-font-en-3.0-15.fc35.noarch.rpm"
+          },
+          "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm"
+          },
+          "sha256:1543cae4d98b7e701c42218004ead3680f01b403a3694dcd56ab504e715690a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.x86_64.rpm"
+          },
+          "sha256:154cb55953505aee6e0546b7b1496a742ad1d01ae59262e1bd3dd473040903ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.x86_64.rpm"
+          },
+          "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.x86_64.rpm"
+          },
+          "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.x86_64.rpm"
+          },
+          "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm"
+          },
+          "sha256:18c9bc1629e34ba5328184a29314c7e751177731fdcbc98371f4587f97fe399b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.x86_64.rpm"
+          },
+          "sha256:1a57f5ae44250b9eb783efe030fb1b9b4907bb4344badef62a6a461ceeb6f8e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.x86_64.rpm"
+          },
+          "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm"
+          },
+          "sha256:1c0981c43460e63693f80bb15559d5016ce11d3d445e4fc69c61ab61a61deae8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/npth-1.6-7.fc35.x86_64.rpm"
+          },
+          "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fonts-filesystem-2.0.5-6.fc35.noarch.rpm"
+          },
+          "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm"
+          },
+          "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm"
+          },
+          "sha256:1f4684fd8720319d2baa1bdad8a5ee6cf2484acb1368fd5e0bc6be8c5126bb79": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.x86_64.rpm"
+          },
+          "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm"
+          },
+          "sha256:228e6fbe3646a580e871378f374a1d7cebc4c592ea8262600e4b41a5c39b1169": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/console-login-helper-messages-motdgen-0.21.2-3.fc35.noarch.rpm"
+          },
+          "sha256:22a906074aaab00a9c1bac318f9d10323566670fc7772c61e196574dfc63ee9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-policycoreutils-3.3-1.fc35.noarch.rpm"
+          },
+          "sha256:2324289e2fa73baaa2d28b12b6a7f523ef5ef6c956bfa84ef8c0b4da866d3592": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.x86_64.rpm"
+          },
+          "sha256:2382a1df3dc5a598eb3b2dd09995ca1964010af291265c965b7fc2906a98084b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm"
+          },
+          "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:24ef51a567ab5ad68258bc3c4958d086f11c8626c57efbd89705d9399411586e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/chrony-4.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:24fb714ceabf1f1ece432f0bf87f511ddeeda8679653754fc195be8425e27efd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-markupsafe-2.0.0-2.fc35.x86_64.rpm"
+          },
+          "sha256:257cfc8c56a77471d8cff02ef7f7c4709676a49a564c0e7538d4eef02532634a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.x86_64.rpm"
+          },
+          "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-attrs-21.2.0-4.fc35.noarch.rpm"
+          },
+          "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm"
+          },
+          "sha256:2706fac0d312be173d045cf8ae230791f77f7fed69f08242183d45ff0f679280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:27919451b78de3aba8ed473b18c9c71f3c91180adfb3f33ec2aa70be684f3e96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/graphite2-1.3.14-8.fc35.x86_64.rpm"
+          },
+          "sha256:2816abc40eb06525f3e48664243708e4fd648bc40a22d04d3c3fc4653a05beb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm"
+          },
+          "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm"
+          },
+          "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm"
+          },
+          "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm"
+          },
+          "sha256:2a1a1b20558b7fabf55512347ee7404a48c90562bbce8375ecaacc2bc4562e56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.x86_64.rpm"
+          },
+          "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm"
+          },
+          "sha256:2adacb64ccf25652aa13b213d180a949a54f75bb505adcdd58c3a35325b129c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/efibootmgr-16-11.fc35.x86_64.rpm"
+          },
+          "sha256:2afa2be2480ded04b833c817616748dc21e031d7cb6ae64c969f73ddea5bfa25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libsemanage-3.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm"
+          },
+          "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm"
+          },
+          "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-urllib3-1.26.7-2.fc35.noarch.rpm"
+          },
+          "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.x86_64.rpm"
+          },
+          "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/efi-filesystem-5-4.fc35.noarch.rpm"
+          },
+          "sha256:2e76f51592fe919f3583063e9548c665d2cd0688f5abe3e3d9eb2711271d5d6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.x86_64.rpm"
+          },
+          "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:2fdb91587fb70d5835cec683d1033a5c59069d6dc8f1ac462d1cd1c388174a04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.x86_64.rpm"
+          },
+          "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm"
+          },
+          "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm"
+          },
+          "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-requests-2.27.0-1.fc35.noarch.rpm"
+          },
+          "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-ply-3.11-13.fc35.noarch.rpm"
+          },
+          "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm"
+          },
+          "sha256:3527a0a6349dd42551b08da5574c4dd993f593b1f2ad8253240aa82834004680": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm"
+          },
+          "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:360960053a501c11bc407c6c8a2f379b79bd249133b7c0ffaba54068385860e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-cloud-35-36.noarch.rpm"
+          },
+          "sha256:361c435856f76b6e2e112534c0592ba1021490e38ff37ef93926f95733dc3da5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.x86_64.rpm"
+          },
+          "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:3681a2bfa9526b157a63bf8876db3b7e7bdf77158f8045fb073c5987aa4ef860": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.x86_64.rpm"
+          },
+          "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:38be4bfe2b3d381d0253cdd39e163ad02f17735b25dd78bf4cc6c48d0b3f4a1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.x86_64.rpm"
+          },
+          "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm"
+          },
+          "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm"
+          },
+          "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm"
+          },
+          "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm"
+          },
+          "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm"
+          },
+          "sha256:3e342a4cf63be7ea0fde629a074e71b1caa29c0cfb387b14aaf39451cb7e1cb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.x86_64.rpm"
+          },
+          "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm"
+          },
+          "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm"
+          },
+          "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:42510fc2fc78334ce4ff5e01c1776ae19d8ff856ab532b52596bd1fedd488f5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm"
+          },
+          "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm"
+          },
+          "sha256:4340b30691e41e7febd0d06bf8a76f7860cbc4650db79dc6f736a4373e9cbdbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpng-1.6.37-11.fc35.x86_64.rpm"
+          },
+          "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm"
+          },
+          "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm"
+          },
+          "sha256:460008c60bfe5ef76c671949906ec6028ad3e883f829ee071215baaf4505935d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/less-590-2.fc35.x86_64.rpm"
+          },
+          "sha256:46d0a6969ec49508e785f24d031ad7ddb07d09c05544cdbf6544b896d59d7eb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libselinux-3.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.x86_64.rpm"
+          },
+          "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.x86_64.rpm"
+          },
+          "sha256:492a776ef88d62abcc7ade5a4998d44663981d72af87bc30f8cc866ffbc4d4c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.x86_64.rpm"
+          },
+          "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm"
+          },
+          "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.x86_64.rpm"
+          },
+          "sha256:4a1dbb7d6a22598bc31d917e42759d7332a343670e35e0022db39a2ebb9e5c99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cloud-utils-growpart-0.31-9.fc35.noarch.rpm"
+          },
+          "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm"
+          },
+          "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm"
+          },
+          "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:4b2ec8a43f46b2b78d313d504e5fac550d60060f5552e4f68ece9df7d0fca38e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-audit-3.0.6-1.fc35.x86_64.rpm"
+          },
+          "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm"
+          },
+          "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-charset-normalizer-2.0.4-1.fc35.noarch.rpm"
+          },
+          "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm"
+          },
+          "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm"
+          },
+          "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-jwt-2.1.0-2.fc35.noarch.rpm"
+          },
+          "sha256:4df41f9a100eca994899d304473024c37382220b4e3c0812c69701bfa450aa06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-cloud-35-36.noarch.rpm"
+          },
+          "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm"
+          },
+          "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/langpacks-core-en-3.0-15.fc35.noarch.rpm"
+          },
+          "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.x86_64.rpm"
+          },
+          "sha256:4ff238b26e42e978a65c963a143ab0edd36fba09ec06f62b9db12148f2340d78": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/syslinux-extlinux-6.04-0.18.fc35.x86_64.rpm"
+          },
+          "sha256:50c54584c8a1a34ff2d5f8edda843c5344dff6ad179e5392bd2efafc95cd4b0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.x86_64.rpm"
+          },
+          "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm"
+          },
+          "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.x86_64.rpm"
+          },
+          "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm"
+          },
+          "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm"
+          },
+          "sha256:537bbb4888324722c268e61e55507c49cdf332562b6106599aa62993c395cbda": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.x86_64.rpm"
+          },
+          "sha256:539d9ef12227716ff904a3e4605c765e6204ffd49a7a2d42762ccd5d921b341c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/console-login-helper-messages-issuegen-0.21.2-3.fc35.noarch.rpm"
+          },
+          "sha256:571ad1c79fa5dc94318169a18b5b395458580c74d7492215b5b0efc5aa07d29d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.x86_64.rpm"
+          },
+          "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-configobj-5.0.6-25.fc35.noarch.rpm"
+          },
+          "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-10.fc35.noarch.rpm"
+          },
+          "sha256:596cc0621aeca6e0432894236d28fb2685b9fb01edb6a3369dcea06a02440f10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.x86_64.rpm"
+          },
+          "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm"
+          },
+          "sha256:5a2c17e7ccc7d7482d977c6ea754fb994ea5e94b204ff8ebb8a9c22ba20827ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-efi-x64-2.06-10.fc35.x86_64.rpm"
+          },
+          "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm"
+          },
+          "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm"
+          },
+          "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:5f9583368a339e13987f4cd287883661c5c08c4ddf29734cd84b7434d2959321": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm"
+          },
+          "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-pycparser-2.20-5.fc35.noarch.rpm"
+          },
+          "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm"
+          },
+          "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm"
+          },
+          "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm"
+          },
+          "sha256:64262879e74e55c105e72e77b6f5e987d9648ac533f784d6ffc24732926ac705": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/mtools-4.0.36-1.fc35.x86_64.rpm"
+          },
+          "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm"
+          },
+          "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm"
+          },
+          "sha256:66eb3a88d7cc3d75697bc869510168d43be2d5f3b35177d32e406860e2553e62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/checkpolicy-3.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm"
+          },
+          "sha256:67863615da55fda402a8c50c15e7a6e6f072e9955b7dee8b517835638493fa00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-efi-2.06-10.fc35.x86_64.rpm"
+          },
+          "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm"
+          },
+          "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm"
+          },
+          "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.x86_64.rpm"
+          },
+          "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm"
+          },
+          "sha256:6b45c63278be3f88368a602d3696ae16f2179c4fca4a24472186ac9b1938283a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/efivar-libs-37-17.fc35.x86_64.rpm"
+          },
+          "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/langpacks-en-3.0-15.fc35.noarch.rpm"
+          },
+          "sha256:6c8b0e7ffb8b92346d46d05a379f2838773af57ae261d34acf1140bffe07f9ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xfsprogs-5.12.0-2.fc35.x86_64.rpm"
+          },
+          "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/hunspell-en-GB-0.20140811.1-20.fc35.noarch.rpm"
+          },
+          "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm"
+          },
+          "sha256:6d714a00ad0f50d11149f199390440caed8765dd417b480816f21724bb9ad76f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.x86_64.rpm"
+          },
+          "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm"
+          },
+          "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-setuptools-57.4.0-1.fc35.noarch.rpm"
+          },
+          "sha256:6f142249758ae80ba20b001050e959e3f5ad64af483e77c23406778ed1b49ba4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/syslinux-6.04-0.18.fc35.x86_64.rpm"
+          },
+          "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm"
+          },
+          "sha256:7219d267c71b81586418726d9a8b395b29c4051f48b99b2d4c425788ce6f0e73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.x86_64.rpm"
+          },
+          "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm"
+          },
+          "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:76957036d8e500aeac846b206e1569ab2d77bee47c4f4b07a406bed3605a504b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/net-tools-2.0-0.60.20160912git.fc35.x86_64.rpm"
+          },
+          "sha256:76bacb8d6679e719d56d3e6f73662e6bdff1bfd280809f2f7fd0a7e3e625d221": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-pyyaml-5.4.1-4.fc35.x86_64.rpm"
+          },
+          "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm"
+          },
+          "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:79171d62f61010777bf57635feaf2f995227b36d9dfdfeb43cfd5acf4ad481e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-extra-2.06-10.fc35.x86_64.rpm"
+          },
+          "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:7ac6af3c01c31e098d4a0bc786bb9b0ae6c854a5d37f32b2b5b4de442b4f4fe0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:7ba84d10050c41fa26eb2602057e234cd7554dafa68529bedc5c51ce15d93182": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.x86_64.rpm"
+          },
+          "sha256:7c5387eff773f13821483f97a9c563abcc9bf633f1af05c292a25db00cba9d36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/syslinux-nonlinux-6.04-0.18.fc35.noarch.rpm"
+          },
+          "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm"
+          },
+          "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm"
+          },
+          "sha256:7f95f92e23d855ce83b3740e5a7888bb0a4b35cf70b68b3e66ce847f09e0a131": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.x86_64.rpm"
+          },
+          "sha256:80989b9402df872100cd1d61c3c44a1e5063f9085408dca2caee944f6c0336fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/syslinux-extlinux-nonlinux-6.04-0.18.fc35.noarch.rpm"
+          },
+          "sha256:80b754d0880271698c1f1aab05b061a8e5e5290c4f7355f211b2c8f058b60efb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/hunspell-filesystem-1.7.0-11.fc35.x86_64.rpm"
+          },
+          "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-idna-3.2-1.fc35.noarch.rpm"
+          },
+          "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-jsonschema-3.2.0-12.fc35.noarch.rpm"
+          },
+          "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm"
+          },
+          "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-jinja2-3.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm"
+          },
+          "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm"
+          },
+          "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm"
+          },
+          "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-oauthlib-3.0.2-11.fc35.noarch.rpm"
+          },
+          "sha256:874779944e2f10107b64356e3797733051d043bc683bf79cda3425e106bd8ea1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dejavu-sans-fonts-2.37-17.fc35.noarch.rpm"
+          },
+          "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm"
+          },
+          "sha256:8a510e37acc96dc2462243ea530ba77ed2e6b16964b0737c4f9fa883ff36aa07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.x86_64.rpm"
+          },
+          "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-pyserial-3.4-12.fc35.noarch.rpm"
+          },
+          "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm"
+          },
+          "sha256:8ce8dfdbfce7c27275408198827f17889b22f3c0597e3b64548542cf8af4327d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.x86_64.rpm"
+          },
+          "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm"
+          },
+          "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm"
+          },
+          "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:9190f8ef3b5b518d5b9a4ea91c94a452cd4f2b3e9ecd6024062333e95c71d572": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/harfbuzz-2.8.2-2.fc35.x86_64.rpm"
+          },
+          "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm"
+          },
+          "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:94b669b65c5a7ac7c4957ad7c9efb982e65ee0b22f1ae844f78837ab823ca69c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/parted-3.4-6.fc35.x86_64.rpm"
+          },
+          "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm"
+          },
+          "sha256:95c00ff3e832f2f89925eff9007fecfdcb5a85d22cd81aeb2897575c58d7b464": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.x86_64.rpm"
+          },
+          "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm"
+          },
+          "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm"
+          },
+          "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-babel-2.9.1-4.fc35.noarch.rpm"
+          },
+          "sha256:97caa631cd7385314bc217c2a910faeb3b1ccf89cee700ae62671a6a12e2a107": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.x86_64.rpm"
+          },
+          "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm"
+          },
+          "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm"
+          },
+          "sha256:9b3871c88738f18840741a1654a164574e72ed1c9cbf405fa6da5a84cb6a4abe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.x86_64.rpm"
+          },
+          "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm"
+          },
+          "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm"
+          },
+          "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:9ecb8e5c854c5627dab136cb5731ef6c073400d6deb81dfd24a6a44bd0b9ad4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.x86_64.rpm"
+          },
+          "sha256:9fe58a0ba8b3b641d0d568a00ddc9ffd6a3ea18deaa80a65762f845bb888513c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.x86_64.rpm"
+          },
+          "sha256:9ffcca99e2ca01870a82cda02fa484c7ff85d054b277e02910df05ab292cda83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.x86_64.rpm"
+          },
+          "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.x86_64.rpm"
+          },
+          "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:a2ebffa755a9962dd761fb7984d48f5240e9e9cfcf9c22e913c4487b8dffdfdb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm"
+          },
+          "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm"
+          },
+          "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc35.noarch.rpm"
+          },
+          "sha256:a7a9e78281889cf222857d9b73f9a1aa034874cab99ec5d4e006c553518d1192": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/freetype-2.11.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm"
+          },
+          "sha256:a8fc6c3a5bce70d7f68e328a69533da48f80e4df1587ffdfac58cf7f60563c66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.x86_64.rpm"
+          },
+          "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm"
+          },
+          "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm"
+          },
+          "sha256:ab640f658573793a6391d67e7d0ed108b70349c64ad1c86c92ae1df3af1c6333": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/shim-ia32-15.4-5.x86_64.rpm"
+          },
+          "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm"
+          },
+          "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm"
+          },
+          "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm"
+          },
+          "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm"
+          },
+          "sha256:b07af17dcbf638dc969aa55572e0fb300583a87b4c2ef755f359e4d7c1a91f4f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.x86_64.rpm"
+          },
+          "sha256:b1914e9500f619aa12834d3018d5c53556b15f8fa801948850ad38f8ec9b223d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.x86_64.rpm"
+          },
+          "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm"
+          },
+          "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm"
+          },
+          "sha256:b492545e958e49bb04288536508b249396e691d7d47c1f322c31af050f57f367": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:b5a1fe4789e8fde6873b432cd3a6dfb1e3025245beaf89e62e37fd23e169639a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.x86_64.rpm"
+          },
+          "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm"
+          },
+          "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm"
+          },
+          "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm"
+          },
+          "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm"
+          },
+          "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm"
+          },
+          "sha256:b86188f018b8ee782fa4df439c15bf8dc78443a0f95c7a144871c6ed5904d9ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.x86_64.rpm"
+          },
+          "sha256:b99b28317bf01d270af6da14b5cb755e492708e034f10d46fa872c82113e1659": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm"
+          },
+          "sha256:ba47f541e53846685c1033028452e4ba9da122ffa10e0765e5576c667e99ab21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.x86_64.rpm"
+          },
+          "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm"
+          },
+          "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm"
+          },
+          "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm"
+          },
+          "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm"
+          },
+          "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:c04936fcd9ceb64a2ebc037d476b2d713f563d03bb6e1017e3f72bf5e983fecb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.x86_64.rpm"
+          },
+          "sha256:c08a45af03dc93d1a768c58edd486f51e0b6f0978a569cd3e22f7fb78561475f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-setools-4.4.0-3.fc35.x86_64.rpm"
+          },
+          "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-pysocks-1.7.1-11.fc35.noarch.rpm"
+          },
+          "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cloud-init-20.4-7.fc35.noarch.rpm"
+          },
+          "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm"
+          },
+          "sha256:c34b4c7349367ad9ec44d4858eb989b916fb118acdec4f07ae1506b257918bd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.x86_64.rpm"
+          },
+          "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm"
+          },
+          "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm"
+          },
+          "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch.rpm"
+          },
+          "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm"
+          },
+          "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tar-1.34-2.fc35.x86_64.rpm"
+          },
+          "sha256:c8a4fc5b29a5f55805fd9b0d51817ab39ca26a5a12b25e7fd2a1b670a33048c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.x86_64.rpm"
+          },
+          "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm"
+          },
+          "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm"
+          },
+          "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm"
+          },
+          "sha256:d16f8f8e8bcddba1941542ba7c54cb166028fc262ad349289d31ebba188a2e9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.x86_64.rpm"
+          },
+          "sha256:d187b43a783c72bb0f6b9c9372d4ed8f9555a70476a5bc5bb1cb0e0c3f75eb98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.x86_64.rpm"
+          },
+          "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm"
+          },
+          "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm"
+          },
+          "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm"
+          },
+          "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:d3910690af40db867f15d304abdbc9f78c381a660310ab5c0d5a87845382d959": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/hunspell-1.7.0-11.fc35.x86_64.rpm"
+          },
+          "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm"
+          },
+          "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/hunspell-en-0.20140811.1-20.fc35.noarch.rpm"
+          },
+          "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm"
+          },
+          "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-jwt+crypto-2.1.0-2.fc35.noarch.rpm"
+          },
+          "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.x86_64.rpm"
+          },
+          "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm"
+          },
+          "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm"
+          },
+          "sha256:d833e17b640e9c8e2c77faa38cb19fed867874754f8998e55b04f0615a221a1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.x86_64.rpm"
+          },
+          "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm"
+          },
+          "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm"
+          },
+          "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm"
+          },
+          "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm"
+          },
+          "sha256:dff5837ed139df9d8f468045a6992d644ed5209ab64c3ba68154b581a87e73b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.x86_64.rpm"
+          },
+          "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm"
+          },
+          "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm"
+          },
+          "sha256:e10ff49ad1a6f50ef5075616ce2f24552a63b0e281add2efbe478787b9e1a578": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-pyrsistent-0.18.0-8.fc35.x86_64.rpm"
+          },
+          "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm"
+          },
+          "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm"
+          },
+          "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm"
+          },
+          "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:e3db0771d1c29b07bbadc8c2c55e8a29d17a56bedaf88dbeb9dd1cd569a6c99c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/mokutil-0.5.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm"
+          },
+          "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/hunspell-en-US-0.20140811.1-20.fc35.noarch.rpm"
+          },
+          "sha256:e4d3bc40dfe1be7c6efce9f91a8bf3a6037bf3f523655f15e18f5f3555c6733b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/inih-49-4.fc35.x86_64.rpm"
+          },
+          "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-jsonpointer-2.0-4.fc35.noarch.rpm"
+          },
+          "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm"
+          },
+          "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm"
+          },
+          "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm"
+          },
+          "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm"
+          },
+          "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm"
+          },
+          "sha256:ecc39f8297bdbe5d797d8c02a530d576ab1c39448c2c6e2c278f3458489d22e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.x86_64.rpm"
+          },
+          "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.x86_64.rpm"
+          },
+          "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm"
+          },
+          "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm"
+          },
+          "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:eefb89e40edd33bdce33983423e40682b4672e0ede42da3a33be17b6d57e4067": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.x86_64.rpm"
+          },
+          "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm"
+          },
+          "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm"
+          },
+          "sha256:ef8f0dbb997b8f1e9a133a85f5e8a6b8579f23e95dbfd0604ac4d4809a759aa9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/console-login-helper-messages-profile-0.21.2-3.fc35.noarch.rpm"
+          },
+          "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm"
+          },
+          "sha256:f28b0afa37f734b359f898180566e82ce63bd508b153bb28fb47f179f6b1338c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm"
+          },
+          "sha256:f2ec557ec85dcaebfbe1e464c68cd5dd826190e3d9a1456c028e2bd1ea7f1c53": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.x86_64.rpm"
+          },
+          "sha256:f4a4e83a8e1a1ba33bbd58ab720d2ba66bc76ef05101dd68d5ccd37a6e4e0b7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/console-login-helper-messages-0.21.2-3.fc35.noarch.rpm"
+          },
+          "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-prettytable-0.7.2-27.fc35.noarch.rpm"
+          },
+          "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm"
+          },
+          "sha256:f639f8c74dea5304f5afa5ca359c3935e8ba93165d342b52327960d98b912633": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.x86_64.rpm"
+          },
+          "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.x86_64.rpm"
+          },
+          "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm"
+          },
+          "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm"
+          },
+          "sha256:fa8c4d43af9adcb7230cc38180381bb01ebc97fb8ce31834c3fde3cb34849bae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:fb08e2d2a145964c84ada417b579b7deb8bf917fb15d4d69df33755a7e7b5ac1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:fbb6d8050c205cb2f775c6622de70d03a6fde7d318eb69a558f9ff80d5b8d424": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rsync-3.2.3-8.fc35.x86_64.rpm"
+          },
+          "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm"
+          },
+          "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm"
+          }
+        }
+      }
+    },
+    "pipeline": {
+      "build": {
+        "pipeline": {
+          "stages": [
+            {
+              "name": "org.osbuild.rpm",
+              "options": {
+                "gpgkeys": [
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                  "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+                ],
+                "packages": [
+                  {
+                    "checksum": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3527a0a6349dd42551b08da5574c4dd993f593b1f2ad8253240aa82834004680",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1c0981c43460e63693f80bb15559d5016ce11d3d445e4fc69c61ab61a61deae8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                    "check_gpg": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "org.osbuild.selinux",
+              "options": {
+                "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+                "labels": {
+                  "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+                }
+              }
+            }
+          ]
+        },
+        "runner": "org.osbuild.fedora33"
+      },
+      "stages": [
+        {
+          "name": "org.osbuild.kernel-cmdline",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "kernel_opts": "ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8"
+          }
+        },
+        {
+          "name": "org.osbuild.rpm",
+          "options": {
+            "gpgkeys": [
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+              "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+            ],
+            "packages": [
+              {
+                "checksum": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:537bbb4888324722c268e61e55507c49cdf332562b6106599aa62993c395cbda",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:42510fc2fc78334ce4ff5e01c1776ae19d8ff856ab532b52596bd1fedd488f5b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2fdb91587fb70d5835cec683d1033a5c59069d6dc8f1ac462d1cd1c388174a04",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:24ef51a567ab5ad68258bc3c4958d086f11c8626c57efbd89705d9399411586e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4a1dbb7d6a22598bc31d917e42759d7332a343670e35e0022db39a2ebb9e5c99",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:dff5837ed139df9d8f468045a6992d644ed5209ab64c3ba68154b581a87e73b4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3681a2bfa9526b157a63bf8876db3b7e7bdf77158f8045fb073c5987aa4ef860",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2adacb64ccf25652aa13b213d180a949a54f75bb505adcdd58c3a35325b129c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6b45c63278be3f88368a602d3696ae16f2179c4fca4a24472186ac9b1938283a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a7a9e78281889cf222857d9b73f9a1aa034874cab99ec5d4e006c553518d1192",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:27919451b78de3aba8ed473b18c9c71f3c91180adfb3f33ec2aa70be684f3e96",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:95c00ff3e832f2f89925eff9007fecfdcb5a85d22cd81aeb2897575c58d7b464",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9190f8ef3b5b518d5b9a4ea91c94a452cd4f2b3e9ecd6024062333e95c71d572",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:154cb55953505aee6e0546b7b1496a742ad1d01ae59262e1bd3dd473040903ff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d3910690af40db867f15d304abdbc9f78c381a660310ab5c0d5a87845382d959",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:80b754d0880271698c1f1aab05b061a8e5e5290c4f7355f211b2c8f058b60efb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e4d3bc40dfe1be7c6efce9f91a8bf3a6037bf3f523655f15e18f5f3555c6733b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1543cae4d98b7e701c42218004ead3680f01b403a3694dcd56ab504e715690a8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5f9583368a339e13987f4cd287883661c5c08c4ddf29734cd84b7434d2959321",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6d714a00ad0f50d11149f199390440caed8765dd417b480816f21724bb9ad76f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3e342a4cf63be7ea0fde629a074e71b1caa29c0cfb387b14aaf39451cb7e1cb1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f2ec557ec85dcaebfbe1e464c68cd5dd826190e3d9a1456c028e2bd1ea7f1c53",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:257cfc8c56a77471d8cff02ef7f7c4709676a49a564c0e7538d4eef02532634a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:361c435856f76b6e2e112534c0592ba1021490e38ff37ef93926f95733dc3da5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d833e17b640e9c8e2c77faa38cb19fed867874754f8998e55b04f0615a221a1e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ecc39f8297bdbe5d797d8c02a530d576ab1c39448c2c6e2c278f3458489d22e5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b86188f018b8ee782fa4df439c15bf8dc78443a0f95c7a144871c6ed5904d9ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:492a776ef88d62abcc7ade5a4998d44663981d72af87bc30f8cc866ffbc4d4c1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2706fac0d312be173d045cf8ae230791f77f7fed69f08242183d45ff0f679280",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1f4684fd8720319d2baa1bdad8a5ee6cf2484acb1368fd5e0bc6be8c5126bb79",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:eefb89e40edd33bdce33983423e40682b4672e0ede42da3a33be17b6d57e4067",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9ffcca99e2ca01870a82cda02fa484c7ff85d054b277e02910df05ab292cda83",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2324289e2fa73baaa2d28b12b6a7f523ef5ef6c956bfa84ef8c0b4da866d3592",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a510e37acc96dc2462243ea530ba77ed2e6b16964b0737c4f9fa883ff36aa07",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2e76f51592fe919f3583063e9548c665d2cd0688f5abe3e3d9eb2711271d5d6c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2a1a1b20558b7fabf55512347ee7404a48c90562bbce8375ecaacc2bc4562e56",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:38be4bfe2b3d381d0253cdd39e163ad02f17735b25dd78bf4cc6c48d0b3f4a1b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4340b30691e41e7febd0d06bf8a76f7860cbc4650db79dc6f736a4373e9cbdbc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:596cc0621aeca6e0432894236d28fb2685b9fb01edb6a3369dcea06a02440f10",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c04936fcd9ceb64a2ebc037d476b2d713f563d03bb6e1017e3f72bf5e983fecb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1a57f5ae44250b9eb783efe030fb1b9b4907bb4344badef62a6a461ceeb6f8e5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7ac6af3c01c31e098d4a0bc786bb9b0ae6c854a5d37f32b2b5b4de442b4f4fe0",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:50c54584c8a1a34ff2d5f8edda843c5344dff6ad179e5392bd2efafc95cd4b0c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7219d267c71b81586418726d9a8b395b29c4051f48b99b2d4c425788ce6f0e73",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d187b43a783c72bb0f6b9c9372d4ed8f9555a70476a5bc5bb1cb0e0c3f75eb98",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d16f8f8e8bcddba1941542ba7c54cb166028fc262ad349289d31ebba188a2e9f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:76957036d8e500aeac846b206e1569ab2d77bee47c4f4b07a406bed3605a504b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:94b669b65c5a7ac7c4957ad7c9efb982e65ee0b22f1ae844f78837ab823ca69c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a8fc6c3a5bce70d7f68e328a69533da48f80e4df1587ffdfac58cf7f60563c66",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9fe58a0ba8b3b641d0d568a00ddc9ffd6a3ea18deaa80a65762f845bb888513c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4b2ec8a43f46b2b78d313d504e5fac550d60060f5552e4f68ece9df7d0fca38e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1412d2c24a9c40dc9ccb1bd95aee49e4c817a95d2777a456c559d26b8014173b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0e2da626938aaec7c67d507dea9ad22a071abbda428f249ecc4a431078b332de",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f639f8c74dea5304f5afa5ca359c3935e8ba93165d342b52327960d98b912633",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:24fb714ceabf1f1ece432f0bf87f511ddeeda8679653754fc195be8425e27efd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:76bacb8d6679e719d56d3e6f73662e6bdff1bfd280809f2f7fd0a7e3e625d221",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c08a45af03dc93d1a768c58edd486f51e0b6f0978a569cd3e22f7fb78561475f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fbb6d8050c205cb2f775c6622de70d03a6fde7d318eb69a558f9ff80d5b8d424",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ab640f658573793a6391d67e7d0ed108b70349c64ad1c86c92ae1df3af1c6333",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:01670b269d87e950484589f2751db8f3ef61e1c4098c2fc1aa71a050c9d880fa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b5a1fe4789e8fde6873b432cd3a6dfb1e3025245beaf89e62e37fd23e169639a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ba47f541e53846685c1033028452e4ba9da122ffa10e0765e5576c667e99ab21",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6f142249758ae80ba20b001050e959e3f5ad64af483e77c23406778ed1b49ba4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4ff238b26e42e978a65c963a143ab0edd36fba09ec06f62b9db12148f2340d78",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:80989b9402df872100cd1d61c3c44a1e5063f9085408dca2caee944f6c0336fd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7c5387eff773f13821483f97a9c563abcc9bf633f1af05c292a25db00cba9d36",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6c8b0e7ffb8b92346d46d05a379f2838773af57ae261d34acf1140bffe07f9ba",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:01feeac42a5067e0d93d26be4fdfbb9e6b98a0199308e5c6fcca3190ad3083ab",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7ba84d10050c41fa26eb2602057e234cd7554dafa68529bedc5c51ce15d93182",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:66eb3a88d7cc3d75697bc869510168d43be2d5f3b35177d32e406860e2553e62",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f4a4e83a8e1a1ba33bbd58ab720d2ba66bc76ef05101dd68d5ccd37a6e4e0b7e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:539d9ef12227716ff904a3e4605c765e6204ffd49a7a2d42762ccd5d921b341c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:228e6fbe3646a580e871378f374a1d7cebc4c592ea8262600e4b41a5c39b1169",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ef8f0dbb997b8f1e9a133a85f5e8a6b8579f23e95dbfd0604ac4d4809a759aa9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:571ad1c79fa5dc94318169a18b5b395458580c74d7492215b5b0efc5aa07d29d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:360960053a501c11bc407c6c8a2f379b79bd249133b7c0ffaba54068385860e9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4df41f9a100eca994899d304473024c37382220b4e3c0812c69701bfa450aa06",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3527a0a6349dd42551b08da5574c4dd993f593b1f2ad8253240aa82834004680",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0fe873066939d1c27abc0791379c1002965364b7bd3070eaa057add9f4dd044c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:08c5a459c03ba0b3844020ed5683f2856396b43228a9a129fc1e464b61293579",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5a2c17e7ccc7d7482d977c6ea754fb994ea5e94b204ff8ebb8a9c22ba20827ee",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:67863615da55fda402a8c50c15e7a6e6f072e9955b7dee8b517835638493fa00",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:79171d62f61010777bf57635feaf2f995227b36d9dfdfeb43cfd5acf4ad481e6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9ecb8e5c854c5627dab136cb5731ef6c073400d6deb81dfd24a6a44bd0b9ad4a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8ce8dfdbfce7c27275408198827f17889b22f3c0597e3b64548542cf8af4327d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:18c9bc1629e34ba5328184a29314c7e751177731fdcbc98371f4587f97fe399b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:460008c60bfe5ef76c671949906ec6028ad3e883f829ee071215baaf4505935d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2816abc40eb06525f3e48664243708e4fd648bc40a22d04d3c3fc4653a05beb7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b1914e9500f619aa12834d3018d5c53556b15f8fa801948850ad38f8ec9b223d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1c0981c43460e63693f80bb15559d5016ce11d3d445e4fc69c61ab61a61deae8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b99b28317bf01d270af6da14b5cb755e492708e034f10d46fa872c82113e1659",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2382a1df3dc5a598eb3b2dd09995ca1964010af291265c965b7fc2906a98084b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fb08e2d2a145964c84ada417b579b7deb8bf917fb15d4d69df33755a7e7b5ac1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b492545e958e49bb04288536508b249396e691d7d47c1f322c31af050f57f367",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:97caa631cd7385314bc217c2a910faeb3b1ccf89cee700ae62671a6a12e2a107",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b07af17dcbf638dc969aa55572e0fb300583a87b4c2ef755f359e4d7c1a91f4f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e3db0771d1c29b07bbadc8c2c55e8a29d17a56bedaf88dbeb9dd1cd569a6c99c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:64262879e74e55c105e72e77b6f5e987d9648ac533f784d6ffc24732926ac705",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c8a4fc5b29a5f55805fd9b0d51817ab39ca26a5a12b25e7fd2a1b670a33048c4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7f95f92e23d855ce83b3740e5a7888bb0a4b35cf70b68b3e66ce847f09e0a131",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9b3871c88738f18840741a1654a164574e72ed1c9cbf405fa6da5a84cb6a4abe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:46d0a6969ec49508e785f24d031ad7ddb07d09c05544cdbf6544b896d59d7eb9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2afa2be2480ded04b833c817616748dc21e031d7cb6ae64c969f73ddea5bfa25",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:22a906074aaab00a9c1bac318f9d10323566670fc7772c61e196574dfc63ee9b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e10ff49ad1a6f50ef5075616ce2f24552a63b0e281add2efbe478787b9e1a578",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a2ebffa755a9962dd761fb7984d48f5240e9e9cfcf9c22e913c4487b8dffdfdb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fa8c4d43af9adcb7230cc38180381bb01ebc97fb8ce31834c3fde3cb34849bae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:874779944e2f10107b64356e3797733051d043bc683bf79cda3425e106bd8ea1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f28b0afa37f734b359f898180566e82ce63bd508b153bb28fb47f179f6b1338c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c34b4c7349367ad9ec44d4858eb989b916fb118acdec4f07ae1506b257918bd2",
+                "check_gpg": true
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.locale",
+          "options": {
+            "language": "en_US"
+          }
+        },
+        {
+          "name": "org.osbuild.hostname",
+          "options": {
+            "hostname": "localhost.localdomain"
+          }
+        },
+        {
+          "name": "org.osbuild.timezone",
+          "options": {
+            "zone": "UTC"
+          }
+        },
+        {
+          "name": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "vfs_type": "ext4",
+                "path": "/",
+                "options": "defaults",
+                "freq": 1,
+                "passno": 1
+              }
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.grub2",
+          "options": {
+            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "legacy": "i386-pc"
+          }
+        },
+        {
+          "name": "org.osbuild.fix-bls",
+          "options": {}
+        },
+        {
+          "name": "org.osbuild.systemd",
+          "options": {
+            "enabled_services": [
+              "cloud-init.service",
+              "cloud-config.service",
+              "cloud-final.service",
+              "cloud-init-local.service"
+            ]
+          }
+        },
+        {
+          "name": "org.osbuild.selinux",
+          "options": {
+            "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+          }
+        }
+      ],
+      "assembler": {
+        "name": "org.osbuild.qemu",
+        "options": {
+          "format": "qcow2",
+          "filename": "disk.qcow2",
+          "size": 2147483648,
+          "ptuuid": "0x14fc63d2",
+          "pttype": "mbr",
+          "partitions": [
+            {
+              "start": 2048,
+              "bootable": true,
+              "filesystem": {
+                "type": "ext4",
+                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "mountpoint": "/"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build-packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm",
+        "checksum": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm",
+        "checksum": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm",
+        "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
+        "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm",
+        "checksum": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b1a8269b312e852d333a5e60a82435e6b9615bcebcdc5bb2687472601a0bbd98",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm",
+        "checksum": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm",
+        "checksum": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
+        "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm",
+        "checksum": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "12.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.x86_64.rpm",
+        "checksum": "sha256:517ac8786e4b1391aa3b529320a340e248e4ccd8b3fa9c85a1467811c93b965d",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.x86_64.rpm",
+        "checksum": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm",
+        "checksum": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm",
+        "checksum": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm",
+        "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm",
+        "checksum": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm",
+        "checksum": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
+        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm",
+        "checksum": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm",
+        "checksum": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm",
+        "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm",
+        "checksum": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
+        "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+        "check_gpg": true
+      },
+      {
+        "name": "liburing",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0a0aa2929bf66793baeb068197ca7c35559f5a6a9c1d50ca8400457fd46b916e",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.x86_64.rpm",
+        "checksum": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm",
+        "checksum": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm",
+        "checksum": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.x86_64.rpm",
+        "checksum": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
+        "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs78",
+        "epoch": 0,
+        "version": "78.15.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/npth-1.6-7.fc35.x86_64.rpm",
+        "checksum": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm",
+        "checksum": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm",
+        "checksum": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm",
+        "checksum": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm",
+        "checksum": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm",
+        "checksum": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "20.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.x86_64.rpm",
+        "checksum": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm",
+        "checksum": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
+        "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm",
+        "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm",
+        "checksum": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tar-1.34-2.fc35.x86_64.rpm",
+        "checksum": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm",
+        "checksum": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm",
+        "checksum": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.70.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:3527a0a6349dd42551b08da5574c4dd993f593b1f2ad8253240aa82834004680",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.x86_64.rpm",
+        "checksum": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm",
+        "checksum": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1c0981c43460e63693f80bb15559d5016ce11d3d445e4fc69c61ab61a61deae8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.x86_64.rpm",
+        "checksum": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.4.36",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm",
+        "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+        "check_gpg": true
+      },
+      {
+        "name": "qemu-img",
+        "epoch": 2,
+        "version": "6.1.0",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.x86_64.rpm",
+        "checksum": "sha256:a1d2ecdc7bd086875f4feb25723963b58b4712a42e37cfa4ab05f50ef7ed5d39",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
+    "packages": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:537bbb4888324722c268e61e55507c49cdf332562b6106599aa62993c395cbda",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm",
+        "checksum": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:42510fc2fc78334ce4ff5e01c1776ae19d8ff856ab532b52596bd1fedd488f5b",
+        "check_gpg": true
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2fdb91587fb70d5835cec683d1033a5c59069d6dc8f1ac462d1cd1c388174a04",
+        "check_gpg": true
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/chrony-4.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:24ef51a567ab5ad68258bc3c4958d086f11c8626c57efbd89705d9399411586e",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "20.4",
+        "release": "7.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cloud-init-20.4-7.fc35.noarch.rpm",
+        "checksum": "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-utils-growpart",
+        "epoch": 0,
+        "version": "0.31",
+        "release": "9.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cloud-utils-growpart-0.31-9.fc35.noarch.rpm",
+        "checksum": "sha256:4a1dbb7d6a22598bc31d917e42759d7332a343670e35e0022db39a2ebb9e5c99",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm",
+        "checksum": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:dff5837ed139df9d8f468045a6992d644ed5209ab64c3ba68154b581a87e73b4",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
+        "check_gpg": true
+      },
+      {
+        "name": "dejavu-sans-fonts",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "17.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dejavu-sans-fonts-2.37-17.fc35.noarch.rpm",
+        "checksum": "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm",
+        "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.x86_64.rpm",
+        "checksum": "sha256:3681a2bfa9526b157a63bf8876db3b7e7bdf77158f8045fb073c5987aa4ef860",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm",
+        "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
+        "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/efi-filesystem-5-4.fc35.noarch.rpm",
+        "checksum": "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/efibootmgr-16-11.fc35.x86_64.rpm",
+        "checksum": "sha256:2adacb64ccf25652aa13b213d180a949a54f75bb505adcdd58c3a35325b129c3",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "37",
+        "release": "17.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/efivar-libs-37-17.fc35.x86_64.rpm",
+        "checksum": "sha256:6b45c63278be3f88368a602d3696ae16f2179c4fca4a24472186ac9b1938283a",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm",
+        "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm",
+        "checksum": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+        "check_gpg": true
+      },
+      {
+        "name": "fonts-filesystem",
+        "epoch": 1,
+        "version": "2.0.5",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fonts-filesystem-2.0.5-6.fc35.noarch.rpm",
+        "checksum": "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee",
+        "check_gpg": true
+      },
+      {
+        "name": "freetype",
+        "epoch": 0,
+        "version": "2.11.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/freetype-2.11.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a7a9e78281889cf222857d9b73f9a1aa034874cab99ec5d4e006c553518d1192",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+        "check_gpg": true
+      },
+      {
+        "name": "graphite2",
+        "epoch": 0,
+        "version": "1.3.14",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/graphite2-1.3.14-8.fc35.x86_64.rpm",
+        "checksum": "sha256:27919451b78de3aba8ed473b18c9c71f3c91180adfb3f33ec2aa70be684f3e96",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm",
+        "checksum": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.x86_64.rpm",
+        "checksum": "sha256:95c00ff3e832f2f89925eff9007fecfdcb5a85d22cd81aeb2897575c58d7b464",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm",
+        "checksum": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
+        "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+        "check_gpg": true
+      },
+      {
+        "name": "harfbuzz",
+        "epoch": 0,
+        "version": "2.8.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/harfbuzz-2.8.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9190f8ef3b5b518d5b9a4ea91c94a452cd4f2b3e9ecd6024062333e95c71d572",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.x86_64.rpm",
+        "checksum": "sha256:154cb55953505aee6e0546b7b1496a742ad1d01ae59262e1bd3dd473040903ff",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell",
+        "epoch": 0,
+        "version": "1.7.0",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/hunspell-1.7.0-11.fc35.x86_64.rpm",
+        "checksum": "sha256:d3910690af40db867f15d304abdbc9f78c381a660310ab5c0d5a87845382d959",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-en",
+        "epoch": 0,
+        "version": "0.20140811.1",
+        "release": "20.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/hunspell-en-0.20140811.1-20.fc35.noarch.rpm",
+        "checksum": "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-en-GB",
+        "epoch": 0,
+        "version": "0.20140811.1",
+        "release": "20.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/hunspell-en-GB-0.20140811.1-20.fc35.noarch.rpm",
+        "checksum": "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-en-US",
+        "epoch": 0,
+        "version": "0.20140811.1",
+        "release": "20.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/hunspell-en-US-0.20140811.1-20.fc35.noarch.rpm",
+        "checksum": "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e",
+        "check_gpg": true
+      },
+      {
+        "name": "hunspell-filesystem",
+        "epoch": 0,
+        "version": "1.7.0",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/hunspell-filesystem-1.7.0-11.fc35.x86_64.rpm",
+        "checksum": "sha256:80b754d0880271698c1f1aab05b061a8e5e5290c4f7355f211b2c8f058b60efb",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "49",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/inih-49-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e4d3bc40dfe1be7c6efce9f91a8bf3a6037bf3f523655f15e18f5f3555c6733b",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1543cae4d98b7e701c42218004ead3680f01b403a3694dcd56ab504e715690a8",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm",
+        "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f9583368a339e13987f4cd287883661c5c08c4ddf29734cd84b7434d2959321",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:6d714a00ad0f50d11149f199390440caed8765dd417b480816f21724bb9ad76f",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute-tc",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:3e342a4cf63be7ea0fde629a074e71b1caa29c0cfb387b14aaf39451cb7e1cb1",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ec557ec85dcaebfbe1e464c68cd5dd826190e3d9a1456c028e2bd1ea7f1c53",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20210722",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.x86_64.rpm",
+        "checksum": "sha256:257cfc8c56a77471d8cff02ef7f7c4709676a49a564c0e7538d4eef02532634a",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm",
+        "checksum": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "15.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/langpacks-core-en-3.0-15.fc35.noarch.rpm",
+        "checksum": "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-core-font-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "15.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/langpacks-core-font-en-3.0-15.fc35.noarch.rpm",
+        "checksum": "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f",
+        "check_gpg": true
+      },
+      {
+        "name": "langpacks-en",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "15.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/langpacks-en-3.0-15.fc35.noarch.rpm",
+        "checksum": "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.x86_64.rpm",
+        "checksum": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.x86_64.rpm",
+        "checksum": "sha256:361c435856f76b6e2e112534c0592ba1021490e38ff37ef93926f95733dc3da5",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm",
+        "checksum": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm",
+        "checksum": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d833e17b640e9c8e2c77faa38cb19fed867874754f8998e55b04f0615a221a1e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.x86_64.rpm",
+        "checksum": "sha256:ecc39f8297bdbe5d797d8c02a530d576ab1c39448c2c6e2c278f3458489d22e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm",
+        "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm",
+        "checksum": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.x86_64.rpm",
+        "checksum": "sha256:b86188f018b8ee782fa4df439c15bf8dc78443a0f95c7a144871c6ed5904d9ae",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "40.20210910cvs.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.x86_64.rpm",
+        "checksum": "sha256:492a776ef88d62abcc7ade5a4998d44663981d72af87bc30f8cc866ffbc4d4c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm",
+        "checksum": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2706fac0d312be173d045cf8ae230791f77f7fed69f08242183d45ff0f679280",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.x86_64.rpm",
+        "checksum": "sha256:1f4684fd8720319d2baa1bdad8a5ee6cf2484acb1368fd5e0bc6be8c5126bb79",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.x86_64.rpm",
+        "checksum": "sha256:eefb89e40edd33bdce33983423e40682b4672e0ede42da3a33be17b6d57e4067",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9ffcca99e2ca01870a82cda02fa484c7ff85d054b277e02910df05ab292cda83",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.x86_64.rpm",
+        "checksum": "sha256:2324289e2fa73baaa2d28b12b6a7f523ef5ef6c956bfa84ef8c0b4da866d3592",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "20.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.x86_64.rpm",
+        "checksum": "sha256:8a510e37acc96dc2462243ea530ba77ed2e6b16964b0737c4f9fa883ff36aa07",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.5.4",
+        "release": "2.rc3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.x86_64.rpm",
+        "checksum": "sha256:2e76f51592fe919f3583063e9548c665d2cd0688f5abe3e3d9eb2711271d5d6c",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.x86_64.rpm",
+        "checksum": "sha256:2a1a1b20558b7fabf55512347ee7404a48c90562bbce8375ecaacc2bc4562e56",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:38be4bfe2b3d381d0253cdd39e163ad02f17735b25dd78bf4cc6c48d0b3f4a1b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpng",
+        "epoch": 2,
+        "version": "1.6.37",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpng-1.6.37-11.fc35.x86_64.rpm",
+        "checksum": "sha256:4340b30691e41e7febd0d06bf8a76f7860cbc4650db79dc6f736a4373e9cbdbc",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.x86_64.rpm",
+        "checksum": "sha256:596cc0621aeca6e0432894236d28fb2685b9fb01edb6a3369dcea06a02440f10",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
+        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm",
+        "checksum": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm",
+        "checksum": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm",
+        "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:c04936fcd9ceb64a2ebc037d476b2d713f563d03bb6e1017e3f72bf5e983fecb",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm",
+        "checksum": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.x86_64.rpm",
+        "checksum": "sha256:1a57f5ae44250b9eb783efe030fb1b9b4907bb4344badef62a6a461ceeb6f8e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:7ac6af3c01c31e098d4a0bc786bb9b0ae6c854a5d37f32b2b5b4de442b4f4fe0",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
+        "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.x86_64.rpm",
+        "checksum": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.x86_64.rpm",
+        "checksum": "sha256:50c54584c8a1a34ff2d5f8edda843c5344dff6ad179e5392bd2efafc95cd4b0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm",
+        "checksum": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm",
+        "checksum": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.x86_64.rpm",
+        "checksum": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.x86_64.rpm",
+        "checksum": "sha256:7219d267c71b81586418726d9a8b395b29c4051f48b99b2d4c425788ce6f0e73",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d187b43a783c72bb0f6b9c9372d4ed8f9555a70476a5bc5bb1cb0e0c3f75eb98",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
+        "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs78",
+        "epoch": 0,
+        "version": "78.15.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:d16f8f8e8bcddba1941542ba7c54cb166028fc262ad349289d31ebba188a2e9f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+        "check_gpg": true
+      },
+      {
+        "name": "net-tools",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "0.60.20160912git.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/net-tools-2.0-0.60.20160912git.fc35.x86_64.rpm",
+        "checksum": "sha256:76957036d8e500aeac846b206e1569ab2d77bee47c4f4b07a406bed3605a504b",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/npth-1.6-7.fc35.x86_64.rpm",
+        "checksum": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm",
+        "checksum": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm",
+        "checksum": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm",
+        "checksum": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm",
+        "checksum": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/parted-3.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:94b669b65c5a7ac7c4957ad7c9efb982e65ee0b22f1ae844f78837ab823ca69c",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.x86_64.rpm",
+        "checksum": "sha256:a8fc6c3a5bce70d7f68e328a69533da48f80e4df1587ffdfac58cf7f60563c66",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm",
+        "checksum": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "20.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.x86_64.rpm",
+        "checksum": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm",
+        "checksum": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
+        "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9fe58a0ba8b3b641d0d568a00ddc9ffd6a3ea18deaa80a65762f845bb888513c",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-attrs",
+        "epoch": 0,
+        "version": "21.2.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-attrs-21.2.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-audit-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4b2ec8a43f46b2b78d313d504e5fac550d60060f5552e4f68ece9df7d0fca38e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-babel",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-babel-2.9.1-4.fc35.noarch.rpm",
+        "checksum": "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cffi",
+        "epoch": 0,
+        "version": "1.14.6",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-cffi-1.14.6-2.fc35.x86_64.rpm",
+        "checksum": "sha256:1412d2c24a9c40dc9ccb1bd95aee49e4c817a95d2777a456c559d26b8014173b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-charset-normalizer",
+        "epoch": 0,
+        "version": "2.0.4",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-charset-normalizer-2.0.4-1.fc35.noarch.rpm",
+        "checksum": "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-configobj",
+        "epoch": 0,
+        "version": "5.0.6",
+        "release": "25.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-configobj-5.0.6-25.fc35.noarch.rpm",
+        "checksum": "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cryptography",
+        "epoch": 0,
+        "version": "3.4.7",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-cryptography-3.4.7-5.fc35.x86_64.rpm",
+        "checksum": "sha256:0e2da626938aaec7c67d507dea9ad22a071abbda428f249ecc4a431078b332de",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "7.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm",
+        "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f639f8c74dea5304f5afa5ca359c3935e8ba93165d342b52327960d98b912633",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "3.2",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-idna-3.2-1.fc35.noarch.rpm",
+        "checksum": "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jinja2",
+        "epoch": 0,
+        "version": "3.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-jinja2-3.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpointer",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-jsonpointer-2.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonschema",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-jsonschema-3.2.0-12.fc35.noarch.rpm",
+        "checksum": "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt+crypto",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-jwt+crypto-2.1.0-2.fc35.noarch.rpm",
+        "checksum": "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-jwt-2.1.0-2.fc35.noarch.rpm",
+        "checksum": "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm",
+        "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-markupsafe-2.0.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:24fb714ceabf1f1ece432f0bf87f511ddeeda8679653754fc195be8425e27efd",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib+signedtoken",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "11.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch.rpm",
+        "checksum": "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib",
+        "epoch": 0,
+        "version": "3.0.2",
+        "release": "11.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-oauthlib-3.0.2-11.fc35.noarch.rpm",
+        "checksum": "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-ply",
+        "epoch": 0,
+        "version": "3.11",
+        "release": "13.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-ply-3.11-13.fc35.noarch.rpm",
+        "checksum": "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "27.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-prettytable-0.7.2-27.fc35.noarch.rpm",
+        "checksum": "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pycparser",
+        "epoch": 0,
+        "version": "2.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-pycparser-2.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyserial",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-pyserial-3.4-12.fc35.noarch.rpm",
+        "checksum": "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "11.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-pysocks-1.7.1-11.fc35.noarch.rpm",
+        "checksum": "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-pyyaml-5.4.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:76bacb8d6679e719d56d3e6f73662e6bdff1bfd280809f2f7fd0a7e3e625d221",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.4.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-setools-4.4.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:c08a45af03dc93d1a768c58edd486f51e0b6f0978a569cd3e22f7fb78561475f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-setuptools-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "30.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm",
+        "checksum": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
+        "check_gpg": true
+      },
+      {
+        "name": "rsync",
+        "epoch": 0,
+        "version": "3.2.3",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rsync-3.2.3-8.fc35.x86_64.rpm",
+        "checksum": "sha256:fbb6d8050c205cb2f775c6622de70d03a6fde7d318eb69a558f9ff80d5b8d424",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm",
+        "checksum": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-ia32",
+        "epoch": 0,
+        "version": "15.4",
+        "release": "5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/shim-ia32-15.4-5.x86_64.rpm",
+        "checksum": "sha256:ab640f658573793a6391d67e7d0ed108b70349c64ad1c86c92ae1df3af1c6333",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-x64",
+        "epoch": 0,
+        "version": "15.4",
+        "release": "5",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/shim-x64-15.4-5.x86_64.rpm",
+        "checksum": "sha256:01670b269d87e950484589f2751db8f3ef61e1c4098c2fc1aa71a050c9d880fa",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:b5a1fe4789e8fde6873b432cd3a6dfb1e3025245beaf89e62e37fd23e169639a",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ba47f541e53846685c1033028452e4ba9da122ffa10e0765e5576c667e99ab21",
+        "check_gpg": true
+      },
+      {
+        "name": "syslinux",
+        "epoch": 0,
+        "version": "6.04",
+        "release": "0.18.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/syslinux-6.04-0.18.fc35.x86_64.rpm",
+        "checksum": "sha256:6f142249758ae80ba20b001050e959e3f5ad64af483e77c23406778ed1b49ba4",
+        "check_gpg": true
+      },
+      {
+        "name": "syslinux-extlinux",
+        "epoch": 0,
+        "version": "6.04",
+        "release": "0.18.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/syslinux-extlinux-6.04-0.18.fc35.x86_64.rpm",
+        "checksum": "sha256:4ff238b26e42e978a65c963a143ab0edd36fba09ec06f62b9db12148f2340d78",
+        "check_gpg": true
+      },
+      {
+        "name": "syslinux-extlinux-nonlinux",
+        "epoch": 0,
+        "version": "6.04",
+        "release": "0.18.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/syslinux-extlinux-nonlinux-6.04-0.18.fc35.noarch.rpm",
+        "checksum": "sha256:80989b9402df872100cd1d61c3c44a1e5063f9085408dca2caee944f6c0336fd",
+        "check_gpg": true
+      },
+      {
+        "name": "syslinux-nonlinux",
+        "epoch": 0,
+        "version": "6.04",
+        "release": "0.18.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/syslinux-nonlinux-6.04-0.18.fc35.noarch.rpm",
+        "checksum": "sha256:7c5387eff773f13821483f97a9c563abcc9bf633f1af05c292a25db00cba9d36",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tar-1.34-2.fc35.x86_64.rpm",
+        "checksum": "sha256:c8198e9e1cd98faa1ffcd01a9bcd4c779faf3baee0edfe7e95f98c20851f8665",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm",
+        "checksum": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.12.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xfsprogs-5.12.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:6c8b0e7ffb8b92346d46d05a379f2838773af57ae261d34acf1140bffe07f9ba",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm",
+        "checksum": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.x86_64.rpm",
+        "checksum": "sha256:01feeac42a5067e0d93d26be4fdfbb9e6b98a0199308e5c6fcca3190ad3083ab",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.x86_64.rpm",
+        "checksum": "sha256:7ba84d10050c41fa26eb2602057e234cd7554dafa68529bedc5c51ce15d93182",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/checkpolicy-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:66eb3a88d7cc3d75697bc869510168d43be2d5f3b35177d32e406860e2553e62",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/console-login-helper-messages-0.21.2-3.fc35.noarch.rpm",
+        "checksum": "sha256:f4a4e83a8e1a1ba33bbd58ab720d2ba66bc76ef05101dd68d5ccd37a6e4e0b7e",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-issuegen",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/console-login-helper-messages-issuegen-0.21.2-3.fc35.noarch.rpm",
+        "checksum": "sha256:539d9ef12227716ff904a3e4605c765e6204ffd49a7a2d42762ccd5d921b341c",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-motdgen",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/console-login-helper-messages-motdgen-0.21.2-3.fc35.noarch.rpm",
+        "checksum": "sha256:228e6fbe3646a580e871378f374a1d7cebc4c592ea8262600e4b41a5c39b1169",
+        "check_gpg": true
+      },
+      {
+        "name": "console-login-helper-messages-profile",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/console-login-helper-messages-profile-0.21.2-3.fc35.noarch.rpm",
+        "checksum": "sha256:ef8f0dbb997b8f1e9a133a85f5e8a6b8579f23e95dbfd0604ac4d4809a759aa9",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:571ad1c79fa5dc94318169a18b5b395458580c74d7492215b5b0efc5aa07d29d",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-cloud",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-cloud-35-36.noarch.rpm",
+        "checksum": "sha256:360960053a501c11bc407c6c8a2f379b79bd249133b7c0ffaba54068385860e9",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-cloud",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-cloud-35-36.noarch.rpm",
+        "checksum": "sha256:4df41f9a100eca994899d304473024c37382220b4e3c0812c69701bfa450aa06",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.70.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:3527a0a6349dd42551b08da5574c4dd993f593b1f2ad8253240aa82834004680",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-langpack-en",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-langpack-en-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:0fe873066939d1c27abc0791379c1002965364b7bd3070eaa057add9f4dd044c",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.x86_64.rpm",
+        "checksum": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-ia32",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-efi-ia32-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:08c5a459c03ba0b3844020ed5683f2856396b43228a9a129fc1e464b61293579",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-x64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-efi-x64-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:5a2c17e7ccc7d7482d977c6ea754fb994ea5e94b204ff8ebb8a9c22ba20827ee",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-efi",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-efi-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:67863615da55fda402a8c50c15e7a6e6f072e9955b7dee8b517835638493fa00",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-extra",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-extra-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:79171d62f61010777bf57635feaf2f995227b36d9dfdfeb43cfd5acf4ad481e6",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:9ecb8e5c854c5627dab136cb5731ef6c073400d6deb81dfd24a6a44bd0b9ad4a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:8ce8dfdbfce7c27275408198827f17889b22f3c0597e3b64548542cf8af4327d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:18c9bc1629e34ba5328184a29314c7e751177731fdcbc98371f4587f97fe399b",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/less-590-2.fc35.x86_64.rpm",
+        "checksum": "sha256:460008c60bfe5ef76c671949906ec6028ad3e883f829ee071215baaf4505935d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm",
+        "checksum": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2816abc40eb06525f3e48664243708e4fd648bc40a22d04d3c3fc4653a05beb7",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b1914e9500f619aa12834d3018d5c53556b15f8fa801948850ad38f8ec9b223d",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1c0981c43460e63693f80bb15559d5016ce11d3d445e4fc69c61ab61a61deae8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b99b28317bf01d270af6da14b5cb755e492708e034f10d46fa872c82113e1659",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2382a1df3dc5a598eb3b2dd09995ca1964010af291265c965b7fc2906a98084b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:fb08e2d2a145964c84ada417b579b7deb8bf917fb15d4d69df33755a7e7b5ac1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b492545e958e49bb04288536508b249396e691d7d47c1f322c31af050f57f367",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:97caa631cd7385314bc217c2a910faeb3b1ccf89cee700ae62671a6a12e2a107",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-atm-libs",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.x86_64.rpm",
+        "checksum": "sha256:b07af17dcbf638dc969aa55572e0fb300583a87b4c2ef755f359e4d7c1a91f4f",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.5.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/mokutil-0.5.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e3db0771d1c29b07bbadc8c2c55e8a29d17a56bedaf88dbeb9dd1cd569a6c99c",
+        "check_gpg": true
+      },
+      {
+        "name": "mtools",
+        "epoch": 0,
+        "version": "4.0.36",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/mtools-4.0.36-1.fc35.x86_64.rpm",
+        "checksum": "sha256:64262879e74e55c105e72e77b6f5e987d9648ac533f784d6ffc24732926ac705",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:c8a4fc5b29a5f55805fd9b0d51817ab39ca26a5a12b25e7fd2a1b670a33048c4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:7f95f92e23d855ce83b3740e5a7888bb0a4b35cf70b68b3e66ce847f09e0a131",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9b3871c88738f18840741a1654a164574e72ed1c9cbf405fa6da5a84cb6a4abe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.x86_64.rpm",
+        "checksum": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.4.36",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm",
+        "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpatch",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "18.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-jsonpatch-1.21-18.fc35.noarch.rpm",
+        "checksum": "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libselinux-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:46d0a6969ec49508e785f24d031ad7ddb07d09c05544cdbf6544b896d59d7eb9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libsemanage-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2afa2be2480ded04b833c817616748dc21e031d7cb6ae64c969f73ddea5bfa25",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-policycoreutils-3.3-1.fc35.noarch.rpm",
+        "checksum": "sha256:22a906074aaab00a9c1bac318f9d10323566670fc7772c61e196574dfc63ee9b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyrsistent",
+        "epoch": 0,
+        "version": "0.18.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-pyrsistent-0.18.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:e10ff49ad1a6f50ef5075616ce2f24552a63b0e281add2efbe478787b9e1a578",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pytz",
+        "epoch": 0,
+        "version": "2021.3",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc35.noarch.rpm",
+        "checksum": "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.27.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-requests-2.27.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.7",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-urllib3-1.26.7-2.fc35.noarch.rpm",
+        "checksum": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a2ebffa755a9962dd761fb7984d48f5240e9e9cfcf9c22e913c4487b8dffdfdb",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:fa8c4d43af9adcb7230cc38180381bb01ebc97fb8ce31834c3fde3cb34849bae",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:874779944e2f10107b64356e3797733051d043bc683bf79cda3425e106bd8ea1",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:f28b0afa37f734b359f898180566e82ce63bd508b153bb28fb47f179f6b1338c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm",
+        "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm",
+        "checksum": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c34b4c7349367ad9ec44d4858eb989b916fb118acdec4f07ae1506b257918bd2",
+        "check_gpg": true
+      }
+    ]
+  },
+  "image-info": {
+    "/etc/resolv.conf": [],
+    "boot-environment": {
+      "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+    },
+    "bootloader": "grub",
+    "bootmenu": [
+      {
+        "grub_arg": "--unrestricted",
+        "grub_class": "fedora",
+        "grub_users": "$grub_users",
+        "initrd": "/boot/initramfs-5.15.13-200.fc35.x86_64.img",
+        "linux": "/boot/vmlinuz-5.15.13-200.fc35.x86_64",
+        "options": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8",
+        "title": "Fedora Linux (5.15.13-200.fc35.x86_64) 35 (Cloud Edition)",
+        "version": "5.15.13-200.fc35.x86_64"
+      }
+    ],
+    "chrony": {
+      "leapsectz": [
+        "right/UTC"
+      ],
+      "pool": [
+        "2.fedora.pool.ntp.org iburst"
+      ]
+    },
+    "cloud-init": {
+      "/etc/cloud": {
+        "cloud.cfg": {
+          "cloud_config_modules": [
+            "ssh-import-id",
+            "locale",
+            "set-passwords",
+            "spacewalk",
+            "yum-add-repo",
+            "ntp",
+            "timezone",
+            "disable-ec2-metadata",
+            "runcmd"
+          ],
+          "cloud_final_modules": [
+            "package-update-upgrade-install",
+            "puppet",
+            "chef",
+            "mcollective",
+            "salt-minion",
+            "reset_rmc",
+            "refresh_rmc_and_interface",
+            "rightscale_userdata",
+            "scripts-vendor",
+            "scripts-per-once",
+            "scripts-per-boot",
+            "scripts-per-instance",
+            "scripts-user",
+            "ssh-authkey-fingerprints",
+            "keys-to-console",
+            "phone-home",
+            "final-message",
+            "power-state-change"
+          ],
+          "cloud_init_modules": [
+            "migrator",
+            "seed_random",
+            "bootcmd",
+            "write-files",
+            "growpart",
+            "resizefs",
+            "disk_setup",
+            "mounts",
+            "set_hostname",
+            "update_hostname",
+            "update_etc_hosts",
+            "ca-certs",
+            "rsyslog",
+            "users-groups",
+            "ssh"
+          ],
+          "disable_root": true,
+          "mount_default_fields": [
+            null,
+            null,
+            "auto",
+            "defaults,nofail",
+            "0",
+            "2"
+          ],
+          "preserve_hostname": false,
+          "resize_rootfs_tmp": "/dev",
+          "ssh_pwauth": 0,
+          "system_info": {
+            "default_user": {
+              "gecos": "fedora Cloud User",
+              "groups": [
+                "wheel",
+                "adm",
+                "systemd-journal"
+              ],
+              "lock_passwd": true,
+              "name": "fedora",
+              "shell": "/bin/bash",
+              "sudo": [
+                "ALL=(ALL) NOPASSWD:ALL"
+              ]
+            },
+            "distro": "fedora",
+            "paths": {
+              "cloud_dir": "/var/lib/cloud/",
+              "templates_dir": "/etc/cloud/templates/"
+            },
+            "ssh_svcname": "sshd"
+          },
+          "users": [
+            "default"
+          ]
+        }
+      },
+      "/etc/cloud/cloud.cfg.d": {
+        "05_logging.cfg": {
+          "_log": [
+            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
+            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
+          ],
+          "log_cfgs": [
+            [
+              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
+            ]
+          ],
+          "output": {
+            "all": "| tee -a /var/log/cloud-init-output.log"
+          }
+        }
+      }
+    },
+    "default-target": "graphical.target",
+    "dracut": {
+      "/usr/lib/dracut/dracut.conf.d": {
+        "01-dist.conf": {
+          "dbus": "/usr/share/dbus-1",
+          "dbusconfdir": "/etc/dbus-1",
+          "dbusinterfaces": "/usr/share/dbus-1/interfaces",
+          "dbusinterfacesconfdir": "/etc/dbus-1/interfaces",
+          "dbusservices": "/usr/share/dbus-1/services",
+          "dbusservicesconfdir": "/etc/dbus-1/services",
+          "dbussession": "/usr/share/dbus-1/session.d",
+          "dbussessionconfdir": "/etc/dbus-1/session.d",
+          "dbussystem": "confdir/etc/dbus-1/system.d",
+          "dbussystemservices": "/usr/share/dbus-1/system-services",
+          "dbussystemservicesconfdir": "/etc/dbus-1/system-services",
+          "early_microcode": "yes",
+          "environment": "/usr/lib/environment.d",
+          "environmentconfdir": "/etc/environment.d",
+          "hostonly": "yes",
+          "hostonly_cmdline": "no",
+          "i18n_default_font": "eurlatgr",
+          "i18n_install_all": "yes",
+          "i18n_vars": "/etc/sysconfig/keyboard:KEYTABLE-KEYMAP /etc/sysconfig/i18n:SYSFONT-FONT,FONTACM-FONT_MAP,FONT_UNIMAP",
+          "install_optional_items": " vi /etc/virc ps grep cat rm ",
+          "prefix": "/",
+          "reproducible": "yes",
+          "stdloglvl": "3",
+          "sysctlconfdir": "/etc/sysctl.d",
+          "sysctld": "/usr/lib/sysctl.d",
+          "sysloglvl": "5",
+          "systemdcatalog": "/usr/lib/systemd/catalog",
+          "systemdntpunits": "/usr/lib/systemd/ntp-units.d",
+          "systemdntpunitsconfdir": "/etc/systemd/ntp-units.d",
+          "systemdportable": "/usr/lib/systemd/portable",
+          "systemdportableconfdir": "/etc/systemd/portable",
+          "systemdsystemconfdir": "/etc/systemd/system",
+          "systemdsystemunitdir": "/usr/lib/systemd/system",
+          "systemduser": "/usr/lib/systemd/user",
+          "systemduserconfdir": "/etc/systemd/user",
+          "systemdutilconfdir": "/etc/systemd",
+          "systemdutildir": "/usr/lib/systemd",
+          "sysusers": "/usr/lib/sysusers.d",
+          "sysusersconfdir": "/etc/sysusers.d",
+          "udevdir": "/usr/lib/udev"
+        },
+        "02-generic-image.conf": {
+          "hostonly": "no"
+        }
+      }
+    },
+    "fstab": [
+      [
+        "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+        "/",
+        "ext4",
+        "defaults",
+        "1",
+        "1"
+      ]
+    ],
+    "groups": [
+      "adm:x:4:",
+      "audio:x:63:",
+      "bin:x:1:",
+      "cdrom:x:11:",
+      "chrony:x:993:",
+      "daemon:x:2:",
+      "dbus:x:81:",
+      "dialout:x:18:",
+      "disk:x:6:",
+      "floppy:x:19:",
+      "ftp:x:50:",
+      "games:x:20:",
+      "input:x:104:",
+      "kmem:x:9:",
+      "kvm:x:36:",
+      "lock:x:54:",
+      "lp:x:7:",
+      "mail:x:12:",
+      "man:x:15:",
+      "mem:x:8:",
+      "nobody:x:65534:",
+      "polkitd:x:994:",
+      "render:x:105:",
+      "root:x:0:",
+      "sgx:x:106:",
+      "ssh_keys:x:996:",
+      "sshd:x:74:",
+      "sys:x:3:",
+      "systemd-coredump:x:997:",
+      "systemd-journal:x:190:",
+      "systemd-network:x:192:",
+      "systemd-oom:x:999:",
+      "systemd-resolve:x:193:",
+      "systemd-timesync:x:998:",
+      "tape:x:33:",
+      "tss:x:59:",
+      "tty:x:5:",
+      "unbound:x:995:",
+      "users:x:100:",
+      "utempter:x:35:",
+      "utmp:x:22:",
+      "video:x:39:",
+      "wheel:x:10:"
+    ],
+    "hostname": "localhost.localdomain",
+    "hosts": [
+      "127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4",
+      "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
+    ],
+    "image-format": {
+      "compat": "1.1",
+      "type": "qcow2"
+    },
+    "locale": {
+      "LANG": "en_US"
+    },
+    "machine-id": "",
+    "os-release": {
+      "ANSI_COLOR": "0;38;2;60;110;180",
+      "BUG_REPORT_URL": "https://bugzilla.redhat.com/",
+      "CPE_NAME": "cpe:/o:fedoraproject:fedora:35",
+      "DOCUMENTATION_URL": "https://docs.fedoraproject.org/en-US/fedora/f35/system-administrators-guide/",
+      "HOME_URL": "https://fedoraproject.org/",
+      "ID": "fedora",
+      "LOGO": "fedora-logo-icon",
+      "NAME": "Fedora Linux",
+      "PLATFORM_ID": "platform:f35",
+      "PRETTY_NAME": "Fedora Linux 35 (Cloud Edition)",
+      "PRIVACY_POLICY_URL": "https://fedoraproject.org/wiki/Legal:PrivacyPolicy",
+      "REDHAT_BUGZILLA_PRODUCT": "Fedora",
+      "REDHAT_BUGZILLA_PRODUCT_VERSION": "35",
+      "REDHAT_SUPPORT_PRODUCT": "Fedora",
+      "REDHAT_SUPPORT_PRODUCT_VERSION": "35",
+      "SUPPORT_URL": "https://ask.fedoraproject.org/",
+      "VARIANT": "Cloud Edition",
+      "VARIANT_ID": "cloud",
+      "VERSION": "35 (Cloud Edition)",
+      "VERSION_CODENAME": "",
+      "VERSION_ID": "35"
+    },
+    "packages": [
+      "NetworkManager-1.32.12-2.fc35.x86_64",
+      "NetworkManager-libnm-1.32.12-2.fc35.x86_64",
+      "acl-2.3.1-2.fc35.x86_64",
+      "alternatives-1.19-1.fc35.x86_64",
+      "audit-3.0.6-1.fc35.x86_64",
+      "audit-libs-3.0.6-1.fc35.x86_64",
+      "basesystem-11-12.fc35.noarch",
+      "bash-5.1.8-2.fc35.x86_64",
+      "bzip2-libs-1.0.8-9.fc35.x86_64",
+      "c-ares-1.17.2-1.fc35.x86_64",
+      "ca-certificates-2021.2.52-1.0.fc35.noarch",
+      "checkpolicy-3.3-1.fc35.x86_64",
+      "chkconfig-1.19-1.fc35.x86_64",
+      "chrony-4.1-3.fc35.x86_64",
+      "cloud-init-20.4-7.fc35.noarch",
+      "cloud-utils-growpart-0.31-9.fc35.noarch",
+      "console-login-helper-messages-0.21.2-3.fc35.noarch",
+      "console-login-helper-messages-issuegen-0.21.2-3.fc35.noarch",
+      "console-login-helper-messages-motdgen-0.21.2-3.fc35.noarch",
+      "console-login-helper-messages-profile-0.21.2-3.fc35.noarch",
+      "coreutils-8.32-31.fc35.x86_64",
+      "coreutils-common-8.32-31.fc35.x86_64",
+      "cpio-2.13-11.fc35.x86_64",
+      "cracklib-2.9.6-27.fc35.x86_64",
+      "cracklib-dicts-2.9.6-27.fc35.x86_64",
+      "crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch",
+      "crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch",
+      "cryptsetup-libs-2.4.2-1.fc35.x86_64",
+      "curl-7.79.1-1.fc35.x86_64",
+      "cyrus-sasl-lib-2.1.27-13.fc35.x86_64",
+      "dbus-1.12.20-5.fc35.x86_64",
+      "dbus-broker-29-4.fc35.x86_64",
+      "dbus-common-1.12.20-5.fc35.noarch",
+      "dbus-libs-1.12.20-5.fc35.x86_64",
+      "dejavu-sans-fonts-2.37-17.fc35.noarch",
+      "deltarpm-3.6.2-10.fc35.x86_64",
+      "device-mapper-1.02.175-6.fc35.x86_64",
+      "device-mapper-libs-1.02.175-6.fc35.x86_64",
+      "dhcp-client-4.4.2-16.b1.fc35.x86_64",
+      "dhcp-common-4.4.2-16.b1.fc35.noarch",
+      "diffutils-3.8-1.fc35.x86_64",
+      "dnf-4.9.0-1.fc35.noarch",
+      "dnf-data-4.9.0-1.fc35.noarch",
+      "dnf-plugins-core-4.0.24-1.fc35.noarch",
+      "dracut-055-6.fc35.x86_64",
+      "dracut-config-generic-055-6.fc35.x86_64",
+      "e2fsprogs-1.46.3-1.fc35.x86_64",
+      "e2fsprogs-libs-1.46.3-1.fc35.x86_64",
+      "efi-filesystem-5-4.fc35.noarch",
+      "efibootmgr-16-11.fc35.x86_64",
+      "efivar-libs-37-17.fc35.x86_64",
+      "elfutils-debuginfod-client-0.186-1.fc35.x86_64",
+      "elfutils-default-yama-scope-0.186-1.fc35.noarch",
+      "elfutils-libelf-0.186-1.fc35.x86_64",
+      "elfutils-libs-0.186-1.fc35.x86_64",
+      "expat-2.4.1-2.fc35.x86_64",
+      "fedora-gpg-keys-35-1.noarch",
+      "fedora-release-cloud-35-36.noarch",
+      "fedora-release-common-35-36.noarch",
+      "fedora-release-identity-cloud-35-36.noarch",
+      "fedora-repos-35-1.noarch",
+      "fedora-repos-modular-35-1.noarch",
+      "file-5.40-9.fc35.x86_64",
+      "file-libs-5.40-9.fc35.x86_64",
+      "filesystem-3.14-7.fc35.x86_64",
+      "findutils-4.8.0-4.fc35.x86_64",
+      "fonts-filesystem-2.0.5-6.fc35.noarch",
+      "freetype-2.11.0-1.fc35.x86_64",
+      "fuse-libs-2.9.9-13.fc35.x86_64",
+      "gawk-5.1.0-4.fc35.x86_64",
+      "gawk-all-langpacks-5.1.0-4.fc35.x86_64",
+      "gdbm-libs-1.22-1.fc35.x86_64",
+      "gettext-0.21-8.fc35.x86_64",
+      "gettext-libs-0.21-8.fc35.x86_64",
+      "glib2-2.70.2-1.fc35.x86_64",
+      "glibc-2.34-11.fc35.x86_64",
+      "glibc-common-2.34-11.fc35.x86_64",
+      "glibc-gconv-extra-2.34-11.fc35.x86_64",
+      "glibc-langpack-en-2.34-11.fc35.x86_64",
+      "gmp-6.2.0-7.fc35.x86_64",
+      "gnupg2-2.3.4-1.fc35.x86_64",
+      "gnupg2-smime-2.3.4-1.fc35.x86_64",
+      "gnutls-3.7.2-2.fc35.x86_64",
+      "gpg-pubkey-9867c58f-601c49ca",
+      "gpgme-1.15.1-6.fc35.x86_64",
+      "graphite2-1.3.14-8.fc35.x86_64",
+      "grep-3.6-4.fc35.x86_64",
+      "groff-base-1.22.4-8.fc35.x86_64",
+      "grub2-common-2.06-10.fc35.noarch",
+      "grub2-efi-ia32-2.06-10.fc35.x86_64",
+      "grub2-efi-x64-2.06-10.fc35.x86_64",
+      "grub2-pc-2.06-10.fc35.x86_64",
+      "grub2-pc-modules-2.06-10.fc35.noarch",
+      "grub2-tools-2.06-10.fc35.x86_64",
+      "grub2-tools-efi-2.06-10.fc35.x86_64",
+      "grub2-tools-extra-2.06-10.fc35.x86_64",
+      "grub2-tools-minimal-2.06-10.fc35.x86_64",
+      "grubby-8.40-55.fc35.x86_64",
+      "gzip-1.10-5.fc35.x86_64",
+      "harfbuzz-2.8.2-2.fc35.x86_64",
+      "hostname-3.23-5.fc35.x86_64",
+      "hunspell-1.7.0-11.fc35.x86_64",
+      "hunspell-en-0.20140811.1-20.fc35.noarch",
+      "hunspell-en-GB-0.20140811.1-20.fc35.noarch",
+      "hunspell-en-US-0.20140811.1-20.fc35.noarch",
+      "hunspell-filesystem-1.7.0-11.fc35.x86_64",
+      "ima-evm-utils-1.3.2-3.fc35.x86_64",
+      "inih-49-4.fc35.x86_64",
+      "initscripts-10.11-1.fc35.x86_64",
+      "initscripts-service-10.11-1.fc35.noarch",
+      "ipcalc-1.0.1-2.fc35.x86_64",
+      "iproute-5.13.0-2.fc35.x86_64",
+      "iproute-tc-5.13.0-2.fc35.x86_64",
+      "iptables-legacy-libs-1.8.7-13.fc35.x86_64",
+      "iptables-libs-1.8.7-13.fc35.x86_64",
+      "iputils-20210722-1.fc35.x86_64",
+      "json-c-0.15-2.fc35.x86_64",
+      "kbd-2.4.0-8.fc35.x86_64",
+      "kbd-misc-2.4.0-8.fc35.noarch",
+      "kernel-5.15.13-200.fc35.x86_64",
+      "kernel-core-5.15.13-200.fc35.x86_64",
+      "kernel-modules-5.15.13-200.fc35.x86_64",
+      "keyutils-libs-1.6.1-3.fc35.x86_64",
+      "kmod-29-4.fc35.x86_64",
+      "kmod-libs-29-4.fc35.x86_64",
+      "kpartx-0.8.6-5.fc35.x86_64",
+      "krb5-libs-1.19.2-2.fc35.x86_64",
+      "langpacks-core-en-3.0-15.fc35.noarch",
+      "langpacks-core-font-en-3.0-15.fc35.noarch",
+      "langpacks-en-3.0-15.fc35.noarch",
+      "less-590-2.fc35.x86_64",
+      "libacl-2.3.1-2.fc35.x86_64",
+      "libarchive-3.5.2-2.fc35.x86_64",
+      "libargon2-20171227-7.fc35.x86_64",
+      "libassuan-2.5.5-3.fc35.x86_64",
+      "libattr-2.5.1-3.fc35.x86_64",
+      "libbasicobjects-0.1.1-48.fc35.x86_64",
+      "libblkid-2.37.2-1.fc35.x86_64",
+      "libbrotli-1.0.9-6.fc35.x86_64",
+      "libcap-2.48-3.fc35.x86_64",
+      "libcap-ng-0.8.2-8.fc35.x86_64",
+      "libcbor-0.7.0-4.fc35.x86_64",
+      "libcollection-0.7.0-48.fc35.x86_64",
+      "libcom_err-1.46.3-1.fc35.x86_64",
+      "libcomps-0.1.18-1.fc35.x86_64",
+      "libcurl-7.79.1-1.fc35.x86_64",
+      "libdb-5.3.28-50.fc35.x86_64",
+      "libdhash-0.5.0-48.fc35.x86_64",
+      "libdnf-0.64.0-1.fc35.x86_64",
+      "libeconf-0.4.0-2.fc35.x86_64",
+      "libedit-3.1-40.20210910cvs.fc35.x86_64",
+      "libevent-2.1.12-4.fc35.x86_64",
+      "libfdisk-2.37.2-1.fc35.x86_64",
+      "libffi-3.1-29.fc35.x86_64",
+      "libfido2-1.8.0-1.fc35.x86_64",
+      "libfsverity-1.4-6.fc35.x86_64",
+      "libgcc-11.2.1-7.fc35.x86_64",
+      "libgcrypt-1.9.4-1.fc35.x86_64",
+      "libgomp-11.2.1-7.fc35.x86_64",
+      "libgpg-error-1.43-1.fc35.x86_64",
+      "libibverbs-38.0-1.fc35.x86_64",
+      "libidn2-2.3.2-3.fc35.x86_64",
+      "libini_config-1.3.1-48.fc35.x86_64",
+      "libkcapi-1.3.1-3.fc35.x86_64",
+      "libkcapi-hmaccalc-1.3.1-3.fc35.x86_64",
+      "libksba-1.6.0-2.fc35.x86_64",
+      "libldb-2.4.1-1.fc35.x86_64",
+      "libmaxminddb-1.6.0-1.fc35.x86_64",
+      "libmnl-1.0.4-14.fc35.x86_64",
+      "libmodulemd-2.13.0-3.fc35.x86_64",
+      "libmount-2.37.2-1.fc35.x86_64",
+      "libndp-1.8-2.fc35.x86_64",
+      "libnetfilter_conntrack-1.0.8-3.fc35.x86_64",
+      "libnfnetlink-1.0.1-20.fc35.x86_64",
+      "libnfsidmap-2.5.4-2.rc3.fc35.x86_64",
+      "libnghttp2-1.45.1-1.fc35.x86_64",
+      "libnl3-3.5.0-8.fc35.x86_64",
+      "libnsl2-1.3.0-4.fc35.x86_64",
+      "libpath_utils-0.2.1-48.fc35.x86_64",
+      "libpcap-1.10.1-2.fc35.x86_64",
+      "libpipeline-1.5.3-3.fc35.x86_64",
+      "libpng-1.6.37-11.fc35.x86_64",
+      "libpsl-0.21.1-4.fc35.x86_64",
+      "libpwquality-1.4.4-6.fc35.x86_64",
+      "libref_array-0.1.5-48.fc35.x86_64",
+      "librepo-1.14.2-1.fc35.x86_64",
+      "libreport-filesystem-2.15.2-6.fc35.noarch",
+      "libseccomp-2.5.3-1.fc35.x86_64",
+      "libsecret-0.20.4-3.fc35.x86_64",
+      "libselinux-3.3-1.fc35.x86_64",
+      "libselinux-utils-3.3-1.fc35.x86_64",
+      "libsemanage-3.3-1.fc35.x86_64",
+      "libsepol-3.3-2.fc35.x86_64",
+      "libsigsegv-2.13-3.fc35.x86_64",
+      "libsmartcols-2.37.2-1.fc35.x86_64",
+      "libsolv-0.7.19-3.fc35.x86_64",
+      "libss-1.46.3-1.fc35.x86_64",
+      "libssh-0.9.6-1.fc35.x86_64",
+      "libssh-config-0.9.6-1.fc35.noarch",
+      "libsss_autofs-2.6.1-1.fc35.x86_64",
+      "libsss_certmap-2.6.1-1.fc35.x86_64",
+      "libsss_idmap-2.6.1-1.fc35.x86_64",
+      "libsss_nss_idmap-2.6.1-1.fc35.x86_64",
+      "libsss_sudo-2.6.1-1.fc35.x86_64",
+      "libstdc++-11.2.1-7.fc35.x86_64",
+      "libtalloc-2.3.3-2.fc35.x86_64",
+      "libtasn1-4.16.0-6.fc35.x86_64",
+      "libtdb-1.4.4-3.fc35.x86_64",
+      "libtevent-0.11.0-1.fc35.x86_64",
+      "libtirpc-1.3.2-1.fc35.x86_64",
+      "libunistring-0.9.10-14.fc35.x86_64",
+      "libusb1-1.0.24-4.fc35.x86_64",
+      "libuser-0.63-7.fc35.x86_64",
+      "libutempter-1.2.1-5.fc35.x86_64",
+      "libuuid-2.37.2-1.fc35.x86_64",
+      "libverto-0.3.2-2.fc35.x86_64",
+      "libxcrypt-4.4.27-1.fc35.x86_64",
+      "libxcrypt-compat-4.4.27-1.fc35.x86_64",
+      "libxkbcommon-1.3.1-1.fc35.x86_64",
+      "libxml2-2.9.12-6.fc35.x86_64",
+      "libyaml-0.2.5-6.fc35.x86_64",
+      "libzstd-1.5.1-4.fc35.x86_64",
+      "linux-atm-libs-2.5.1-30.fc35.x86_64",
+      "linux-firmware-20211216-127.fc35.noarch",
+      "linux-firmware-whence-20211216-127.fc35.noarch",
+      "lmdb-libs-0.9.29-2.fc35.x86_64",
+      "lua-libs-5.4.3-2.fc35.x86_64",
+      "lz4-libs-1.9.3-3.fc35.x86_64",
+      "man-db-2.9.4-2.fc35.x86_64",
+      "memstrack-0.2.4-1.fc35.x86_64",
+      "mkpasswd-5.5.10-2.fc35.x86_64",
+      "mokutil-0.5.0-1.fc35.x86_64",
+      "mozjs78-78.15.0-1.fc35.x86_64",
+      "mpdecimal-2.5.1-2.fc35.x86_64",
+      "mpfr-4.1.0-8.fc35.x86_64",
+      "mtools-4.0.36-1.fc35.x86_64",
+      "ncurses-6.2-8.20210508.fc35.x86_64",
+      "ncurses-base-6.2-8.20210508.fc35.noarch",
+      "ncurses-libs-6.2-8.20210508.fc35.x86_64",
+      "net-tools-2.0-0.60.20160912git.fc35.x86_64",
+      "nettle-3.7.3-2.fc35.x86_64",
+      "npth-1.6-7.fc35.x86_64",
+      "openldap-2.4.59-3.fc35.x86_64",
+      "openssh-8.7p1-3.fc35.x86_64",
+      "openssh-clients-8.7p1-3.fc35.x86_64",
+      "openssh-server-8.7p1-3.fc35.x86_64",
+      "openssl-libs-1.1.1l-2.fc35.x86_64",
+      "openssl-pkcs11-0.4.11-4.fc35.x86_64",
+      "os-prober-1.77-8.fc35.x86_64",
+      "p11-kit-0.23.22-4.fc35.x86_64",
+      "p11-kit-trust-0.23.22-4.fc35.x86_64",
+      "pam-1.5.2-5.fc35.x86_64",
+      "parted-3.4-6.fc35.x86_64",
+      "passwd-0.80-11.fc35.x86_64",
+      "pcre-8.45-1.fc35.x86_64",
+      "pcre2-10.37-4.fc35.x86_64",
+      "pcre2-syntax-10.37-4.fc35.noarch",
+      "pcsc-lite-1.9.5-1.fc35.x86_64",
+      "pcsc-lite-ccid-1.4.36-2.fc35.x86_64",
+      "pcsc-lite-libs-1.9.5-1.fc35.x86_64",
+      "pigz-2.5-2.fc35.x86_64",
+      "pinentry-1.2.0-1.fc35.x86_64",
+      "policycoreutils-3.3-1.fc35.x86_64",
+      "polkit-0.120-1.fc35.x86_64",
+      "polkit-libs-0.120-1.fc35.x86_64",
+      "polkit-pkla-compat-0.1-20.fc35.x86_64",
+      "popt-1.18-6.fc35.x86_64",
+      "procps-ng-3.3.17-3.fc35.x86_64",
+      "protobuf-c-1.4.0-1.fc35.x86_64",
+      "psmisc-23.4-2.fc35.x86_64",
+      "publicsuffix-list-dafsa-20210518-2.fc35.noarch",
+      "python-pip-wheel-21.2.3-4.fc35.noarch",
+      "python-setuptools-wheel-57.4.0-1.fc35.noarch",
+      "python-unversioned-command-3.10.1-2.fc35.noarch",
+      "python3-3.10.1-2.fc35.x86_64",
+      "python3-attrs-21.2.0-4.fc35.noarch",
+      "python3-audit-3.0.6-1.fc35.x86_64",
+      "python3-babel-2.9.1-4.fc35.noarch",
+      "python3-cffi-1.14.6-2.fc35.x86_64",
+      "python3-charset-normalizer-2.0.4-1.fc35.noarch",
+      "python3-configobj-5.0.6-25.fc35.noarch",
+      "python3-cryptography-3.4.7-5.fc35.x86_64",
+      "python3-dateutil-2.8.1-7.fc35.noarch",
+      "python3-dbus-1.2.18-2.fc35.x86_64",
+      "python3-distro-1.6.0-1.fc35.noarch",
+      "python3-dnf-4.9.0-1.fc35.noarch",
+      "python3-dnf-plugins-core-4.0.24-1.fc35.noarch",
+      "python3-gpg-1.15.1-6.fc35.x86_64",
+      "python3-hawkey-0.64.0-1.fc35.x86_64",
+      "python3-idna-3.2-1.fc35.noarch",
+      "python3-jinja2-3.0.1-2.fc35.noarch",
+      "python3-jsonpatch-1.21-18.fc35.noarch",
+      "python3-jsonpointer-2.0-4.fc35.noarch",
+      "python3-jsonschema-3.2.0-12.fc35.noarch",
+      "python3-jwt+crypto-2.1.0-2.fc35.noarch",
+      "python3-jwt-2.1.0-2.fc35.noarch",
+      "python3-libcomps-0.1.18-1.fc35.x86_64",
+      "python3-libdnf-0.64.0-1.fc35.x86_64",
+      "python3-libs-3.10.1-2.fc35.x86_64",
+      "python3-libselinux-3.3-1.fc35.x86_64",
+      "python3-libsemanage-3.3-1.fc35.x86_64",
+      "python3-markupsafe-2.0.0-2.fc35.x86_64",
+      "python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch",
+      "python3-oauthlib-3.0.2-11.fc35.noarch",
+      "python3-ply-3.11-13.fc35.noarch",
+      "python3-policycoreutils-3.3-1.fc35.noarch",
+      "python3-prettytable-0.7.2-27.fc35.noarch",
+      "python3-pycparser-2.20-5.fc35.noarch",
+      "python3-pyrsistent-0.18.0-8.fc35.x86_64",
+      "python3-pyserial-3.4-12.fc35.noarch",
+      "python3-pysocks-1.7.1-11.fc35.noarch",
+      "python3-pytz-2021.3-1.fc35.noarch",
+      "python3-pyyaml-5.4.1-4.fc35.x86_64",
+      "python3-requests-2.27.0-1.fc35.noarch",
+      "python3-rpm-4.17.0-1.fc35.x86_64",
+      "python3-setools-4.4.0-3.fc35.x86_64",
+      "python3-setuptools-57.4.0-1.fc35.noarch",
+      "python3-six-1.16.0-4.fc35.noarch",
+      "python3-unbound-1.13.2-1.fc35.x86_64",
+      "python3-urllib3-1.26.7-2.fc35.noarch",
+      "qrencode-libs-4.1.1-1.fc35.x86_64",
+      "readline-8.1-3.fc35.x86_64",
+      "rootfiles-8.1-30.fc35.noarch",
+      "rpm-4.17.0-1.fc35.x86_64",
+      "rpm-build-libs-4.17.0-1.fc35.x86_64",
+      "rpm-libs-4.17.0-1.fc35.x86_64",
+      "rpm-plugin-selinux-4.17.0-1.fc35.x86_64",
+      "rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64",
+      "rpm-sign-libs-4.17.0-1.fc35.x86_64",
+      "rsync-3.2.3-8.fc35.x86_64",
+      "sed-4.8-8.fc35.x86_64",
+      "selinux-policy-35.8-1.fc35.noarch",
+      "selinux-policy-targeted-35.8-1.fc35.noarch",
+      "setup-2.13.9.1-2.fc35.noarch",
+      "shadow-utils-4.9-8.fc35.x86_64",
+      "shim-ia32-15.4-5.x86_64",
+      "shim-x64-15.4-5.x86_64",
+      "sqlite-libs-3.36.0-3.fc35.x86_64",
+      "sssd-client-2.6.1-1.fc35.x86_64",
+      "sssd-common-2.6.1-1.fc35.x86_64",
+      "sssd-kcm-2.6.1-1.fc35.x86_64",
+      "sssd-nfs-idmap-2.6.1-1.fc35.x86_64",
+      "sudo-1.9.7p2-2.fc35.x86_64",
+      "sudo-python-plugin-1.9.7p2-2.fc35.x86_64",
+      "syslinux-6.04-0.18.fc35.x86_64",
+      "syslinux-extlinux-6.04-0.18.fc35.x86_64",
+      "syslinux-extlinux-nonlinux-6.04-0.18.fc35.noarch",
+      "syslinux-nonlinux-6.04-0.18.fc35.noarch",
+      "systemd-249.7-2.fc35.x86_64",
+      "systemd-libs-249.7-2.fc35.x86_64",
+      "systemd-networkd-249.7-2.fc35.x86_64",
+      "systemd-oomd-defaults-249.7-2.fc35.noarch",
+      "systemd-pam-249.7-2.fc35.x86_64",
+      "systemd-resolved-249.7-2.fc35.x86_64",
+      "systemd-udev-249.7-2.fc35.x86_64",
+      "tar-1.34-2.fc35.x86_64",
+      "tpm2-tss-3.1.0-3.fc35.x86_64",
+      "trousers-0.3.15-4.fc35.x86_64",
+      "trousers-lib-0.3.15-4.fc35.x86_64",
+      "tzdata-2021e-1.fc35.noarch",
+      "unbound-libs-1.13.2-1.fc35.x86_64",
+      "util-linux-2.37.2-1.fc35.x86_64",
+      "util-linux-core-2.37.2-1.fc35.x86_64",
+      "vim-data-8.2.4006-1.fc35.noarch",
+      "vim-minimal-8.2.4006-1.fc35.x86_64",
+      "which-2.21-27.fc35.x86_64",
+      "whois-nls-5.5.10-2.fc35.noarch",
+      "xfsprogs-5.12.0-2.fc35.x86_64",
+      "xkeyboard-config-2.33-2.fc35.noarch",
+      "xz-5.2.5-7.fc35.x86_64",
+      "xz-libs-5.2.5-7.fc35.x86_64",
+      "yum-4.9.0-1.fc35.noarch",
+      "zchunk-libs-1.1.15-2.fc35.x86_64",
+      "zlib-1.2.11-30.fc35.x86_64"
+    ],
+    "partition-table": "dos",
+    "partition-table-id": "0x14fc63d2",
+    "partitions": [
+      {
+        "bootable": true,
+        "fstype": "ext4",
+        "label": null,
+        "partuuid": "14fc63d2-01",
+        "size": 2146435072,
+        "start": 1048576,
+        "type": "83",
+        "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+      }
+    ],
+    "passwd": [
+      "adm:x:3:4:adm:/var/adm:/sbin/nologin",
+      "bin:x:1:1:bin:/bin:/sbin/nologin",
+      "chrony:x:994:993::/var/lib/chrony:/sbin/nologin",
+      "daemon:x:2:2:daemon:/sbin:/sbin/nologin",
+      "dbus:x:81:81:System message bus:/:/sbin/nologin",
+      "ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin",
+      "games:x:12:100:games:/usr/games:/sbin/nologin",
+      "halt:x:7:0:halt:/sbin:/sbin/halt",
+      "lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin",
+      "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
+      "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
+      "operator:x:11:0:operator:/root:/sbin/nologin",
+      "polkitd:x:995:994:User for polkitd:/:/sbin/nologin",
+      "root:x:0:0:root:/root:/bin/bash",
+      "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
+      "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
+      "sync:x:5:0:sync:/sbin:/bin/sync",
+      "systemd-coredump:x:997:997:systemd Core Dumper:/:/usr/sbin/nologin",
+      "systemd-network:x:192:192:systemd Network Management:/:/usr/sbin/nologin",
+      "systemd-oom:x:999:999:systemd Userspace OOM Killer:/:/usr/sbin/nologin",
+      "systemd-resolve:x:193:193:systemd Resolver:/:/usr/sbin/nologin",
+      "systemd-timesync:x:998:998:systemd Time Synchronization:/:/usr/sbin/nologin",
+      "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
+      "unbound:x:996:995:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
+    ],
+    "rpm-verify": {
+      "changed": {
+        "/boot/grub2/fonts/unicode.pf2": ".M.......",
+        "/etc/machine-id": ".M.......",
+        "/etc/udev/hwdb.bin": ".M.......",
+        "/proc": ".M.......",
+        "/sys": ".M.......",
+        "/var/log/lastlog": ".M....G.."
+      },
+      "missing": []
+    },
+    "selinux": {
+      "context-mismatch": [
+        {
+          "actual": "system_u:object_r:unlabeled_t:s0",
+          "expected": "system_u:object_r:lost_found_t:s0",
+          "filename": "/lost+found"
+        }
+      ],
+      "policy": {
+        "SELINUX": "enforcing",
+        "SELINUXTYPE": "targeted"
+      }
+    },
+    "services-disabled": [
+      "arp-ethers.service",
+      "chrony-wait.service",
+      "console-getty.service",
+      "console-login-helper-messages-gensnippet-os-release.service",
+      "console-login-helper-messages-gensnippet-ssh-keys.service",
+      "debug-shell.service",
+      "exit.target",
+      "halt.target",
+      "kexec.target",
+      "loadmodules.service",
+      "man-db-restart-cache-update.service",
+      "nis-domainname.service",
+      "poweroff.target",
+      "proc-sys-fs-binfmt_misc.mount",
+      "rdisc.service",
+      "remote-cryptsetup.target",
+      "remote-veritysetup.target",
+      "runlevel0.target",
+      "selinux-check-proper-disable.service",
+      "serial-getty@.service",
+      "sshd-keygen@.service",
+      "sshd.socket",
+      "sssd-autofs.socket",
+      "sssd-nss.socket",
+      "sssd-pac.socket",
+      "sssd-pam-priv.socket",
+      "sssd-pam.socket",
+      "sssd-ssh.socket",
+      "sssd-sudo.socket",
+      "systemd-boot-check-no-failures.service",
+      "systemd-network-generator.service",
+      "systemd-networkd-wait-online.service",
+      "systemd-networkd.service",
+      "systemd-networkd.socket",
+      "systemd-pstore.service",
+      "systemd-sysext.service",
+      "systemd-time-wait-sync.service",
+      "systemd-timesyncd.service",
+      "tcsd.service"
+    ],
+    "services-enabled": [
+      "NetworkManager-dispatcher.service",
+      "NetworkManager-wait-online.service",
+      "NetworkManager.service",
+      "auditd.service",
+      "autovt@.service",
+      "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
+      "ctrl-alt-del.target",
+      "dbus-broker.service",
+      "dbus-org.freedesktop.home1.service",
+      "dbus-org.freedesktop.nm-dispatcher.service",
+      "dbus-org.freedesktop.oom1.service",
+      "dbus-org.freedesktop.resolve1.service",
+      "dbus.service",
+      "dbus.socket",
+      "dnf-makecache.timer",
+      "fstrim.timer",
+      "getty@.service",
+      "import-state.service",
+      "pcscd.socket",
+      "reboot.target",
+      "remote-fs.target",
+      "rpmdb-rebuild.service",
+      "runlevel6.target",
+      "selinux-autorelabel-mark.service",
+      "sshd.service",
+      "sssd-kcm.socket",
+      "sssd.service",
+      "systemd-homed-activate.service",
+      "systemd-homed.service",
+      "systemd-oomd.service",
+      "systemd-resolved.service",
+      "systemd-userdbd.socket",
+      "unbound-anchor.timer"
+    ],
+    "sudoers": {
+      "/etc/sudoers": [
+        "Defaults   !visiblepw",
+        "Defaults    always_set_home",
+        "Defaults    match_group_by_gid",
+        "Defaults    always_query_group_plugin",
+        "Defaults    env_reset",
+        "Defaults    env_keep =  \"COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS\"",
+        "Defaults    env_keep += \"MAIL QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE\"",
+        "Defaults    env_keep += \"LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES\"",
+        "Defaults    env_keep += \"LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE\"",
+        "Defaults    env_keep += \"LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY\"",
+        "Defaults    secure_path = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+        "root\tALL=(ALL) \tALL",
+        "%wheel\tALL=(ALL)\tALL"
+      ]
+    },
+    "sysctl.d": {
+      "/usr/lib/sysctl.d": {
+        "10-default-yama-scope.conf": [
+          "kernel.yama.ptrace_scope = 0"
+        ],
+        "50-coredump.conf": [
+          "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h",
+          "kernel.core_pipe_limit=16",
+          "fs.suid_dumpable=2"
+        ],
+        "50-default.conf": [
+          "kernel.sysrq = 16",
+          "kernel.core_uses_pid = 1",
+          "net.ipv4.conf.default.rp_filter = 2",
+          "net.ipv4.conf.*.rp_filter = 2",
+          "-net.ipv4.conf.all.rp_filter",
+          "net.ipv4.conf.default.accept_source_route = 0",
+          "net.ipv4.conf.*.accept_source_route = 0",
+          "-net.ipv4.conf.all.accept_source_route",
+          "net.ipv4.conf.default.promote_secondaries = 1",
+          "net.ipv4.conf.*.promote_secondaries = 1",
+          "-net.ipv4.conf.all.promote_secondaries",
+          "-net.ipv4.ping_group_range = 0 2147483647",
+          "-net.core.default_qdisc = fq_codel",
+          "fs.protected_hardlinks = 1",
+          "fs.protected_symlinks = 1",
+          "fs.protected_regular = 1",
+          "fs.protected_fifos = 1"
+        ],
+        "50-libkcapi-optmem_max.conf": [
+          "net.core.optmem_max = 81920"
+        ],
+        "50-pid-max.conf": [
+          "kernel.pid_max = 4194304"
+        ]
+      }
+    },
+    "systemd-service-dropins": {
+      "/usr/lib/systemd/system": {
+        "systemd-hostnamed.service.d": {
+          "Service": {
+            "PrivateDevices": "no"
+          }
+        },
+        "systemd-logind.service.d": {
+          "Service": {
+            "Environment": "SYSTEMD_REBOOT_TO_BOOT_LOADER_MENU=true"
+          }
+        },
+        "systemd-udev-trigger.service.d": {
+          "Unit": {
+            "RefuseManualStop": "true"
+          }
+        },
+        "user@.service.d": {
+          "Service": {
+            "ManagedOOMMemoryPressure": "kill",
+            "ManagedOOMMemoryPressureLimit": "50%"
+          }
+        }
+      }
+    },
+    "timezone": "UTC",
+    "tmpfiles.d": {
+      "/usr/lib/tmpfiles.d": {
+        "cloud-init.conf": [
+          "d /run/cloud-init 0700 root root - -"
+        ],
+        "console-login-helper-messages-issuegen.conf": [
+          "r /etc/issue.d/*_clhm_*.issue - - - - -"
+        ],
+        "console-login-helper-messages-motdgen.conf": [
+          "d /run/motd.d - - - - -"
+        ],
+        "console-login-helper-messages-profile.conf": [
+          "L /etc/profile.d/console-login-helper-messages-profile.sh - - - - ../../usr/share/console-login-helper-messages/profile.sh"
+        ],
+        "console-login-helper-messages.conf": [
+          "d /run/console-login-helper-messages - - - - -"
+        ],
+        "cryptsetup.conf": [
+          "d /run/cryptsetup 0700 root root -"
+        ],
+        "dnf.conf": [
+          "R /var/tmp/dnf*/locks/*",
+          "r /var/cache/dnf/download_lock.pid",
+          "r /var/cache/dnf/metadata_lock.pid",
+          "r /var/lib/dnf/rpmdb_lock.pid",
+          "r /var/log/log_lock.pid"
+        ],
+        "etc.conf": [
+          "L /etc/os-release - - - - ../usr/lib/os-release",
+          "L+ /etc/mtab - - - - ../proc/self/mounts",
+          "L! /etc/resolv.conf - - - - ../run/systemd/resolve/stub-resolv.conf",
+          "C! /etc/nsswitch.conf - - - -",
+          "C! /etc/pam.d - - - -",
+          "C! /etc/issue - - - -"
+        ],
+        "home.conf": [
+          "Q /home 0755 - - -",
+          "q /srv 0755 - - -"
+        ],
+        "journal-nocow.conf": [
+          "h /var/log/journal - - - - +C",
+          "h /var/log/journal/%m - - - - +C",
+          "h /var/log/journal/remote - - - - +C"
+        ],
+        "legacy.conf": [
+          "d /run/lock 0755 root root -",
+          "L /var/lock - - - - ../run/lock",
+          "d /run/lock/subsys 0755 root root -",
+          "r! /forcefsck",
+          "r! /fastboot",
+          "r! /forcequotacheck"
+        ],
+        "libselinux.conf": [
+          "d /run/setrans 0755 root root"
+        ],
+        "man-db.conf": [
+          "d /var/cache/man 0755 root root 1w"
+        ],
+        "pam.conf": [
+          "d /run/console 0755 root root -",
+          "d /run/faillock 0755 root root -",
+          "d /run/sepermit 0755 root root -",
+          "d /run/motd.d 0755 root root -",
+          "f /var/log/tallylog 0600 root root -"
+        ],
+        "portables.conf": [
+          "Q /var/lib/portables 0700"
+        ],
+        "selinux-policy.conf": [
+          "z /sys/devices/system/cpu/online - - -",
+          "Z /sys/class/net - - -",
+          "z /sys/kernel/uevent_helper - - -",
+          "w /sys/fs/selinux/checkreqprot - - - - 0"
+        ],
+        "setup.conf": [
+          "f /run/motd 0644 root root -",
+          "d /run/motd.d 0755 root root -"
+        ],
+        "static-nodes-permissions.conf": [
+          "z /dev/snd/seq      0660 - audio -",
+          "z /dev/snd/timer    0660 - audio -",
+          "z /dev/loop-control 0660 - disk  -",
+          "z /dev/net/tun      0666 - -     -",
+          "z /dev/fuse         0666 - -     -",
+          "z /dev/kvm          0666 - kvm -",
+          "z /dev/vhost-net    0666 - kvm -",
+          "z /dev/vhost-vsock  0666 - kvm -"
+        ],
+        "sudo.conf": [
+          "d /run/sudo 0711 root root",
+          "D /run/sudo/ts 0700 root root"
+        ],
+        "systemd-nologin.conf": [
+          "F! /run/nologin 0644 - - - \"System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8).\""
+        ],
+        "systemd-pstore.conf": [
+          "d /var/lib/systemd/pstore 0755 root root 14d"
+        ],
+        "systemd-tmp.conf": [
+          "x /tmp/systemd-private-%b-*",
+          "X /tmp/systemd-private-%b-*/tmp",
+          "x /var/tmp/systemd-private-%b-*",
+          "X /var/tmp/systemd-private-%b-*/tmp",
+          "R! /tmp/systemd-private-*",
+          "R! /var/tmp/systemd-private-*",
+          "x  /var/lib/systemd/coredump/.#core*.%b*",
+          "r! /var/lib/systemd/coredump/.#*"
+        ],
+        "systemd.conf": [
+          "d /run/user 0755 root root -",
+          "F! /run/utmp 0664 root utmp -",
+          "d /run/systemd/ask-password 0755 root root -",
+          "d /run/systemd/seats 0755 root root -",
+          "d /run/systemd/sessions 0755 root root -",
+          "d /run/systemd/users 0755 root root -",
+          "d /run/systemd/machines 0755 root root -",
+          "d /run/systemd/shutdown 0755 root root -",
+          "d /run/systemd/netif 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/links 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/leases 0755 systemd-network systemd-network -",
+          "d /run/systemd/netif/lldp 0755 systemd-network systemd-network -",
+          "d /run/log 0755 root root -",
+          "z /run/log/journal 2755 root systemd-journal - -",
+          "Z /run/log/journal/%m ~2750 root systemd-journal - -",
+          "a+ /run/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /run/log/journal/%m/*.journal* - - - - group:adm:r--,group:wheel:r--",
+          "z /var/log/journal 2755 root systemd-journal - -",
+          "z /var/log/journal/%m 2755 root systemd-journal - -",
+          "z /var/log/journal/%m/system.journal 0640 root systemd-journal - -",
+          "a+ /var/log/journal    - - - - d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m - - - - d:group:adm:r-x,d:group:wheel:r-x,group:adm:r-x,group:wheel:r-x",
+          "a+ /var/log/journal/%m/system.journal - - - - group:adm:r--,group:wheel:r--",
+          "d /var/lib/systemd 0755 root root -",
+          "d /var/lib/systemd/coredump 0755 root root 3d",
+          "d /var/lib/private 0700 root root -",
+          "d /var/log/private 0700 root root -",
+          "d /var/cache/private 0700 root root -"
+        ],
+        "tmp.conf": [
+          "q /tmp 1777 root root 10d",
+          "q /var/tmp 1777 root root 30d"
+        ],
+        "tpm2-tss-fapi.conf": [
+          "d       /var/lib/tpm2-tss/system/keystore   2775 tss  tss   -           -",
+          "a+      /var/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx",
+          "d       /run/tpm2-tss/eventlog                2775 tss  tss   -           -",
+          "a+      /run/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx"
+        ],
+        "var.conf": [
+          "q /var 0755 - - -",
+          "L /var/run - - - - ../run",
+          "d /var/log 0755 - - -",
+          "f /var/log/wtmp 0664 root utmp -",
+          "f /var/log/btmp 0660 root utmp -",
+          "f /var/log/lastlog 0664 root utmp -",
+          "d /var/cache 0755 - - -",
+          "d /var/lib 0755 - - -",
+          "d /var/spool 0755 - - -"
+        ],
+        "x11.conf": [
+          "D! /tmp/.X11-unix 1777 root root 10d",
+          "D! /tmp/.ICE-unix 1777 root root 10d",
+          "D! /tmp/.XIM-unix 1777 root root 10d",
+          "D! /tmp/.font-unix 1777 root root 10d",
+          "D! /tmp/.Test-unix 1777 root root 10d",
+          "r! /tmp/.X[0-9]*-lock"
+        ]
+      }
+    }
+  }
+}

--- a/tools/test-case-generators/distro-arch-imagetype-map.json
+++ b/tools/test-case-generators/distro-arch-imagetype-map.json
@@ -6,10 +6,14 @@
             "openstack",
             "qcow2",
             "vhd",
-            "vmdk"
+            "vmdk",
+            "oci"
         ],
         "aarch64": [
-            "ami"
+            "ami",
+            "openstack",
+            "qcow2",
+            "oci"
         ]
     },
     "fedora-35": {
@@ -19,10 +23,14 @@
             "openstack",
             "qcow2",
             "vhd",
-            "vmdk"
+            "vmdk",
+            "oci"
         ],
         "aarch64": [
-            "ami"
+            "ami",
+            "openstack",
+            "qcow2",
+            "oci"
         ]
     },
     "centos-8": {

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -224,6 +224,17 @@
     "no-image-info": true,
     "overrides": {}
   },
+  "oci": {
+    "compose-request": {
+      "distro": "",
+      "arch": "",
+      "image-type": "oci",
+      "repositories": [],
+      "filename": "disk.qcow2",
+      "blueprint": {}
+    },
+    "overrides": {}
+  },
   "qcow2": {
     "compose-request": {
       "distro": "",


### PR DESCRIPTION
Add F34 and F35 image test cases for all remaining image types, which
were previously not tested. With this PR, image test cases are now
generated for all image types on all architectures as supported by the
Fedora distro definition.

Signed-off-by: Tomas Hozza <thozza@redhat.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
