### PR TITLE
internal/cloud: Allow aws creds from defaults

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -44,8 +44,10 @@ type OSBuildJobImpl struct {
 func (impl *OSBuildJobImpl) getAWS(region string, accessId string, secret string, token string) (*awscloud.AWS, error) {
 	if accessId != "" && secret != "" {
 		return awscloud.New(region, accessId, secret, token)
-	} else {
+	} else if impl.AWSCreds != "" {
 		return awscloud.NewFromFile(impl.AWSCreds, region)
+	} else {
+		return awscloud.NewDefault(region)
 	}
 }
 

--- a/internal/cloud/awscloud/awscloud.go
+++ b/internal/cloud/awscloud/awscloud.go
@@ -57,6 +57,12 @@ func NewFromFile(filename string, region string) (*AWS, error) {
 	return newAwsFromCreds(credentials.NewSharedCredentials(filename, "default"), region)
 }
 
+// Initialize a new AWS object from defaults.
+// Looks for env variables, shared credential file, and EC2 Instance Roles.
+func NewDefault(region string) (*AWS, error) {
+	return newAwsFromCreds(nil, region)
+}
+
 func (a *AWS) Upload(filename, bucket, key string) (*s3manager.UploadOutput, error) {
 	file, err := os.Open(filename)
 	if err != nil {


### PR DESCRIPTION
Defaults according to https://docs.aws.amazon.com/sdk-for-go/api/aws/#Config:
Defaults to a chain of credential providers to search for credentials in
environment variables, shared credential file, and EC2 Instance Roles.

If nothing is specified fall back to whatever instance role.

