### PR TITLE
Extend information gathered by `image-info`

### DIFF
--- a/test/data/manifests/centos_8-aarch64-ami-boot.json
+++ b/test/data/manifests/centos_8-aarch64-ami-boot.json
@@ -10704,6 +10704,15 @@
     },
     "default-target": "multi-user.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "contentdir": "centos",
         "infra": "stock",
@@ -11274,8 +11283,8 @@
         "fstype": "xfs",
         "label": "root",
         "partuuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
-        "size": 9989681152,
-        "start": 747685888,
+        "size": 9989732352,
+        "start": 747634688,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
         "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
       },
@@ -11294,7 +11303,7 @@
         "fstype": "xfs",
         "label": null,
         "partuuid": "CB07C243-BC44-4717-853E-28852021225B",
-        "size": 536922112,
+        "size": 536870912,
         "start": 210763776,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
         "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
@@ -11341,6 +11350,7 @@
         "/etc/pam.d/postlogin": "....L....",
         "/etc/pam.d/smartcard-auth": "....L....",
         "/etc/pam.d/system-auth": "....L....",
+        "/etc/ssh/sshd_config": "S.5....T.",
         "/proc": ".M.......",
         "/sys": ".M.......",
         "/var/log/lastlog": ".M....G..",
@@ -11431,6 +11441,49 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication no",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -11662,6 +11715,89 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/centos_8-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_commit-boot.json
@@ -10609,6 +10609,49 @@
       "timedatex.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10913,6 +10956,89 @@
         ]
       }
     },
-    "type": "ostree/commit"
+    "type": "ostree/commit",
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
+      }
+    }
   }
 }

--- a/test/data/manifests/centos_8-aarch64-openstack-boot.json
+++ b/test/data/manifests/centos_8-aarch64-openstack-boot.json
@@ -10975,6 +10975,15 @@
     },
     "default-target": "graphical.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "contentdir": "centos",
         "infra": "stock",
@@ -11694,6 +11703,49 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -11905,6 +11957,89 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/centos_8-aarch64-qcow2-boot.json
+++ b/test/data/manifests/centos_8-aarch64-qcow2-boot.json
@@ -10921,6 +10921,15 @@
     },
     "default-target": "multi-user.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "contentdir": "centos",
         "infra": "stock",
@@ -11643,6 +11652,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -11856,6 +11908,89 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/centos_8-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-aarch64-qcow2_customize-boot.json
@@ -13204,6 +13204,15 @@
     },
     "default-target": "multi-user.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "contentdir": "centos",
         "infra": "stock",
@@ -13983,6 +13992,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -14196,6 +14248,89 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/centos_8-aarch64-tar-boot.json
+++ b/test/data/manifests/centos_8-aarch64-tar-boot.json
@@ -7508,6 +7508,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",
@@ -7673,6 +7697,89 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/centos_8-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/centos_8-ppc64le-qcow2-boot.json
@@ -11629,6 +11629,15 @@
     },
     "default-target": "multi-user.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "contentdir": "centos",
         "infra": "stock",
@@ -12388,6 +12397,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -12601,6 +12653,89 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/centos_8-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-ppc64le-qcow2_customize-boot.json
@@ -14462,6 +14462,15 @@
     },
     "default-target": "multi-user.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "contentdir": "centos",
         "infra": "stock",
@@ -15278,6 +15287,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -15491,6 +15543,89 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/centos_8-ppc64le-tar-boot.json
+++ b/test/data/manifests/centos_8-ppc64le-tar-boot.json
@@ -7615,6 +7615,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",
@@ -7780,6 +7804,89 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/centos_8-x86_64-ami-boot.json
+++ b/test/data/manifests/centos_8-x86_64-ami-boot.json
@@ -10276,6 +10276,15 @@
     },
     "default-target": "multi-user.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "contentdir": "centos",
         "infra": "stock",
@@ -10849,6 +10858,7 @@
         "/etc/pam.d/postlogin": "....L....",
         "/etc/pam.d/smartcard-auth": "....L....",
         "/etc/pam.d/system-auth": "....L....",
+        "/etc/ssh/sshd_config": "S.5....T.",
         "/proc": ".M.......",
         "/sys": ".M.......",
         "/var/log/lastlog": ".M....G..",
@@ -10934,6 +10944,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication no",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -11159,6 +11212,89 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/centos_8-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit-boot.json
@@ -10935,6 +10935,49 @@
       "timedatex.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -11239,6 +11282,89 @@
         ]
       }
     },
-    "type": "ostree/commit"
+    "type": "ostree/commit",
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
+      }
+    }
   }
 }

--- a/test/data/manifests/centos_8-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit_rt-boot.json
@@ -10889,6 +10889,49 @@
       "timedatex.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -11193,6 +11236,89 @@
         ]
       }
     },
-    "type": "ostree/commit"
+    "type": "ostree/commit",
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
+      }
+    }
   }
 }

--- a/test/data/manifests/centos_8-x86_64-openstack-boot.json
+++ b/test/data/manifests/centos_8-x86_64-openstack-boot.json
@@ -11169,6 +11169,15 @@
     },
     "default-target": "graphical.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "contentdir": "centos",
         "infra": "stock",
@@ -11901,6 +11910,49 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -12112,6 +12164,89 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/centos_8-x86_64-qcow2-boot.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2-boot.json
@@ -11087,6 +11087,15 @@
     },
     "default-target": "multi-user.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "contentdir": "centos",
         "infra": "stock",
@@ -11820,6 +11829,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -12033,6 +12085,89 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/centos_8-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2_customize-boot.json
@@ -13395,6 +13395,15 @@
     },
     "default-target": "multi-user.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "contentdir": "centos",
         "infra": "stock",
@@ -14186,6 +14195,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -14399,6 +14451,89 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/centos_8-x86_64-tar-boot.json
+++ b/test/data/manifests/centos_8-x86_64-tar-boot.json
@@ -7620,6 +7620,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",
@@ -7785,6 +7809,89 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/centos_8-x86_64-vhd-boot.json
+++ b/test/data/manifests/centos_8-x86_64-vhd-boot.json
@@ -11230,6 +11230,15 @@
     },
     "default-target": "multi-user.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "contentdir": "centos",
         "infra": "stock",
@@ -11973,6 +11982,49 @@
       "unbound-anchor.timer",
       "waagent.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -12181,6 +12233,89 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/centos_8-x86_64-vmdk-boot.json
+++ b/test/data/manifests/centos_8-x86_64-vmdk-boot.json
@@ -10688,6 +10688,15 @@
     },
     "default-target": "graphical.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "contentdir": "centos",
         "infra": "stock",
@@ -11396,6 +11405,49 @@
       "vgauthd.service",
       "vmtoolsd.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -11601,6 +11653,89 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_34-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-ami-boot.json
@@ -9443,6 +9443,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10104,6 +10115,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10340,6 +10395,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_34-aarch64-oci-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-oci-boot.json
@@ -9261,6 +9261,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9908,6 +9919,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10156,6 +10211,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_34-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-openstack-boot.json
@@ -9792,6 +9792,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10485,6 +10496,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10724,6 +10779,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_34-aarch64-qcow2-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-qcow2-boot.json
@@ -9285,6 +9285,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9934,6 +9945,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10182,6 +10237,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_34-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-qcow2_customize-boot.json
@@ -9389,6 +9389,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10047,6 +10058,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10295,6 +10350,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_34-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-ami-boot.json
@@ -9396,6 +9396,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10033,6 +10044,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10269,6 +10324,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_commit-boot.json
@@ -11666,6 +11666,50 @@
       "udisks2.service",
       "zezere_ignition.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -12009,6 +12053,142 @@
         ]
       }
     },
-    "type": "ostree/commit"
+    "type": "ostree/commit",
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
+      }
+    }
   }
 }

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_commit_debug-boot.json
@@ -11672,6 +11672,50 @@
       "udisks2.service",
       "zezere_ignition.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -12015,6 +12059,142 @@
         ]
       }
     },
-    "type": "ostree/commit"
+    "type": "ostree/commit",
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
+      }
+    }
   }
 }

