### PR TITLE
Revert "mockbuild: temporarily pin RHEL 9 compose to an older one"

### DIFF
--- a/schutzbot/el9-mock-configs/templates/rhel-9.tpl
+++ b/schutzbot/el9-mock-configs/templates/rhel-9.tpl
@@ -30,19 +30,19 @@ user_agent={{ user_agent }}
 
 [rhel9-baseos]
 name=RHEL 9 BaseOS
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/RHEL-9.0.0-20220216.0/compose/BaseOS/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/BaseOS/$basearch/os/
 enabled=1
 gpgcheck=0
 
 [rhel9-appstream]
 name=RHEL 9 AppStream
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/RHEL-9.0.0-20220216.0/compose/AppStream/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/AppStream/$basearch/os/
 enabled=1
 gpgcheck=0
 
 [rhel9-crb]
 name=RHEL 9 CRB
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/RHEL-9.0.0-20220216.0/compose/CRB/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/CRB/$basearch/os/
 enabled=1
 gpgcheck=0
 


### PR DESCRIPTION
Unpin before the compose is deleted. We should really use the same repos as define in Schutzfile at some point.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
