### PR TITLE
rhel86/90: change isolevel of image-installer to 3

### DIFF
--- a/internal/distro/rhel86/stage_options.go
+++ b/internal/distro/rhel86/stage_options.go
@@ -346,6 +346,7 @@ func xorrisofsStageOptions(filename, isolabel, arch string, isolinux bool) *osbu
 		VolID:    fmt.Sprintf(isolabel, arch),
 		SysID:    "LINUX",
 		EFI:      "images/efiboot.img",
+		ISOLevel: 3,
 	}
 
 	if isolinux {

--- a/internal/distro/rhel90/stage_options.go
+++ b/internal/distro/rhel90/stage_options.go
@@ -346,6 +346,7 @@ func xorrisofsStageOptions(filename, isolabel, arch string, isolinux bool) *osbu
 		VolID:    fmt.Sprintf(isolabel, arch),
 		SysID:    "LINUX",
 		EFI:      "images/efiboot.img",
+		ISOLevel: 3,
 	}
 
 	if isolinux {

--- a/test/cases/regression-bigiso.sh
+++ b/test/cases/regression-bigiso.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# https://bugzilla.redhat.com/show_bug.cgi?id=2056451
+
+# Get OS data.
+source /usr/libexec/osbuild-composer-test/set-env-variables.sh
+
+# Provision the software under test.
+/usr/libexec/osbuild-composer-test/provision.sh
+
+case "${ID}-${VERSION_ID}" in
+    "rhel-8.6" | "rhel-9.0" | "centos-9")
+        ;;
+    *)
+        echo "$0 is not enabled for ${ID}-${VERSION_ID} skipping..."
+        exit 0
+        ;;
+esac
+
+if [ "$ARCH" != "x86_64" ]; then
+  echo "Workstation group is only available on x86_64"
+  exit 0
+fi
+
+
+set -xeuo pipefail
+
+function get_build_info() {
+    key="$1"
+    fname="$2"
+    if rpm -q --quiet weldr-client; then
+        key=".body${key}"
+    fi
+    jq -r "${key}" "${fname}"
+}
+
+# Provision the software under test.
+BLUEPRINT_FILE=/tmp/blueprint.toml
+COMPOSE_START=/tmp/compose-start.json
+COMPOSE_INFO=/tmp/compose-info.json
+
+# Write a basic blueprint for our image.
+tee "$BLUEPRINT_FILE" > /dev/null << 'EOF'
+name = "toobig"
+description = "too big blueprint"
+version = "0.0.1"
+modules = []
+#groups = []
+
+[[customizations.user]]
+# password for admin is rootroot
+name = "admin"
+description = "admin"
+password = "$6$ismFu3TUg0KR8.kJ$rddx3JVWXVaPF06XHeS1QNV6D6U3vo8WN4mi/V2mKLZ9ZKsMUlIwLhU.WvxfT.5F1PqUrx8Y8DUr/a5iTJQlw."
+home = "/home/admin/"
+shell = "/usr/bin/bash"
+groups = ["users", "wheel"]
+
+[[groups]]
+name="Workstation"
+
+[[packages]]
+name="httpd"
+version="*"
+
+[[packages]]
+name="gnome-session"
+version="*"
+
+[customizations]
+hostname = "custombase"
+EOF
+
+sudo composer-cli blueprints push "$BLUEPRINT_FILE"
+sudo composer-cli blueprints depsolve toobig
+sudo composer-cli --json compose start toobig image-installer | tee "${COMPOSE_START}"
+COMPOSE_ID=$(get_build_info ".build_id" "$COMPOSE_START")
+# Wait for the compose to finish.
+echo "⏱ Waiting for compose to finish: ${COMPOSE_ID}"
+while true; do
+    sudo composer-cli --json compose info "${COMPOSE_ID}" | tee "$COMPOSE_INFO" > /dev/null
+    COMPOSE_STATUS=$(get_build_info ".queue_status" "$COMPOSE_INFO")
+
+    # Is the compose finished?
+    if [[ $COMPOSE_STATUS != RUNNING ]] && [[ $COMPOSE_STATUS != WAITING ]]; then
+        break
+    fi
+
+    # Wait 30 seconds and try again.
+    sleep 30
+done
+
+sudo composer-cli compose delete "${COMPOSE_ID}" >/dev/null
+
+jq . "${COMPOSE_INFO}"
+
+# Did the compose finish with success?
+if [[ $COMPOSE_STATUS != FINISHED ]]; then
+    echo "Something went wrong with the compose. 😢"
+    exit 1
+fi

--- a/test/cases/regression.sh
+++ b/test/cases/regression.sh
@@ -15,6 +15,7 @@ TEST_CASES=(
     "regression-include-excluded-packages.sh"
     "regression-composer-works-behind-satellite.sh"
     "regression-composer-works-behind-satellite-fallback.sh"
+    "regression-bigiso.sh"
 )
 
 # Print out a nice test divider so we know when tests stop and start.

--- a/test/data/manifests/centos_8-x86_64-image_installer-boot.json
+++ b/test/data/manifests/centos_8-x86_64-image_installer-boot.json
@@ -2098,7 +2098,8 @@
                 "catalog": "isolinux/boot.cat"
               },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin"
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
+              "isolevel": 3
             }
           },
           {

--- a/test/data/manifests/centos_9-x86_64-image_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-image_installer-boot.json
@@ -2060,7 +2060,8 @@
                 "catalog": "isolinux/boot.cat"
               },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin"
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
+              "isolevel": 3
             }
           },
           {

--- a/test/data/manifests/rhel_86-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-image_installer-boot.json
@@ -2132,7 +2132,8 @@
                 "catalog": "isolinux/boot.cat"
               },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin"
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
+              "isolevel": 3
             }
           },
           {

--- a/test/data/manifests/rhel_90-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-image_installer-boot.json
@@ -2077,7 +2077,8 @@
                 "catalog": "isolinux/boot.cat"
               },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin"
+              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
+              "isolevel": 3
             }
           },
           {


### PR DESCRIPTION
So it can contain payload bigger than 4GiB.

Related: rhbz#2056451
Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