--- a/test/data/manifests/fedora_34-x86_64-oci-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-oci-boot.json
@@ -9316,6 +9316,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9945,6 +9956,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10193,6 +10248,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_34-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-openstack-boot.json
@@ -9745,6 +9745,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10414,6 +10425,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10653,6 +10708,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_34-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-qcow2-boot.json
@@ -9340,6 +9340,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9971,6 +9982,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10219,6 +10274,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_34-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-qcow2_customize-boot.json
@@ -9444,6 +9444,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10084,6 +10095,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10332,6 +10387,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_34-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-vhd-boot.json
@@ -8857,6 +8857,17 @@
       ]
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9466,6 +9477,50 @@
       "unbound-anchor.timer",
       "waagent.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -9699,6 +9754,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_34-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-vmdk-boot.json
@@ -9340,6 +9340,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9970,6 +9981,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10218,6 +10273,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_35-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-ami-boot.json
@@ -9734,6 +9734,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10416,6 +10427,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10652,6 +10707,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_35-aarch64-oci-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-oci-boot.json
@@ -9654,6 +9654,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10328,6 +10339,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10576,6 +10631,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_35-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-openstack-boot.json
@@ -10083,6 +10083,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10797,6 +10808,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -11036,6 +11091,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_35-aarch64-qcow2-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-qcow2-boot.json
@@ -9678,6 +9678,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10354,6 +10365,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10602,6 +10657,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_35-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-qcow2_customize-boot.json
@@ -9782,6 +9782,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10467,6 +10478,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10715,6 +10770,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_35-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-ami-boot.json
@@ -9687,6 +9687,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10339,6 +10350,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10575,6 +10630,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_commit-boot.json
@@ -11708,6 +11708,50 @@
       "udisks2.service",
       "zezere_ignition.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -12051,6 +12095,142 @@
         ]
       }
     },
-    "type": "ostree/commit"
+    "type": "ostree/commit",
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
+      }
+    }
   }
 }

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_commit_debug-boot.json
@@ -11714,6 +11714,50 @@
       "udisks2.service",
       "zezere_ignition.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -12057,6 +12101,142 @@
         ]
       }
     },
-    "type": "ostree/commit"
+    "type": "ostree/commit",
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
+      }
+    }
   }
 }

--- a/test/data/manifests/fedora_35-x86_64-oci-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-oci-boot.json
@@ -9862,6 +9862,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10522,6 +10533,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10770,6 +10825,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_35-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-openstack-boot.json
@@ -10036,6 +10036,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10720,6 +10731,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10959,6 +11014,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_35-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-qcow2-boot.json
@@ -9886,6 +9886,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10548,6 +10559,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10796,6 +10851,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_35-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-qcow2_customize-boot.json
@@ -9990,6 +9990,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10661,6 +10672,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10909,6 +10964,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_35-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-vhd-boot.json
@@ -9114,6 +9114,17 @@
       ]
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9736,6 +9747,50 @@
       "unbound-anchor.timer",
       "waagent.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -9969,6 +10024,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/fedora_35-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-vmdk-boot.json
