### PR TITLE
tests: Use human readable size for mountpoint

### DIFF
--- a/test/cases/filesystem.sh
+++ b/test/cases/filesystem.sh
@@ -156,7 +156,7 @@ size = 131072000
 
 [[customizations.filesystem]]
 mountpoint = "/var/log/audit"
-size = 131072000
+size = "125 MiB"
 
 [[customizations.filesystem]]
 mountpoint = "/usr"


### PR DESCRIPTION
Follow up to
https://github.com/osbuild/osbuild-composer/pull/1921 and
https://bugzilla.redhat.com/show_bug.cgi?id=2023635


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
