### PR TITLE
ci: large runners for some ostree tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -276,7 +276,7 @@ New OSTree:
       - RUNNER:
           - rhos-01/rhel-8.6-nightly-x86_64-large
           - rhos-01/rhel-9.0-nightly-x86_64-large
-          - rhos-01/centos-stream-8-x86_64
+          - rhos-01/centos-stream-8-x86_64-large
           - rhos-01/centos-stream-9-x86_64-large
 
 OSTree simplified installer:
@@ -289,8 +289,8 @@ OSTree simplified installer:
     matrix:
       - RUNNER:
           - rhos-01/rhel-8.6-nightly-x86_64-large
-          - rhos-01/centos-stream-8-x86_64
-          - rhos-01/rhel-9.0-nightly-x86_64
+          - rhos-01/centos-stream-8-x86_64-large
+          - rhos-01/rhel-9.0-nightly-x86_64-large
           - rhos-01/centos-stream-9-x86_64-large
 
 OSTree raw image:
@@ -302,9 +302,9 @@ OSTree raw image:
   parallel:
     matrix:
       - RUNNER:
-          - rhos-01/rhel-8.6-nightly-x86_64
-          - rhos-01/centos-stream-8-x86_64
-          - rhos-01/rhel-9.0-nightly-x86_64
+          - rhos-01/rhel-8.6-nightly-x86_64-large
+          - rhos-01/centos-stream-8-x86_64-large
+          - rhos-01/rhel-9.0-nightly-x86_64-large
           - rhos-01/centos-stream-9-x86_64-large
 
 .INTEGRATION_TESTS: &INTEGRATION_TESTS


### PR DESCRIPTION
The longer running ostree tests (all except ostree.sh) benefit from
running on large runners because of their long runtime. Changing all to
large runners.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