@@ -9886,6 +9886,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "False",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "True"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10547,6 +10558,50 @@
       "systemd-userdbd.socket",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10795,6 +10850,250 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "fedora-cisco-openh264.repo": {
+          "fedora-cisco-openh264": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          },
+          "fedora-cisco-openh264-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "14d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-cisco-openh264-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "True",
+            "type": "rpm"
+          }
+        },
+        "fedora-modular.repo": {
+          "fedora-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-modular.repo": {
+          "updates-modular": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing-modular.repo": {
+          "updates-testing-modular": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-modular-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
+            "name": "Fedora Modular $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates-testing.repo": {
+          "updates-testing": {
+            "countme": "1",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Test Updates Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-testing-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Test Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora-updates.repo": {
+          "updates": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Updates - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "updates-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "6h",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Updates Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        },
+        "fedora.repo": {
+          "fedora": {
+            "countme": "1",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-debuginfo": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - $basearch - Debug",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          },
+          "fedora-source": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
+            "metadata_expire": "7d",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch",
+            "name": "Fedora $releasever - Source",
+            "repo_gpgcheck": "0",
+            "skip_if_unavailable": "False",
+            "type": "rpm"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/rhel_8-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-ami-boot.json
@@ -8621,6 +8621,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9136,23 +9147,23 @@
     "partitions": [
       {
         "bootable": false,
-        "fstype": "vfat",
-        "label": "EFI\\ System",
-        "partuuid": "1DE333BA-33A7-D147-9B27-C87268BA36B9",
-        "size": 498073600,
-        "start": 1048576,
-        "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-        "uuid": "46BB-8120"
-      },
-      {
-        "bootable": false,
         "fstype": "xfs",
         "label": null,
-        "partuuid": "61F6795F-CFE6-0A4A-8F75-4F48244B5E38",
+        "partuuid": "7CEC5879-020E-9F4B-A44D-928D0A8BAAEE",
         "size": 5942263296,
         "start": 500170752,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
         "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd"
+      },
+      {
+        "bootable": false,
+        "fstype": "vfat",
+        "label": "EFI\\ System",
+        "partuuid": "EB0B4FC0-0920-FB49-94B1-8D41B171E1CA",
+        "size": 498073600,
+        "start": 1048576,
+        "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+        "uuid": "46BB-8120"
       }
     ],
     "passwd": [
@@ -9320,6 +9331,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_8-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-openstack-boot.json
@@ -9177,6 +9177,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9736,7 +9747,7 @@
         "bootable": false,
         "fstype": "xfs",
         "label": null,
-        "partuuid": "05A59C6D-FC02-AC42-A5C8-D3E64E563E4E",
+        "partuuid": "A6240362-CE77-EB45-8F4E-9280C6357EE1",
         "size": 3794779648,
         "start": 500170752,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
@@ -9746,7 +9757,7 @@
         "bootable": false,
         "fstype": "vfat",
         "label": "EFI\\ System",
-        "partuuid": "EC12F3B2-5136-3043-8AF1-A5E0AF10E33B",
+        "partuuid": "E983D456-8F48-964F-9AEC-E51120DE1F70",
         "size": 498073600,
         "start": 1048576,
         "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
@@ -9922,6 +9933,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_8-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-qcow2-boot.json
@@ -9639,6 +9639,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10230,7 +10241,7 @@
         "bootable": false,
         "fstype": "vfat",
         "label": "EFI\\ System",
-        "partuuid": "24057256-3BD7-2746-98C8-C1DACD7D1E7A",
+        "partuuid": "26279506-8D85-534C-B2D3-051E3FE19E1A",
         "size": 498073600,
         "start": 1048576,
         "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
@@ -10240,7 +10251,7 @@
         "bootable": false,
         "fstype": "xfs",
         "label": null,
-        "partuuid": "D7E7C8A2-E6A5-D246-A4F9-643ED968F48C",
+        "partuuid": "468A705D-7634-B040-9F79-1A976E043FEF",
         "size": 3794779648,
         "start": 500170752,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
@@ -10431,6 +10442,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_8-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-qcow2_customize-boot.json
@@ -9761,6 +9761,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10358,23 +10369,23 @@
     "partitions": [
       {
         "bootable": false,
-        "fstype": "xfs",
-        "label": null,
-        "partuuid": "37B1B6A9-7E1E-6F47-BDE9-B4D13190CC43",
-        "size": 3794779648,
-        "start": 500170752,
-        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-        "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd"
-      },
-      {
-        "bootable": false,
         "fstype": "vfat",
         "label": "EFI\\ System",
-        "partuuid": "F1BDCC59-A510-D545-B801-F97EA792CF16",
+        "partuuid": "0566FDB8-5C6B-4D4E-B9AD-354D05CE1A95",
         "size": 498073600,
         "start": 1048576,
         "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
         "uuid": "46BB-8120"
+      },
+      {
+        "bootable": false,
+        "fstype": "xfs",
+        "label": null,
+        "partuuid": "D2795D04-7480-AA46-8A32-26B11C45BE39",
+        "size": 3794779648,
+        "start": 500170752,
+        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+        "uuid": "0bd700f8-090f-4556-b797-b340297ea1bd"
       }
     ],
     "passwd": [
@@ -10563,6 +10574,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_8-aarch64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-rhel_edge_commit-boot.json
@@ -8824,6 +8824,49 @@
       "sshd.service",
       "timedatex.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_8-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-tar-boot.json
@@ -5757,6 +5757,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysctl.d": {
       "/usr/lib/sysctl.d": {
         "10-default-yama-scope.conf": [

--- a/test/data/manifests/rhel_8-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-ppc64le-qcow2-boot.json
@@ -10402,6 +10402,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11233,6 +11244,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_8-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_8-ppc64le-qcow2_customize-boot.json
@@ -10524,6 +10524,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11365,6 +11376,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_8-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_8-ppc64le-tar-boot.json
@@ -5860,6 +5860,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysctl.d": {
       "/usr/lib/sysctl.d": {
         "10-default-yama-scope.conf": [

--- a/test/data/manifests/rhel_8-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-s390x-qcow2-boot.json
@@ -10256,6 +10256,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11060,6 +11071,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_8-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_8-s390x-qcow2_customize-boot.json
@@ -10378,6 +10378,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11192,6 +11203,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_8-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_8-s390x-tar-boot.json
@@ -6670,6 +6670,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysctl.d": {
       "/usr/lib/sysctl.d": {
         "10-default-yama-scope.conf": [

--- a/test/data/manifests/rhel_8-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ami-boot.json
@@ -8617,6 +8617,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9297,6 +9308,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_8-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-openstack-boot.json
@@ -9188,6 +9188,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9915,6 +9926,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_8-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-qcow2-boot.json
@@ -9620,6 +9620,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10392,6 +10403,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_8-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-qcow2_customize-boot.json
@@ -9742,6 +9742,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10524,6 +10535,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_8-x86_64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-rhel_edge_commit-boot.json
@@ -9138,6 +9138,49 @@
       "sshd.service",
       "timedatex.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_8-x86_64-rhel_edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-rhel_edge_commit_rt-boot.json
@@ -9584,6 +9584,49 @@
       "timedatex.service",
       "tuned.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_8-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-tar-boot.json
@@ -5832,6 +5832,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysctl.d": {
       "/usr/lib/sysctl.d": {
         "10-default-yama-scope.conf": [

--- a/test/data/manifests/rhel_8-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-vhd-boot.json
@@ -9137,6 +9137,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9862,6 +9873,49 @@
       "unbound-anchor.timer",
       "waagent.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_8-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-vmdk-boot.json
@@ -8636,6 +8636,17 @@
       ]
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9334,6 +9345,49 @@
       "vgauthd.service",
       "vmtoolsd.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_84-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-ami-boot.json
@@ -9241,6 +9241,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9996,6 +10007,49 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_84-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-openstack-boot.json
@@ -9692,6 +9692,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10485,6 +10496,49 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_84-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-qcow2-boot.json
@@ -9726,6 +9726,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10532,6 +10543,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_84-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-qcow2_customize-boot.json
@@ -9837,6 +9837,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10653,6 +10664,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_84-aarch64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-rhel_edge_commit-boot.json
@@ -9226,6 +9226,49 @@
       "timedatex.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_84-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-tar-boot.json
@@ -5986,6 +5986,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_84-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-ppc64le-qcow2-boot.json
@@ -10484,6 +10484,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11333,6 +11344,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_84-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_84-ppc64le-qcow2_customize-boot.json
@@ -10595,6 +10595,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11454,6 +11465,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_84-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_84-ppc64le-tar-boot.json
@@ -6089,6 +6089,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_84-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-s390x-qcow2-boot.json
@@ -10392,6 +10392,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11210,6 +11221,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_84-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_84-s390x-qcow2_customize-boot.json
@@ -10503,6 +10503,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11331,6 +11342,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_84-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ami-boot.json
@@ -9402,6 +9402,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10182,6 +10193,49 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_84-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-openstack-boot.json
@@ -9868,6 +9868,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10687,6 +10698,49 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -9857,6 +9857,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10686,6 +10697,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_84-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2_customize-boot.json
@@ -9968,6 +9968,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10807,6 +10818,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_84-x86_64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-rhel_edge_commit-boot.json
@@ -9540,6 +9540,49 @@
       "timedatex.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_84-x86_64-rhel_edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-rhel_edge_commit_rt-boot.json
@@ -9937,6 +9937,49 @@
       "tuned.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_84-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-tar-boot.json
@@ -6061,6 +6061,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_84-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vhd-boot.json
@@ -9919,6 +9919,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10746,6 +10757,49 @@
       "unbound-anchor.timer",
       "waagent.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
@@ -9526,6 +9526,17 @@
       ]
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10331,6 +10342,49 @@
       "vgauthd.service",
       "vmtoolsd.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_85-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-ami-boot.json
@@ -10170,6 +10170,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10969,6 +10980,49 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication no",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_85-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-ec2-boot.json
@@ -10219,6 +10219,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11023,6 +11034,49 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication no",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -11257,6 +11311,124 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "redhat-rhui-beta.repo": {
+          "rhel-8-appstream-beta-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/appstream/debug",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-appstream-beta-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/appstream/os",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-appstream-beta-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/appstream/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-beta-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/baseos/debug",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-beta-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/baseos/os",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-beta-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/baseos/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-beta-debug-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror//content/beta/rhel8/rhui/8/$basearch/supplementary/debug",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - Supplementary Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-beta-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror//content/beta/rhel8/rhui/8/$basearch/supplementary/os",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - Supplementary Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-beta-source-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror//content/beta/rhel8/rhui/8/$basearch/supplementary/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - Supplementary Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          }
+        },
+        "redhat-rhui-client-config.repo": {
+          "rhui-client-config-server-8": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/protected/rhui-client-config/rhel/server/8/$basearch/os",
+            "name": "Red Hat Update Infrastructure 3 Client Configuration Server 8",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/rhui-client-config-server-8.crt",
+            "sslclientkey": "/etc/pki/rhui/rhui-client-config-server-8.key",
+            "sslverify": "1"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/rhel_85-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_commit-boot.json
@@ -9812,6 +9812,49 @@
       "timedatex.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_85-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-openstack-boot.json
@@ -10350,6 +10350,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11132,6 +11143,49 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_85-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-qcow2-boot.json
@@ -10365,6 +10365,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11159,6 +11170,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_85-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-qcow2_customize-boot.json
@@ -12768,6 +12768,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -13655,6 +13666,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_85-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-tar-boot.json
@@ -6960,6 +6960,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_85-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_85-ppc64le-qcow2-boot.json
@@ -11112,6 +11112,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11943,6 +11954,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_85-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-ppc64le-qcow2_customize-boot.json
@@ -13948,6 +13948,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -14871,6 +14882,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_85-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_85-ppc64le-tar-boot.json
@@ -7343,6 +7343,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_85-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_85-s390x-qcow2-boot.json
@@ -11817,6 +11817,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -12619,6 +12630,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_85-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-s390x-qcow2_customize-boot.json
@@ -14111,6 +14111,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -15005,6 +15016,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_85-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_85-s390x-tar-boot.json
@@ -8478,7 +8478,7 @@
         "id": "rhel-20210322163432-4.18.0-299.1.el8.s390x",
         "initrd": "/boot/initramfs-4.18.0-299.1.el8.s390x.img",
         "linux": "/boot/vmlinuz-4.18.0-299.1.el8.s390x",
-        "options": "root=UUID=c15851aa-1615-4898-8051-fff0e8518320 rootflags=subvol=root",
+        "options": "root=UUID=b9867d4e-38c1-4bed-a75d-57debfed3565 rootflags=subvol=root",
         "title": "Red Hat Enterprise Linux (4.18.0-299.1.el8.s390x) 8.5 (Ootpa)",
         "version": "4.18.0-299.1.el8.s390x"
       }
@@ -8876,6 +8876,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_85-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ami-boot.json
@@ -9807,6 +9807,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10547,6 +10558,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication no",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_85-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2-boot.json
@@ -9857,6 +9857,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10602,6 +10613,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication no",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10830,6 +10884,124 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "redhat-rhui-beta.repo": {
+          "rhel-8-appstream-beta-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/appstream/debug",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-appstream-beta-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/appstream/os",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-appstream-beta-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/appstream/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-beta-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/baseos/debug",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-beta-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/baseos/os",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-beta-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/baseos/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-beta-debug-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror//content/beta/rhel8/rhui/8/$basearch/supplementary/debug",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - Supplementary Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-beta-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror//content/beta/rhel8/rhui/8/$basearch/supplementary/os",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - Supplementary Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-beta-source-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror//content/beta/rhel8/rhui/8/$basearch/supplementary/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - Supplementary Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          }
+        },
+        "redhat-rhui-client-config.repo": {
+          "rhui-client-config-server-8": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/protected/rhui-client-config/rhel/server/8/$basearch/os",
+            "name": "Red Hat Update Infrastructure 3 Client Configuration Server 8",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/rhui-client-config-server-8.crt",
+            "sslclientkey": "/etc/pki/rhui/rhui-client-config-server-8.key",
+            "sslverify": "1"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
@@ -12117,6 +12117,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -13066,6 +13077,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication no",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -13307,6 +13361,190 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "redhat-rhui-client-config-ha.repo": {
+          "rhui-client-config-server-8-ha": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/protected/rhui-client-config/rhel/server/8/$basearch/ha",
+            "name": "Red Hat Update Infrastructure 3 Client Configuration Server 8 HA",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/rhui-client-config-server-8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/rhui-client-config-server-8-ha.key",
+            "sslverify": "1"
+          }
+        },
+        "redhat-rhui-ha.repo": {
+          "codeready-builder-for-rhel-8-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/codeready-builder/debug",
+            "name": "Red Hat CodeReady Linux Builder for RHEL 8 $basearch (Debug RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "codeready-builder-for-rhel-8-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/codeready-builder/os",
+            "name": "Red Hat CodeReady Linux Builder for RHEL 8 $basearch (RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "codeready-builder-for-rhel-8-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/codeready-builder/source/SRPMS",
+            "name": "Red Hat CodeReady Linux Builder for RHEL 8 $basearch (Source RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-appstream-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/appstream/debug",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-appstream-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/appstream/os",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-appstream-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/appstream/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/baseos/debug",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/baseos/os",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/baseos/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/supplementary/debug",
+            "name": "Red Hat Enterprise Linux 8 - Supplementary (Debug RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/supplementary/os",
+            "name": "Red Hat Enterprise Linux 8 - Supplementary (RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/supplementary/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 - Supplementary (Source RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-8-for-x86_64-highavailability-debug-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/x86_64/highavailability/debug",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - High Availability (Debug RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-8-for-x86_64-highavailability-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/x86_64/highavailability/os",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - High Availability (RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-8-for-x86_64-highavailability-source-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/x86_64/highavailability/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - High Availability (Source RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/rhel_85-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_commit-boot.json
@@ -10125,6 +10125,49 @@
       "timedatex.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_85-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_commit_rt-boot.json
@@ -10856,6 +10856,49 @@
       "tuned.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_85-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-openstack-boot.json
@@ -10557,6 +10557,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11367,6 +11378,49 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_85-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-qcow2-boot.json
@@ -10533,6 +10533,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11352,6 +11363,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_85-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-qcow2_customize-boot.json
@@ -12979,6 +12979,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -13892,6 +13903,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_85-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-tar-boot.json
@@ -7064,6 +7064,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_85-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-vhd-boot.json
@@ -10614,6 +10614,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11435,6 +11446,49 @@
       "unbound-anchor.timer",
       "waagent.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_85-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-vmdk-boot.json
@@ -10154,6 +10154,17 @@
       ]
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10945,6 +10956,49 @@
       "vgauthd.service",
       "vmtoolsd.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_86-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ami-boot.json
@@ -10150,6 +10150,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10950,6 +10961,49 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication no",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_86-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ec2-boot.json
@@ -10199,6 +10199,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11004,6 +11015,49 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication no",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -11238,6 +11292,124 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "redhat-rhui-beta.repo": {
+          "rhel-8-appstream-beta-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/appstream/debug",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-appstream-beta-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/appstream/os",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-appstream-beta-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/appstream/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-beta-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/baseos/debug",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-beta-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/baseos/os",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-beta-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/baseos/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-beta-debug-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror//content/beta/rhel8/rhui/8/$basearch/supplementary/debug",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - Supplementary Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-beta-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror//content/beta/rhel8/rhui/8/$basearch/supplementary/os",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - Supplementary Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-beta-source-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror//content/beta/rhel8/rhui/8/$basearch/supplementary/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - Supplementary Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          }
+        },
+        "redhat-rhui-client-config.repo": {
+          "rhui-client-config-server-8": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/protected/rhui-client-config/rhel/server/8/$basearch/os",
+            "name": "Red Hat Update Infrastructure 3 Client Configuration Server 8",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/rhui-client-config-server-8.crt",
+            "sslclientkey": "/etc/pki/rhui/rhui-client-config-server-8.key",
+            "sslverify": "1"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/rhel_86-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_commit-boot.json
@@ -9793,6 +9793,49 @@
       "timedatex.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_86-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-openstack-boot.json
@@ -10434,6 +10434,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11225,6 +11236,49 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_86-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-qcow2-boot.json
@@ -10345,6 +10345,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11140,6 +11151,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_86-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-qcow2_customize-boot.json
@@ -12660,6 +12660,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -13512,6 +13523,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_86-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-tar-boot.json
@@ -6926,6 +6926,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_86-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_86-ppc64le-qcow2-boot.json
@@ -11001,6 +11001,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11840,6 +11851,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_86-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-ppc64le-qcow2_customize-boot.json
@@ -13816,6 +13816,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -14712,6 +14723,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_86-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_86-ppc64le-tar-boot.json
@@ -7025,6 +7025,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_86-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_86-s390x-qcow2-boot.json
@@ -11670,6 +11670,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -12478,6 +12489,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_86-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-s390x-qcow2_customize-boot.json
@@ -13905,6 +13905,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -14770,6 +14781,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_86-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_86-s390x-tar-boot.json
@@ -8165,7 +8165,7 @@
         "id": "rhel-20210927213626-4.18.0-345.1.el8.s390x",
         "initrd": "/boot/initramfs-4.18.0-345.1.el8.s390x.img",
         "linux": "/boot/vmlinuz-4.18.0-345.1.el8.s390x",
-        "options": "root=UUID=03ae1441-3a92-4f66-bd03-a222de005b19 rootflags=subvol=root",
+        "options": "root=UUID=b9867d4e-38c1-4bed-a75d-57debfed3565 rootflags=subvol=root",
         "title": "Red Hat Enterprise Linux (4.18.0-345.1.el8.s390x) 8.6 (Ootpa)",
         "version": "4.18.0-345.1.el8.s390x"
       }
@@ -8545,6 +8545,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_86-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ami-boot.json
@@ -9787,6 +9787,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10528,6 +10539,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication no",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_86-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2-boot.json
@@ -9838,6 +9838,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10584,6 +10595,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication no",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10812,6 +10866,124 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "redhat-rhui-beta.repo": {
+          "rhel-8-appstream-beta-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/appstream/debug",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-appstream-beta-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/appstream/os",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-appstream-beta-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/appstream/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-beta-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/baseos/debug",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-beta-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/baseos/os",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-beta-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel8/rhui/8/$basearch/baseos/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-beta-debug-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror//content/beta/rhel8/rhui/8/$basearch/supplementary/debug",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - Supplementary Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-beta-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror//content/beta/rhel8/rhui/8/$basearch/supplementary/os",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - Supplementary Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-beta-source-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror//content/beta/rhel8/rhui/8/$basearch/supplementary/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - Supplementary Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8.key",
+            "sslverify": "1"
+          }
+        },
+        "redhat-rhui-client-config.repo": {
+          "rhui-client-config-server-8": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/protected/rhui-client-config/rhel/server/8/$basearch/os",
+            "name": "Red Hat Update Infrastructure 3 Client Configuration Server 8",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/rhui-client-config-server-8.crt",
+            "sslclientkey": "/etc/pki/rhui/rhui-client-config-server-8.key",
+            "sslverify": "1"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
@@ -12125,6 +12125,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -13077,6 +13088,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication no",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -13318,6 +13372,190 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "redhat-rhui-client-config-ha.repo": {
+          "rhui-client-config-server-8-ha": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/protected/rhui-client-config/rhel/server/8/$basearch/ha",
+            "name": "Red Hat Update Infrastructure 3 Client Configuration Server 8 HA",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/rhui-client-config-server-8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/rhui-client-config-server-8-ha.key",
+            "sslverify": "1"
+          }
+        },
+        "redhat-rhui-ha.repo": {
+          "codeready-builder-for-rhel-8-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/codeready-builder/debug",
+            "name": "Red Hat CodeReady Linux Builder for RHEL 8 $basearch (Debug RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "codeready-builder-for-rhel-8-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/codeready-builder/os",
+            "name": "Red Hat CodeReady Linux Builder for RHEL 8 $basearch (RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "codeready-builder-for-rhel-8-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/codeready-builder/source/SRPMS",
+            "name": "Red Hat CodeReady Linux Builder for RHEL 8 $basearch (Source RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-appstream-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/appstream/debug",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-appstream-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/appstream/os",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-appstream-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/appstream/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - AppStream from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/baseos/debug",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/baseos/os",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-baseos-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/baseos/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for $basearch - BaseOS from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/supplementary/debug",
+            "name": "Red Hat Enterprise Linux 8 - Supplementary (Debug RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/supplementary/os",
+            "name": "Red Hat Enterprise Linux 8 - Supplementary (RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhel-8-supplementary-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/supplementary/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 - Supplementary (Source RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-8-for-x86_64-highavailability-debug-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/x86_64/highavailability/debug",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - High Availability (Debug RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-8-for-x86_64-highavailability-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/x86_64/highavailability/os",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - High Availability (RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-8-for-x86_64-highavailability-source-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/x86_64/highavailability/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - High Availability (Source RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-ha.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-ha.key",
+            "sslverify": "1"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
@@ -12555,6 +12555,15 @@
     },
     "default-target": "multi-user.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "releasever": "8.6"
       }
@@ -13534,6 +13543,49 @@
       "unbound-anchor.timer",
       "uuidd.socket"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication no",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -13782,6 +13834,190 @@
     "tuned": {
       "active_profile": "sap-hana",
       "profile_mode": "manual"
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "redhat-rhui-client-config-sap-bundle.repo": {
+          "rhui-client-config-server-8-sap-bundle": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/protected/rhui-client-config/rhel/server/8/$basearch/sap-bundle",
+            "name": "Red Hat Update Infrastructure 3 Client Configuration for SAP Bundle",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/rhui-client-config-server-8-sap-bundle.crt",
+            "sslclientkey": "/etc/pki/rhui/rhui-client-config-server-8-sap-bundle.key",
+            "sslverify": "1"
+          }
+        },
+        "redhat-rhui-sap-bundle-e4s.repo": {
+          "rhel-8-for-x86_64-appstream-e4s-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/e4s/rhel8/rhui/$releasever/$basearch/appstream/debug",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - AppStream - Update Services for SAP Solutions from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-sap-bundle-e4s.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-sap-bundle-e4s.key",
+            "sslverify": "1"
+          },
+          "rhel-8-for-x86_64-appstream-e4s-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/e4s/rhel8/rhui/$releasever/$basearch/appstream/os",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - AppStream - Update Services for SAP Solutions from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-sap-bundle-e4s.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-sap-bundle-e4s.key",
+            "sslverify": "1"
+          },
+          "rhel-8-for-x86_64-appstream-e4s-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/e4s/rhel8/rhui/$releasever/$basearch/appstream/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - AppStream - Update Services for SAP Solutions from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-sap-bundle-e4s.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-sap-bundle-e4s.key",
+            "sslverify": "1"
+          },
+          "rhel-8-for-x86_64-baseos-e4s-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/e4s/rhel8/rhui/$releasever/$basearch/baseos/debug",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - BaseOS - Update Services for SAP Solutions from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-sap-bundle-e4s.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-sap-bundle-e4s.key",
+            "sslverify": "1"
+          },
+          "rhel-8-for-x86_64-baseos-e4s-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/e4s/rhel8/rhui/$releasever/$basearch/baseos/os",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - BaseOS - Update Services for SAP Solutions from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-sap-bundle-e4s.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-sap-bundle-e4s.key",
+            "sslverify": "1"
+          },
+          "rhel-8-for-x86_64-baseos-e4s-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/e4s/rhel8/rhui/$releasever/$basearch/baseos/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - BaseOS - Update Services for SAP Solutions from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-sap-bundle-e4s.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-sap-bundle-e4s.key",
+            "sslverify": "1"
+          },
+          "rhel-8-for-x86_64-highavailability-e4s-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/e4s/rhel8/rhui/$releasever/$basearch/highavailability/debug",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - High Availability - Update Services for SAP Solutions from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-sap-bundle-e4s.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-sap-bundle-e4s.key",
+            "sslverify": "1"
+          },
+          "rhel-8-for-x86_64-highavailability-e4s-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/e4s/rhel8/rhui/$releasever/$basearch/highavailability/os",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - High Availability - Update Services for SAP Solutions from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-sap-bundle-e4s.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-sap-bundle-e4s.key",
+            "sslverify": "1"
+          },
+          "rhel-8-for-x86_64-highavailability-e4s-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/e4s/rhel8/rhui/$releasever/$basearch/highavailability/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - High Availability - Update Services for SAP Solutions from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-sap-bundle-e4s.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-sap-bundle-e4s.key",
+            "sslverify": "1"
+          },
+          "rhel-8-for-x86_64-sap-netweaver-e4s-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/e4s/rhel8/rhui/$releasever/$basearch/sap/debug",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-sap-bundle-e4s.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-sap-bundle-e4s.key",
+            "sslverify": "1"
+          },
+          "rhel-8-for-x86_64-sap-netweaver-e4s-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/e4s/rhel8/rhui/$releasever/$basearch/sap/os",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - SAP NetWeaver - Update Services for SAP Solutions from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-sap-bundle-e4s.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-sap-bundle-e4s.key",
+            "sslverify": "1"
+          },
+          "rhel-8-for-x86_64-sap-netweaver-e4s-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/e4s/rhel8/rhui/$releasever/$basearch/sap/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-sap-bundle-e4s.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-sap-bundle-e4s.key",
+            "sslverify": "1"
+          },
+          "rhel-8-for-x86_64-sap-solutions-e4s-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/e4s/rhel8/rhui/$releasever/$basearch/sap-solutions/debug",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - SAP Solutions - Update Services for SAP Solutions from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-sap-bundle-e4s.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-sap-bundle-e4s.key",
+            "sslverify": "1"
+          },
+          "rhel-8-for-x86_64-sap-solutions-e4s-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/e4s/rhel8/rhui/$releasever/$basearch/sap-solutions/os",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - SAP Solutions - Update Services for SAP Solutions from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-sap-bundle-e4s.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-sap-bundle-e4s.key",
+            "sslverify": "1"
+          },
+          "rhel-8-for-x86_64-sap-solutions-e4s-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui3.REGION.aws.ce.redhat.com/pulp/mirror/content/e4s/rhel8/rhui/$releasever/$basearch/sap-solutions/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 8 for x86_64 - SAP Solutions - Update Services for SAP Solutions from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel8-sap-bundle-e4s.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel8-sap-bundle-e4s.key",
+            "sslverify": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/test/data/manifests/rhel_86-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit-boot.json
@@ -10106,6 +10106,49 @@
       "timedatex.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_86-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit_rt-boot.json
