### PR TITLE
test: Remove "ansible-galaxy collection install"

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -25,9 +25,6 @@ ge86=$(echo "${VERSION_ID}" | awk '{print $1 >= 8.6}')  # do a numerical compari
 echo -n "${ID}=${VERSION_ID} "
 if [[ "${ID}" == "rhel" || "${ID}" == "centos" ]] && (( ge86 )); then
     sudo dnf install -y ansible-core koji
-
-    # NOTE: do we need this?
-    sudo ansible-galaxy collection install community.general
 fi
 
 sudo mkdir -p /etc/osbuild-composer


### PR DESCRIPTION
Since "ANSIBLE_STDOUT_CALLBACK=yaml" has been removed from all ostree test script, "ansible-galaxy collection install" should be removed as well.

We encountered galaxy server issue in test https://gitlab.com/osbuild/ci/osbuild-composer/-/jobs/2120498876#L2336
Let's remove it to avoid issues.