### PR TITLE
Worker: get download feedback from osbuild

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -370,6 +370,21 @@ API:
           - aws/rhel-9.0-nightly-x86_64
         INTERNAL_NETWORK: ["true"]
 
+download_failure:
+  stage: test
+  extends: .terraform/openstack
+  rules:
+    - if: '$CI_PIPELINE_SOURCE != "schedule"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.0-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-8.6-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "8"'
+  script:
+    - schutzbot/deploy.sh
+    - /usr/libexec/tests/osbuild-composer/download_error.sh
+  parallel:
+    matrix:
+      - RUNNER:
+          - rhos-01/centos-stream-8-x86_64
+
 libvirt:
   stage: test
   extends: .terraform/openstack

--- a/Schutzfile
+++ b/Schutzfile
@@ -2,21 +2,21 @@
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "087b403042f5179de61a7fc306066d90f8d57e08"
+        "commit": "c38717e43fa34c407e6e9b993f626b475448165e"
       }
     }
   },
   "rhel-8.5": {
     "dependencies": {
       "osbuild": {
-        "commit": "087b403042f5179de61a7fc306066d90f8d57e08"
+        "commit": "c38717e43fa34c407e6e9b993f626b475448165e"
       }
     }
   },
   "rhel-8.6": {
     "dependencies": {
       "osbuild": {
-        "commit": "087b403042f5179de61a7fc306066d90f8d57e08"
+        "commit": "c38717e43fa34c407e6e9b993f626b475448165e"
       }
     },
     "repos": {
@@ -60,7 +60,7 @@
   "rhel-9.0": {
     "dependencies": {
       "osbuild": {
-        "commit": "087b403042f5179de61a7fc306066d90f8d57e08"
+        "commit": "c38717e43fa34c407e6e9b993f626b475448165e"
       }
     },
     "repos": {
@@ -104,7 +104,7 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "087b403042f5179de61a7fc306066d90f8d57e08"
+        "commit": "c38717e43fa34c407e6e9b993f626b475448165e"
       }
     }
   }

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -155,6 +155,15 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 		return err
 	}
 