@@ -10847,6 +10847,49 @@
       "tuned.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_86-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-openstack-boot.json
@@ -10641,6 +10641,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11459,6 +11470,49 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_86-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-qcow2-boot.json
@@ -10513,6 +10513,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11332,6 +11343,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_86-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-qcow2_customize-boot.json
@@ -12871,6 +12871,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -13748,6 +13759,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_86-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-tar-boot.json
@@ -7030,6 +7030,30 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_86-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-vhd-boot.json
@@ -10594,6 +10594,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11415,6 +11426,49 @@
       "unbound-anchor.timer",
       "waagent.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_86-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-vmdk-boot.json
@@ -10134,6 +10134,17 @@
       ]
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10924,6 +10935,49 @@
       "vgauthd.service",
       "vmtoolsd.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ami-boot.json
@@ -9113,6 +9113,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9922,6 +9933,43 @@
       "tuned.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server",
+          "PasswordAuthentication no"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ec2-boot.json
@@ -9175,6 +9175,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9990,6 +10001,43 @@
       "tuned.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server",
+          "PasswordAuthentication no"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10270,6 +10318,124 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "redhat-rhui-beta.repo": {
+          "rhui-rhel-9-appstream-beta-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/appstream/debug",
+            "name": "Red Hat Enterprise Linux 9 - AppStream Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-appstream-beta-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/appstream/os",
+            "name": "Red Hat Enterprise Linux 9 - AppStream Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-appstream-beta-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/appstream/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 9 - AppStream Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-baseos-beta-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/baseos/debug",
+            "name": "Red Hat Enterprise Linux 9 - BaseOS Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-baseos-beta-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/baseos/os",
+            "name": "Red Hat Enterprise Linux 9 - BaseOS Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-baseos-beta-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/baseos/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 9 - BaseOS Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-supplementary-beta-debug-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/supplementary/debug",
+            "name": "Red Hat Enterprise Linux 9 - Supplementary Beta (Debug RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-supplementary-beta-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/supplementary/os",
+            "name": "Red Hat Enterprise Linux 9 - Supplementary Beta (RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-supplementary-beta-source-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/supplementary/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 9 - Supplementary Beta (Source RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          }
+        },
+        "redhat-rhui-client-config.repo": {
+          "rhui-client-config-server-9": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/protected/rhui-client-config/rhel/server/9/$basearch/os",
+            "name": "Red Hat Enterprise Linux 9 Client Configuration",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/rhui-client-config-server-9.crt",
+            "sslclientkey": "/etc/pki/rhui/rhui-client-config-server-9.key",
+            "sslverify": "1"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/rhel_90-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_commit-boot.json
@@ -8791,6 +8791,42 @@
       "sshd.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-openstack-boot.json
@@ -9098,6 +9098,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9888,6 +9899,42 @@
       "tuned.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
@@ -9246,6 +9246,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10057,6 +10068,42 @@
       "sssd.service",
       "tuned.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2_customize-boot.json
@@ -11620,6 +11620,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -12463,6 +12474,42 @@
       "sssd.service",
       "tuned.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-tar-boot.json
@@ -5740,6 +5740,27 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_90-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-qcow2-boot.json
@@ -10042,6 +10042,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10901,6 +10912,42 @@
       "sssd.service",
       "tuned.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-qcow2_customize-boot.json
@@ -12496,6 +12496,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -13387,6 +13398,42 @@
       "sssd.service",
       "tuned.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-tar-boot.json
@@ -5904,6 +5904,27 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_90-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2-boot.json
@@ -10825,7 +10825,7 @@
         "grub_arg": "--unrestricted",
         "grub_class": "kernel",
         "grub_users": "$grub_users",
-        "id": "-20220209130747-5.14.0-55.el9.s390x",
+        "id": "-20220214183313-5.14.0-55.el9.s390x",
         "initrd": "/boot/initramfs-5.14.0-55.el9.s390x.img",
         "linux": "/boot/vmlinuz-5.14.0-55.el9.s390x",
         "options": "root=UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
@@ -10950,6 +10950,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11778,6 +11789,42 @@
       "sssd.service",
       "tuned.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2_customize-boot.json
@@ -13089,7 +13089,7 @@
         "grub_arg": "--unrestricted",
         "grub_class": "kernel",
         "grub_users": "$grub_users",
-        "id": "-20220209131029-0-rescue-ffffffffffffffffffffffffffffffff",
+        "id": "-20220214183523-0-rescue-ffffffffffffffffffffffffffffffff",
         "initrd": "/boot/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
         "linux": "/boot/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff",
         "options": "root=UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
@@ -13100,7 +13100,7 @@
         "grub_arg": "--unrestricted",
         "grub_class": "kernel",
         "grub_users": "$grub_users",
-        "id": "-20220209131029-5.14.0-55.el9.s390x",
+        "id": "-20220214183523-5.14.0-55.el9.s390x",
         "initrd": "/boot/initramfs-5.14.0-55.el9.s390x.img",
         "linux": "/boot/vmlinuz-5.14.0-55.el9.s390x",
         "options": "root=UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",
@@ -13225,6 +13225,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -14085,6 +14096,42 @@
       "sssd.service",
       "tuned.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_90-s390x-tar-boot.json
@@ -7219,6 +7219,27 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_90-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ami-boot.json
@@ -8884,6 +8884,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9667,6 +9678,43 @@
       "sssd.service",
       "tuned.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server",
+          "PasswordAuthentication no"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2-boot.json
@@ -8948,6 +8948,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9737,6 +9748,43 @@
       "sssd.service",
       "tuned.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server",
+          "PasswordAuthentication no"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10011,6 +10059,124 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "redhat-rhui-beta.repo": {
+          "rhui-rhel-9-appstream-beta-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/appstream/debug",
+            "name": "Red Hat Enterprise Linux 9 - AppStream Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-appstream-beta-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/appstream/os",
+            "name": "Red Hat Enterprise Linux 9 - AppStream Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-appstream-beta-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/appstream/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 9 - AppStream Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-baseos-beta-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/baseos/debug",
+            "name": "Red Hat Enterprise Linux 9 - BaseOS Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-baseos-beta-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/baseos/os",
+            "name": "Red Hat Enterprise Linux 9 - BaseOS Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-baseos-beta-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/baseos/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 9 - BaseOS Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-supplementary-beta-debug-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/supplementary/debug",
+            "name": "Red Hat Enterprise Linux 9 - Supplementary Beta (Debug RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-supplementary-beta-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/supplementary/os",
+            "name": "Red Hat Enterprise Linux 9 - Supplementary Beta (RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-supplementary-beta-source-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/supplementary/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 9 - Supplementary Beta (Source RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          }
+        },
+        "redhat-rhui-client-config.repo": {
+          "rhui-client-config-server-9": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/protected/rhui-client-config/rhel/server/9/$basearch/os",
+            "name": "Red Hat Enterprise Linux 9 Client Configuration",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/rhui-client-config-server-9.crt",
+            "sslclientkey": "/etc/pki/rhui/rhui-client-config-server-9.key",
+            "sslverify": "1"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
@@ -11387,6 +11387,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -12393,6 +12404,43 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server",
+          "PasswordAuthentication no"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
@@ -12669,6 +12669,15 @@
     },
     "default-target": "multi-user.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "releasever": "9.0"
       }
