### PR TITLE
worker/osbuild-koji: fix double-reporting of osbuild-koji job status

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild-koji.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild-koji.go
@@ -7,12 +7,13 @@ import (
 	"os"
 	"path"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/upload/koji"
 	"github.com/osbuild/osbuild-composer/internal/worker"
 	"github.com/osbuild/osbuild-composer/internal/worker/clienterrors"
-	"github.com/sirupsen/logrus"
 )
 
 type OSBuildKojiJobImpl struct {
@@ -168,11 +169,6 @@ func (impl *OSBuildKojiJobImpl) Run(job worker.Job) error {
 
 	// copy pipeline info to the result
 	result.PipelineNames = args.PipelineNames
-
-	err = job.Update(&result)
-	if err != nil {
-		return fmt.Errorf("Error reporting job result: %v", err)
-	}
 
 	return nil
 }


### PR DESCRIPTION
This was causing:

Feb 21 06:08:06 ip-10-30-18-43.us-east-1.aws.redhat.com osbuild-worker[20798]: time="2022-02-21T06:08:06Z" level=warning msg="Error reporting job result: error setting job status: 404 — Token not found (IMAGE-BUILDER-WORKER-5)"

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
