### PR TITLE
Pre-define an ostree remote for RFE raw images (including created via simplified installer)

### DIFF
--- a/internal/distro/rhel86/pipelines.go
+++ b/internal/distro/rhel86/pipelines.go
@@ -790,10 +790,11 @@ func ostreeDeployPipeline(
 	p.Name = "image-tree"
 	p.Build = "name:build"
 	osname := "redhat"
+	remote := "rhel-edge"
 
 	p.AddStage(osbuild.OSTreeInitFsStage())
 	p.AddStage(osbuild.NewOSTreePullStage(
-		&osbuild.OSTreePullStageOptions{Repo: repoPath},
+		&osbuild.OSTreePullStageOptions{Repo: repoPath, Remote: remote},
 		ostreePullStageInputs("org.osbuild.source", options.OSTree.Parent, options.OSTree.Ref),
 	))
 	p.AddStage(osbuild.NewOSTreeOsInitStage(
@@ -807,6 +808,7 @@ func ostreeDeployPipeline(
 		&osbuild.OSTreeDeployStageOptions{
 			OsName: osname,
 			Ref:    options.OSTree.Ref,
+			Remote: remote,
 			Mounts: []string{"/boot", "/boot/efi"},
 			Rootfs: osbuild.Rootfs{
 				Label: "root",
@@ -817,6 +819,21 @@ func ostreeDeployPipeline(
 			},
 		},
 	))
+
+	if options.OSTree.URL != "" {
+		p.AddStage(osbuild.NewOSTreeRemotesStage(
+			&osbuild.OSTreeRemotesStageOptions{
+				Repo: "/ostree/repo",
+				Remotes: []osbuild.OSTreeRemote{
+					{
+						Name: remote,
+						URL:  options.OSTree.URL,
+					},
+				},
+			},
+		))
+	}
+
 	p.AddStage(osbuild.NewOSTreeFillvarStage(
 		&osbuild.OSTreeFillvarStageOptions{
 			Deployment: osbuild.OSTreeDeployment{

--- a/internal/distro/rhel90/pipelines.go
+++ b/internal/distro/rhel90/pipelines.go
@@ -786,10 +786,11 @@ func ostreeDeployPipeline(
 	p.Name = "image-tree"
 	p.Build = "name:build"
 	osname := "redhat"
+	remote := "rhel-edge"
 
 	p.AddStage(osbuild.OSTreeInitFsStage())
 	p.AddStage(osbuild.NewOSTreePullStage(
-		&osbuild.OSTreePullStageOptions{Repo: repoPath},
+		&osbuild.OSTreePullStageOptions{Repo: repoPath, Remote: remote},
 		ostreePullStageInputs("org.osbuild.source", options.OSTree.Parent, options.OSTree.Ref),
 	))
 	p.AddStage(osbuild.NewOSTreeOsInitStage(
@@ -803,6 +804,7 @@ func ostreeDeployPipeline(
 		&osbuild.OSTreeDeployStageOptions{
 			OsName: osname,
 			Ref:    options.OSTree.Ref,
+			Remote: remote,
 			Mounts: []string{"/boot", "/boot/efi"},
 			Rootfs: osbuild.Rootfs{
 				Label: "root",
@@ -813,6 +815,21 @@ func ostreeDeployPipeline(
 			},
 		},
 	))
+
+	if options.OSTree.URL != "" {
+		p.AddStage(osbuild.NewOSTreeRemotesStage(
+			&osbuild.OSTreeRemotesStageOptions{
+				Repo: "/ostree/repo",
+				Remotes: []osbuild.OSTreeRemote{
+					{
+						Name: remote,
+						URL:  options.OSTree.URL,
+					},
+				},
+			},
+		))
+	}
+
 	p.AddStage(osbuild.NewOSTreeFillvarStage(
 		&osbuild.OSTreeFillvarStageOptions{
 			Deployment: osbuild.OSTreeDeployment{

--- a/internal/osbuild2/ostree_deploy_stage.go
+++ b/internal/osbuild2/ostree_deploy_stage.go
@@ -11,6 +11,8 @@ type OSTreeDeployStageOptions struct {
 
 	Ref string `json:"ref"`
 
+	Remote string `json:"remote,omitempty"`
+
 	Mounts []string `json:"mounts"`
 
 	Rootfs Rootfs `json:"rootfs"`

--- a/internal/osbuild2/ostree_pull_stage.go
+++ b/internal/osbuild2/ostree_pull_stage.go
@@ -4,6 +4,8 @@ package osbuild2
 type OSTreePullStageOptions struct {
 	// Location of the ostree repo
 	Repo string `json:"repo"`
+	// Remote to configure for all commits
+	Remote string `json:"remote,omitempty"`
 }
 
 func (OSTreePullStageOptions) isStageOptions() {}

--- a/test/cases/ostree-raw-image.sh
+++ b/test/cases/ostree-raw-image.sh
@@ -604,11 +604,6 @@ until [ "$(sudo podman inspect -f '{{.State.Running}}' rhel-edge)" == "true" ]; 
     sleep 1;
 done;
 
-# Workaround to https://github.com/osbuild/osbuild-composer/issues/1693
-greenprint "🗳 Add external prod edge repo"
-sudo ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" admin@${UEFI_GUEST_ADDRESS} "echo ${EDGE_USER_PASSWORD} |sudo -S ostree remote add --no-gpg-verify --no-sign-verify rhel-edge ${PROD_REPO_URL}"
-sudo ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" admin@${UEFI_GUEST_ADDRESS} "echo ${EDGE_USER_PASSWORD} |sudo -S ostree admin switch rhel-edge:${OSTREE_REF}"
-
 # Pull upgrade to prod mirror
 greenprint "⛓ Pull upgrade to prod mirror"
 sudo ostree --repo="$PROD_REPO" pull --mirror edge-stage "$OSTREE_REF"

--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -662,11 +662,6 @@ until [ "$(sudo podman inspect -f '{{.State.Running}}' rhel-edge)" == "true" ]; 
     sleep 1;
 done;
 
-# Workaround to https://github.com/osbuild/osbuild-composer/issues/1693
-greenprint "🗳 Add external prod edge repo"
-sudo ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" admin@${UEFI_GUEST_ADDRESS} "echo ${EDGE_USER_PASSWORD} |sudo -S ostree remote add --no-gpg-verify --no-sign-verify rhel-edge ${PROD_REPO_URL}"
-sudo ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" admin@${UEFI_GUEST_ADDRESS} "echo ${EDGE_USER_PASSWORD} |sudo -S ostree admin switch rhel-edge:${OSTREE_REF}"
-
 # Pull upgrade to prod mirror
 greenprint "⛓ Pull upgrade to prod mirror"
 sudo ostree --repo="$PROD_REPO" pull --mirror edge-stage "$OSTREE_REF"


### PR DESCRIPTION
I'm re-bringing this up from https://github.com/osbuild/osbuild-composer/pull/1697 as that didn't make 85 and even if we still don't have automatic updates this is pretty important for the admin workflow who's used to just serve the update and `rpm-ostree upgrade` - it should be pretty safe to land this (I don't remember what was the risk)

From the old PR:

> Preset a remote called rhel-edge with the URL that was used to fetch the commit, so it can be used to fetch updates.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