@@ -13770,6 +13779,43 @@
       "upower.service",
       "uuidd.socket"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server",
+          "PasswordAuthentication no"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit-boot.json
@@ -9154,6 +9154,42 @@
       "sshd.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit_rt-boot.json
@@ -10550,6 +10550,17 @@
       ]
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11315,6 +11326,42 @@
       "tuned.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-openstack-boot.json
@@ -9533,6 +9533,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10358,6 +10369,42 @@
       "tuned.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-qcow2-boot.json
@@ -9499,6 +9499,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10331,6 +10342,42 @@
       "sssd.service",
       "tuned.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-qcow2_customize-boot.json
@@ -12079,6 +12079,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -12955,6 +12966,42 @@
       "sssd.service",
       "tuned.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-tar-boot.json
@@ -5922,6 +5922,27 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_90-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-vhd-boot.json
@@ -9443,6 +9443,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10264,6 +10275,42 @@
       "udisks2.service",
       "waagent.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-vmdk-boot.json
@@ -9104,6 +9104,17 @@
       ]
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9904,6 +9915,42 @@
       "vgauthd.service",
       "vmtoolsd.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_90_beta-aarch64-ami-boot.json
@@ -9166,6 +9166,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9979,6 +9990,50 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_90_beta-aarch64-ec2-boot.json
@@ -9215,6 +9215,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10033,6 +10044,50 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -10303,6 +10358,124 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "redhat-rhui-beta.repo": {
+          "rhui-rhel-9-appstream-beta-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/appstream/debug",
+            "name": "Red Hat Enterprise Linux 9 - AppStream Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-appstream-beta-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/appstream/os",
+            "name": "Red Hat Enterprise Linux 9 - AppStream Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-appstream-beta-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/appstream/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 9 - AppStream Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-baseos-beta-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/baseos/debug",
+            "name": "Red Hat Enterprise Linux 9 - BaseOS Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-baseos-beta-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/baseos/os",
+            "name": "Red Hat Enterprise Linux 9 - BaseOS Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-baseos-beta-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/baseos/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 9 - BaseOS Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-supplementary-beta-debug-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/supplementary/debug",
+            "name": "Red Hat Enterprise Linux 9 - Supplementary Beta (Debug RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-supplementary-beta-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/supplementary/os",
+            "name": "Red Hat Enterprise Linux 9 - Supplementary Beta (RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-supplementary-beta-source-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/supplementary/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 9 - Supplementary Beta (Source RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          }
+        },
+        "redhat-rhui-client-config.repo": {
+          "rhui-client-config-server-9": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/protected/rhui-client-config/rhel/server/9/$basearch/os",
+            "name": "Red Hat Enterprise Linux 9 Client Configuration",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/rhui-client-config-server-9.crt",
+            "sslclientkey": "/etc/pki/rhui/rhui-client-config-server-9.key",
+            "sslverify": "1"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/rhel_90_beta-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90_beta-aarch64-edge_commit-boot.json
@@ -8908,6 +8908,50 @@
       "sshd.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_90_beta-aarch64-openstack-boot.json
@@ -9115,6 +9115,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9892,6 +9903,50 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90_beta-aarch64-qcow2-boot.json
@@ -9211,6 +9211,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10005,6 +10016,50 @@
       "sssd.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90_beta-aarch64-qcow2_customize-boot.json
@@ -11655,6 +11655,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -12481,6 +12492,50 @@
       "sssd.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_90_beta-aarch64-tar-boot.json
@@ -5804,6 +5804,31 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_90_beta-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_90_beta-ppc64le-qcow2-boot.json
@@ -10009,6 +10009,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10851,6 +10862,50 @@
       "sssd.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90_beta-ppc64le-qcow2_customize-boot.json
@@ -12513,6 +12513,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -13387,6 +13398,50 @@
       "sssd.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_90_beta-ppc64le-tar-boot.json
@@ -5968,6 +5968,31 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_90_beta-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_90_beta-s390x-qcow2-boot.json
@@ -10792,7 +10792,7 @@
         "grub_arg": "--unrestricted",
         "grub_class": "kernel",
         "grub_users": "$grub_users",
-        "id": "-20211007122507-5.14.0-4.el9.s390x",
+        "id": "-20220214182505-5.14.0-4.el9.s390x",
         "initrd": "/boot/initramfs-5.14.0-4.el9.s390x.img",
         "linux": "/boot/vmlinuz-5.14.0-4.el9.s390x",
         "options": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
@@ -10917,6 +10917,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11734,6 +11745,50 @@
       "sssd.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90_beta-s390x-qcow2_customize-boot.json
@@ -13126,7 +13126,7 @@
         "grub_arg": "--unrestricted",
         "grub_class": "kernel",
         "grub_users": "$grub_users",
-        "id": "-20211007122711-0-rescue-ffffffffffffffffffffffffffffffff",
+        "id": "-20220214182709-0-rescue-ffffffffffffffffffffffffffffffff",
         "initrd": "/boot/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
         "linux": "/boot/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff",
         "options": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
@@ -13137,7 +13137,7 @@
         "grub_arg": "--unrestricted",
         "grub_class": "kernel",
         "grub_users": "$grub_users",
-        "id": "-20211007122711-5.14.0-4.el9.s390x",
+        "id": "-20220214182709-5.14.0-4.el9.s390x",
         "initrd": "/boot/initramfs-5.14.0-4.el9.s390x.img",
         "linux": "/boot/vmlinuz-5.14.0-4.el9.s390x",
         "options": "root=UUID=0194fdc2-fa2f-4cc0-81d3-ff12045b73c8 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
@@ -13262,6 +13262,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -14111,6 +14122,50 @@
       "sssd.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_90_beta-s390x-tar-boot.json
@@ -7296,6 +7296,31 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_90_beta-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-ami-boot.json
@@ -8823,6 +8823,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9569,6 +9580,50 @@
       "sssd.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-ec2-boot.json
@@ -8874,6 +8874,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9625,6 +9636,50 @@
       "sssd.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -9889,6 +9944,124 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "redhat-rhui-beta.repo": {
+          "rhui-rhel-9-appstream-beta-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/appstream/debug",
+            "name": "Red Hat Enterprise Linux 9 - AppStream Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-appstream-beta-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/appstream/os",
+            "name": "Red Hat Enterprise Linux 9 - AppStream Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-appstream-beta-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/appstream/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 9 - AppStream Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-baseos-beta-rhui-debug-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/baseos/debug",
+            "name": "Red Hat Enterprise Linux 9 - BaseOS Beta from RHUI (Debug RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-baseos-beta-rhui-rpms": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/baseos/os",
+            "name": "Red Hat Enterprise Linux 9 - BaseOS Beta from RHUI (RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-baseos-beta-rhui-source-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/baseos/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 9 - BaseOS Beta from RHUI (Source RPMs)",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-supplementary-beta-debug-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/supplementary/debug",
+            "name": "Red Hat Enterprise Linux 9 - Supplementary Beta (Debug RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-supplementary-beta-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/supplementary/os",
+            "name": "Red Hat Enterprise Linux 9 - Supplementary Beta (RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          },
+          "rhui-rhel-9-supplementary-beta-source-rhui-rpms": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/content/beta/rhel9/rhui/9/$basearch/supplementary/source/SRPMS",
+            "name": "Red Hat Enterprise Linux 9 - Supplementary Beta (Source RPMs) from RHUI",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/content-rhel9.crt",
+            "sslclientkey": "/etc/pki/rhui/content-rhel9.key",
+            "sslverify": "1"
+          }
+        },
+        "redhat-rhui-client-config.repo": {
+          "rhui-client-config-server-9": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
+            "mirrorlist": "https://rhui.REGION.aws.ce.redhat.com/pulp/mirror/protected/rhui-client-config/rhel/server/9/$basearch/os",
+            "name": "Red Hat Enterprise Linux 9 Client Configuration",
+            "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+            "sslclientcert": "/etc/pki/rhui/product/rhui-client-config-server-9.crt",
+            "sslclientkey": "/etc/pki/rhui/rhui-client-config-server-9.key",
+            "sslverify": "1"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/rhel_90_beta-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-ec2_ha-boot.json
@@ -11261,6 +11261,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -12222,6 +12233,50 @@
       "sssd.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-ec2_sap-boot.json
@@ -11945,6 +11945,15 @@
     },
     "default-target": "multi-user.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "releasever": "9.0"
       }
