### PR TITLE
test: update govc env variables documentation

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -235,15 +235,15 @@ The following environment variables are required
 
 The following environment variables are required
 
-- `GOVMOMI_URL` - vCenter hostname
-- `GOVMOMI_USERNAME`
-- `GOVMOMI_PASSWORD`
-- `GOVMOMI_DATACENTER`
-- `GOVMOMI_CLUSTER`
-- `GOVMOMI_NETWORK`
-- `GOVMOMI_DATASTORE`
-- `GOVMOMI_FOLDER`
-- `GOVMOMI_INSECURE` - value of 1 will skip checking SSL certificates
+- `GOVC_URL` - vCenter hostname
+- `GOVC_USERNAME`
+- `GOVC_PASSWORD`
+- `GOVC_DATACENTER`
+- `GOVC_CLUSTER`
+- `GOVC_NETWORK`
+- `GOVC_DATASTORE`
+- `GOVC_FOLDER`
+- `GOVC_INSECURE` - value of 1 will skip checking SSL certificates
 
 **WARNING:** when configuring the credentials for Schutzbot we've experienced
 an issue where the first line in the credentials file gets lost resulting in


### PR DESCRIPTION
govc cli no longer uses GOVMOMI_* enviroment variables. As the govc documentation indicates, this variables should be GOVC_*

[govc usage](https://github.com/vmware/govmomi/blob/master/govc/README.md#usage)


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
