### PR TITLE
worker: Properly log successful image builds

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild-koji.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild-koji.go
@@ -61,6 +61,8 @@ func validateKojiResult(result *worker.OSBuildKojiJobResult, jobID string) {
 		reason := "osbuild job was unsuccessful"
 		logWithId.Errorf("osbuild job failed: %s", reason)
 		result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorBuildJob, reason)
+	} else {
+		logWithId.Infof("osbuild-koji job succeeded")
 	}
 }
 

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -62,6 +62,8 @@ func validateResult(result *worker.OSBuildJobResult, jobID string) {
 		logWithId.Errorf("osbuild job failed: %s", reason)
 		result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorBuildJob, reason)
 		return
+	} else {
+		logWithId.Infof("osbuild job succeeded")
 	}
 	result.Success = true
 }


### PR DESCRIPTION
This will make counting successful image builds in Splunk and Cloudwatch
much simpler and robust.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/