@@ -12957,6 +12966,50 @@
       "unbound-anchor.timer",
       "uuidd.socket"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-edge_commit-boot.json
@@ -9271,6 +9271,50 @@
       "sshd.service",
       "udisks2.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-edge_commit_rt-boot.json
@@ -10726,6 +10726,17 @@
       ]
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11498,6 +11509,50 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-openstack-boot.json
@@ -9537,6 +9537,17 @@
       }
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10347,6 +10358,50 @@
       "udisks2.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-qcow2-boot.json
@@ -9451,6 +9451,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10264,6 +10275,50 @@
       "sssd.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-qcow2_customize-boot.json
@@ -12101,6 +12101,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -12958,6 +12969,50 @@
       "sssd.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-tar-boot.json
@@ -5986,6 +5986,31 @@
       "selinux-autorelabel-mark.service",
       "sshd.service"
     ],
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sysconfig": {
       "kernel": {
         "DEFAULTKERNEL": "kernel",

--- a/test/data/manifests/rhel_90_beta-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-vhd-boot.json
@@ -9447,6 +9447,17 @@
       }
     },
     "default-target": "multi-user.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -10253,6 +10264,50 @@
       "unbound-anchor.timer",
       "waagent.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/test/data/manifests/rhel_90_beta-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-vmdk-boot.json