+	if osbuildJobResult.OSBuildOutput.Sources != nil {
+		for _, source := range osbuildJobResult.OSBuildOutput.Sources {
+			if !source.Success {
+				osbuildJobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorBuildJob, source.Error)
+				return nil
+			}
+		}
+	}
+
 	// Include pipeline stages output inside the worker's logs.
 	// Order pipelines based on PipelineNames from job
 	for _, pipelineName := range osbuildJobResult.PipelineNames.All() {

--- a/internal/osbuild2/result.go
+++ b/internal/osbuild2/result.go
@@ -15,6 +15,7 @@ type Result struct {
 	Error    json.RawMessage             `json:"error,omitempty"`
 	Log      map[string]PipelineResult   `json:"log"`
 	Metadata map[string]PipelineMetadata `json:"metadata"`
+	Sources  []OsbuildSource             `json:"sources,omitempty"`
 }
 
 type PipelineResult []StageResult
@@ -38,6 +39,12 @@ type StageMetadata interface {
 type RawStageMetadata json.RawMessage
 
 func (RawStageMetadata) isStageMetadata() {}
+
+type OsbuildSource struct {
+	Source  string `json:"source"`
+	Success bool   `json:"success"`
+	Error   string `json:"error_message,omitempty"`
+}
 
 // UnmarshalJSON decodes json-encoded StageResult.
 //

--- a/test/cases/download_error.sh
+++ b/test/cases/download_error.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/bash
+
+set -euxo pipefail
+
+# Colorful timestamped output.
+function greenprint {
+    echo -e "\033[1;32m[$(date -Isecond)] ${1}\033[0m"
+}
+
+ARTIFACTS=ci-artifacts
+mkdir -p "${ARTIFACTS}"
+
+source /usr/libexec/osbuild-composer-test/set-env-variables.sh
+
+#
+# Provision the software under test.
+#
+
+/usr/libexec/osbuild-composer-test/provision.sh
+
+#
+# Set up the database queue
+#
+if which podman 2>/dev/null >&2; then
+  CONTAINER_RUNTIME=podman
+elif which docker 2>/dev/null >&2; then
+  CONTAINER_RUNTIME=docker
+else
+  echo No container runtime found, install podman or docker.
+  exit 2
+fi
+
+# Start the db
+sudo ${CONTAINER_RUNTIME} run -d --name osbuild-composer-db \
+    --health-cmd "pg_isready -U postgres -d osbuildcomposer" --health-interval 2s \
+    --health-timeout 2s --health-retries 10 \
+    -e POSTGRES_USER=postgres \
+    -e POSTGRES_PASSWORD=foobar \
+    -e POSTGRES_DB=osbuildcomposer \
+    -p 5432:5432 \
+    quay.io/osbuild/postgres:13-alpine
+
+# Dump the logs once to have a little more output
+sudo ${CONTAINER_RUNTIME} logs osbuild-composer-db
+
+# Initialize a module in a temp dir so we can get tern without introducing
+# vendoring inconsistency
+pushd "$(mktemp -d)"
+sudo dnf install -y go
+go mod init temp
+go get github.com/jackc/tern
+PGUSER=postgres PGPASSWORD=foobar PGDATABASE=osbuildcomposer PGHOST=localhost PGPORT=5432 \
+      go run github.com/jackc/tern migrate -m /usr/share/tests/osbuild-composer/schemas
+popd
+
+cat <<EOF | sudo tee "/etc/osbuild-composer/osbuild-composer.toml"
+log_level = "debug"
+[koji]
+allowed_domains = [ "localhost", "client.osbuild.org" ]
+ca = "/etc/osbuild-composer/ca-crt.pem"
+[koji.aws_config]
+bucket = "${AWS_BUCKET}"
+[worker]
+allowed_domains = [ "localhost", "worker.osbuild.org" ]
+ca = "/etc/osbuild-composer/ca-crt.pem"
+pg_host = "localhost"
+pg_port = "5432"
+pg_database = "osbuildcomposer"
+pg_user = "postgres"
+pg_password = "foobar"
+pg_ssl_mode = "disable"
+pg_max_conns = 10
+EOF
+
+sudo systemctl restart osbuild-composer
+
+
+WORKDIR=$(mktemp -d)
+KILL_PIDS=()
+function cleanup() {
+  set +eu
+  sudo rm -rf "$WORKDIR"
+
+  for P in "${KILL_PIDS[@]}"; do
+      sudo pkill -P "$P"
+  done
+  set -eu
+}
+trap cleanup EXIT
+
+# make a dummy rpm and repo to test payload_repositories
+sudo dnf install -y rpm-build createrepo
+DUMMYRPMDIR=$(mktemp -d)
+DUMMYSPECFILE="$DUMMYRPMDIR/dummy.spec"
+PAYLOAD_REPO_PORT="9999"
+
+pushd "$DUMMYRPMDIR"
+
+cat <<EOF > "$DUMMYSPECFILE"
+#----------- spec file starts ---------------
+Name:                   dummy
+Version:                1.0.0
+Release:                0
+BuildArch:              noarch
+Vendor:                 dummy
+Summary:                Provides %{name}
+License:                BSD
+Provides:               dummy
+
+%description
+%{summary}
+
+%files
+EOF
+
+mkdir -p "DUMMYRPMDIR/rpmbuild"
+rpmbuild --quiet --define "_topdir $DUMMYRPMDIR/rpmbuild" -bb "$DUMMYSPECFILE"
+
+mkdir -p "$DUMMYRPMDIR/repo"
+cp "$DUMMYRPMDIR"/rpmbuild/RPMS/noarch/*rpm "$DUMMYRPMDIR/repo"
+pushd "$DUMMYRPMDIR/repo"
+createrepo .
+sudo python3 -m http.server "$PAYLOAD_REPO_PORT" &
+KILL_PIDS+=("$!")
+popd
+popd
+
+
+REQUEST_FILE="${WORKDIR}/request.json"
+cat > "$REQUEST_FILE" << EOF
+{
+    "distribution": "centos-8",
+    "image_request": {
+        "architecture": "x86_64",
+        "image_type": "aws",
+        "repositories": [
+            {
+            "baseurl": "http://mirror.centos.org/centos/8-stream/extras/x86_64/os/",
+            "rhsm": false
+            },
+            {
+                "baseurl": "http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/",
+                "rhsm": false
+            },
+            {
+            "baseurl": "http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/",
+            "rhsm": false
+            }
+        ],
+        "upload_options": {
+            "region": "trucmuche"
+        }
+    }
+}
+EOF
+
+#
+# Send the request and wait for the job to finish.
+#
+# Separate `curl` and `jq` commands here, because piping them together hides
+# the server's response in case of an error.
+#
+
+function collectMetrics(){
+    METRICS_OUTPUT=$(curl \
+                          --cacert /etc/osbuild-composer/ca-crt.pem \
+                          --key /etc/osbuild-composer/client-key.pem \
+                          --cert /etc/osbuild-composer/client-crt.pem \
+                          https://localhost/metrics)
+
+    echo "$METRICS_OUTPUT" | grep "^image_builder_composer_total_compose_requests" | cut -f2 -d' '
+}
+
+function sendCompose() {
+    OUTPUT=$(mktemp)
+    HTTPSTATUS=$(curl \
+                 --silent \
+                 --show-error \
+                 --cacert /etc/osbuild-composer/ca-crt.pem \
+                 --key /etc/osbuild-composer/client-key.pem \
+                 --cert /etc/osbuild-composer/client-crt.pem \
+                 --header 'Content-Type: application/json' \
+                 --request POST \
+                 --data @"$1" \
+                 --write-out '%{http_code}' \
+                 --output "$OUTPUT" \
+                 https://localhost/api/image-builder-composer/v3/compose)
+
+    test "$HTTPSTATUS" = "201"
+    COMPOSE_ID=$(jq -r '.id' "$OUTPUT")
+}
+
+function waitForState() {
+    local DESIRED_STATE="${1:-success}"
+
+    while true
+    do
+        OUTPUT=$(curl \
+                     --silent \
+                     --show-error \
+                     --cacert /etc/osbuild-composer/ca-crt.pem \
+                     --key /etc/osbuild-composer/client-key.pem \
+                     --cert /etc/osbuild-composer/client-crt.pem \
+                     "https://localhost/api/image-builder-composer/v2/composes/$COMPOSE_ID")
+
+        COMPOSE_STATUS=$(echo "$OUTPUT" | jq -r '.image_status.status')
+
+        case "$COMPOSE_STATUS" in
+            "$DESIRED_STATE")
+                break
+                ;;
+            # all valid status values for a compose which hasn't finished yet
+            "pending"|"building"|"uploading"|"registering")
+                ;;
+            # default undesired state
+            "failure")
+                echo "Image compose failed"
+                exit 1
+                ;;
+            *)
+                echo "API returned unexpected image_status.status value: '$COMPOSE_STATUS'"
+                exit 1
+                ;;
+        esac
+
+        sleep 30
+    done
+}
+
+# break dnf-json, make it return always the same false url
+sudo systemctl disable --now osbuild-composer.service osbuild-composer-api.socket osbuild-worker@1.service osbuild-dnf-json.socket dnf-json.service
+sudo sed -i '/package.remote_location/c\                "remote_location": "http://pouet.pouet.com",' /usr/libexec/osbuild-composer/dnf-json
+sudo systemctl enable --now osbuild-composer-api.socket osbuild-dnf-json.socket osbuild-worker@1.service
+
+# downloading fails
+sendCompose "$REQUEST_FILE"
+waitForState "failure"
+
+journalctl -u osbuild-worker@1.service  | grep pouet.com


### PR DESCRIPTION
Now osbuild gives feedback about failing downloads. Get this info and
parse it to inform the user.

Linked to https://github.com/osbuild/osbuild/pull/961


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