@@ -9111,6 +9111,17 @@
       ]
     },
     "default-target": "graphical.target",
+    "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      }
+    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -9896,6 +9907,50 @@
       "vgauthd.service",
       "vmtoolsd.service"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "50-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "Include /etc/ssh/sshd_config.d/*.conf",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      },
+      "/etc/ssh/sshd_config.d": {
+        "50-redhat.conf": [
+          "Include /etc/crypto-policies/back-ends/opensshserver.config",
+          "SyslogFacility AUTHPRIV",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",

--- a/tools/image-info
+++ b/tools/image-info
@@ -1766,6 +1766,168 @@ def read_security_limits_configs(tree):
     return _read_glob_paths_with_parser(tree, checked_globs, read_tmpfilesd_config)
 
 
+def read_ssh_config(config_path):
+    """
+    Read the content of provided SSH(d) configuration file.
+
+    Returns: list of uncommented and non-empty lines read from the configuation
+    file.
+
+    An example return value:
+    [
+        "Match final all",
+        "Include /etc/crypto-policies/back-ends/openssh.config",
+        "GSSAPIAuthentication yes",
+        "ForwardX11Trusted yes",
+        "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+        "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+        "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+        "SendEnv XMODIFIERS"
+    ]
+    """
+    config_lines = []
+
+    with open(config_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            if line[0] == "#":
+                continue
+            config_lines.append(line)
+
+    return config_lines
+
+
+def read_ssh_configs(tree):
+    """
+    Read all SSH configuration files from a predefined list of paths and
+    parse them.
+
+    The searched paths are:
+    - "/etc/ssh/ssh_config"
+    - "/etc/ssh/ssh_config.d/*.conf"
+
+    Returns: dictionary as returned by '_read_glob_paths_with_parser()' with
+    configuration representation as returned by 'read_ssh_config()'.
+
+    An example return value:
+    {
+        "/etc/ssh": {
+            "ssh_config": [
+                "Include /etc/ssh/ssh_config.d/*.conf"
+            ]
+        },
+        "/etc/ssh/ssh_config.d": {
+            "05-redhat.conf": [
+                "Match final all",
+                "Include /etc/crypto-policies/back-ends/openssh.config",
+                "GSSAPIAuthentication yes",
+                "ForwardX11Trusted yes",
+                "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+                "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+                "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+                "SendEnv XMODIFIERS"
+            ]
+        }
+    }
+    """
+    checked_globs = [
+        "/etc/ssh/ssh_config",
+        "/etc/ssh/ssh_config.d/*.conf"
+    ]
+
+    return _read_glob_paths_with_parser(tree, checked_globs, read_ssh_config)
+
+
+def read_sshd_configs(tree):
+    """
+    Read all SSHd configuration files from a predefined list of paths and
+    parse them.
+
+    The searched paths are:
+    - "/etc/ssh/sshd_config"
+    - "/etc/ssh/sshd_config.d/*.conf"
+
+    Returns: dictionary as returned by '_read_glob_paths_with_parser()' with
+    configuration representation as returned by 'read_ssh_config()'.
+
+    An example return value:
+    {
+        "/etc/ssh": {
+            "sshd_config": [
+                "HostKey /etc/ssh/ssh_host_rsa_key",
+                "HostKey /etc/ssh/ssh_host_ecdsa_key",
+                "HostKey /etc/ssh/ssh_host_ed25519_key",
+                "SyslogFacility AUTHPRIV",
+                "PermitRootLogin no",
+                "AuthorizedKeysFile\t.ssh/authorized_keys",
+                "PasswordAuthentication no",
+                "ChallengeResponseAuthentication no",
+                "GSSAPIAuthentication yes",
+                "GSSAPICleanupCredentials no",
+                "UsePAM yes",
+                "X11Forwarding yes",
+                "PrintMotd no",
+                "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+                "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+                "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+                "AcceptEnv XMODIFIERS",
+                "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server",
+                "ClientAliveInterval 420"
+            ]
+        }
+    }
+    """
+    checked_globs = [
+        "/etc/ssh/sshd_config",
+        "/etc/ssh/sshd_config.d/*.conf"
+    ]
+
+    return _read_glob_paths_with_parser(tree, checked_globs, read_ssh_config)
+
+
+def read_yum_repos(tree):
+    """
+    Read all YUM/DNF repo files.
+
+    The searched paths are:
+    - "/etc/yum.repos.d/*.repo"
+
+    Returns: dictionary as returned by '_read_glob_paths_with_parser()' with
+    configuration representation as returned by '_read_inifile_to_dict()'.
+
+    An example return value:
+    {
+        "/etc/yum.repos.d": {
+            "google-cloud.repo": {
+                "google-cloud-sdk": {
+                    "baseurl": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64",
+                    "enabled": "1",
+                    "gpgcheck": "1",
+                    "gpgkey": "https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg",
+                    "name": "Google Cloud SDK",
+                    "repo_gpgcheck": "0"
+                },
+                "google-compute-engine": {
+                    "baseurl": "https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable",
+                    "enabled": "1",
+                    "gpgcheck": "1",
+                    "gpgkey": "https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg",
+                    "name": "Google Compute Engine",
+                    "repo_gpgcheck": "0"
+                }
+            }
+        }
+    }
+    """
+    checked_globs = [
+        "/etc/yum.repos.d/*.repo"
+    ]
+
+    return _read_glob_paths_with_parser(tree, checked_globs, _read_inifile_to_dict)
+
+
 def read_sudoers(tree):
     """
     Read uncommented lines from sudoers configuration file and /etc/sudoers.d
@@ -1862,6 +2024,49 @@ def read_udev_rules(tree):
     return result
 
 
+def _read_inifile_to_dict(config_path):
+    """
+    Read INI file from the provided path
+
+    Returns: a dictionary representing the provided INI file content.
+
+    An example return value:
+    {
+        "google-cloud-sdk": {
+            "baseurl": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg",
+            "name": "Google Cloud SDK",
+            "repo_gpgcheck": "0"
+        },
+        "google-compute-engine": {
+            "baseurl": "https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable",
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg",
+            "name": "Google Compute Engine",
+            "repo_gpgcheck": "0"
+        }
+    }
+    """
+    result = {}
+
+    with contextlib.suppress(FileNotFoundError):
+        with open(config_path) as f:
+            parser = configparser.RawConfigParser()
+            # prevent conversion of the opion name to lowercase
+            parser.optionxform = lambda option: option
+            parser.readfp(f)
+
+            for section in parser.sections():
+                section_config = dict(parser.items(section))
+                if section_config:
+                    result[section] = section_config
+
+    return result
+
+
 def read_dnf_conf(tree):
     """
     Read DNF configuration and defined variable files.
@@ -1886,22 +2091,9 @@ def read_dnf_conf(tree):
     """
     result = {}
 
-    with contextlib.suppress(FileNotFoundError):
-        with open(f"{tree}/etc/dnf/dnf.conf") as f:
-            parser = configparser.RawConfigParser()
-            # prevent conversion of the opion name to lowercase
-            parser.optionxform = lambda option: option
-            parser.read(f)
-
-            dnf_config = {}
-            for section in parser.sections():
-                section_config = {}
-                section_config.update(parser[section])
-                if section_config:
-                    dnf_config[section] = section_config
-
-            if dnf_config:
-                result["dnf.conf"] = dnf_config
+    dnf_config = _read_inifile_to_dict(f"{tree}/etc/dnf/dnf.conf")
+    if dnf_config:
+        result["dnf.conf"] = dnf_config
 
     dnf_vars = {}
     for file in glob.glob(f"{tree}/etc/dnf/vars/*"):
@@ -1911,6 +2103,41 @@ def read_dnf_conf(tree):
         result["vars"] = dnf_vars
 
     return result
+
+
+def read_dnf_automatic_conf(tree):
+    """
+    Read DNF Automatic configuation.
+
+    Returns: dictionary as returned by '_read_inifile_to_dict()'.
+
+    An example return value:
+    {
+        "base": {
+            "debuglevel": "1"
+        },
+        "command_email": {
+            "email_from": "root@example.com",
+            "email_to": "root"
+        },
+        "commands": {
+            "apply_updates": "yes",
+            "download_updates": "yes",
+            "network_online_timeout": "60",
+            "random_sleep": "0",
+            "upgrade_type": "security"
+        },
+        "email": {
+            "email_from": "root@example.com",
+            "email_host": "localhost",
+            "email_to": "root"
+        },
+        "emitters": {
+            "emit_via": "stdio"
+        }
+    }
+    """
+    return _read_inifile_to_dict(f"{tree}/etc/dnf/automatic.conf")
 
 
 def read_authselect_conf(tree):
@@ -2023,6 +2250,14 @@ def append_filesystem(report, tree, *, is_ostree=False):
         if dnf_conf:
             report["dnf"] = dnf_conf
 
+        dnf_automatic = read_dnf_automatic_conf(tree)
+        if dnf_automatic:
+            report["/etc/dnf/automatic.conf"] = dnf_automatic
+
+        yum_repos = read_yum_repos(tree)
+        if yum_repos:
+            report["yum_repos"] = yum_repos
+
         dracut_configs = read_dracut_configs(tree)
         if dracut_configs:
             report["dracut"] = dracut_configs
@@ -2073,6 +2308,14 @@ def append_filesystem(report, tree, *, is_ostree=False):
         selinux = read_selinux_info(tree, is_ostree)
         if selinux:
             report["selinux"] = selinux
+
+        ssh_configs = read_ssh_configs(tree)
+        if ssh_configs:
+            report["ssh_config"] = ssh_configs
+
+        sshd_configs = read_sshd_configs(tree)
+        if sshd_configs:
+            report["sshd_config"] = sshd_configs
 
         sudoers_conf = read_sudoers(tree)
         if sudoers_conf:


### PR DESCRIPTION
Extend the information gathered by `image-info`. This is needed to properly inspect GCE images.

Enhancements:
 - read all ssh client configuration files
 - read all sshd configuration files
 - read all YUM / DNF repos
 - read DNF Automatic configuration
 - fix reading of DNF configuration

Fun facts:
 - regenerated **205** image test cases in total
 - `x86_64` architecture
   - 103 image test cases
   - took 8 h 17 min
 - `aarch64` architecture
   - 64 image test cases
   - took 3 h 50 min
 - `s390x` architecture
   - 17 image test cases
   - took 1 h 05 min
 - `ppc64le` architecture
   - 21 image test cases
   - took 4 h 45 min

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
