### PR TITLE
templates/worker: fix depsolve error rate

### DIFF
--- a/templates/dashboards/grafana-dashboard-image-builder-worker-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-image-builder-worker-general.configmap.yml
@@ -31,7 +31,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1644336592519,
+      "iteration": 1645525186957,
       "links": [],
       "panels": [
         {
@@ -279,8 +279,6 @@ data:
               },
               "mappings": [],
               "max": 1,
-              "min": 3,
-              "noValue": "0",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -300,7 +298,7 @@ data:
             "x": 16,
             "y": 1
           },
-          "id": 194,
+          "id": 228,
           "options": {
             "legend": {
               "calcs": [],
@@ -314,10 +312,9 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "(\n  sum(rate(image_builder_worker_total_jobs{type=~\"osbuild:.*\", status=\"5xx\"}[$interval]))\n  / \n  sum(rate(image_builder_worker_total_jobs{type=~\"osbuild:.*\", status!=\"4xx\"}[$interval]))\n)\nOR on() vector(0) # set fallback incase the above query result is empty",
-              "instant": false,
+              "expr": "(\n  sum(rate(image_builder_worker_total_jobs{type=~\"osbuild:.*\", status=\"5xx\"}[$interval]))\n  /\n  sum(rate(image_builder_worker_total_jobs{type=~\"osbuild:.*\", status!=\"4xx\"}[$interval]))\n)\nOR on() vector(0) # set fallback incase the above query result is empty",
               "interval": "",
-              "legendFormat": "build_job_error_rate",
+              "legendFormat": "",
               "refId": "A"
             }
           ],
@@ -1219,7 +1216,7 @@ data:
         },
         {
           "datasource": "${datasource}",
-          "description": "The throughput rate of osbuild job errors and non-errors over time for the selected time range",
+          "description": "The throughput rate of depsolve job errors and non-errors over time for the selected time range",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1318,12 +1315,12 @@ data:
               "refId": "B"
             }
           ],
-          "title": "Build Job Throughput Rate",
+          "title": "Depsolve Job Throughput Rate",
           "type": "timeseries"
         },
         {
           "datasource": "${datasource}",
-          "description": "The number of osbuild job errors (as a percentage) over time for the selected time range",
+          "description": "The number of depsolve job errors (as a percentage) over time for the selected time range",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1359,6 +1356,8 @@ data:
               },
               "mappings": [],
               "max": 1,
+              "min": 3,
+              "noValue": "0",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -1378,7 +1377,7 @@ data:
             "x": 16,
             "y": 35
           },
-          "id": 228,
+          "id": 194,
           "options": {
             "legend": {
               "calcs": [],
@@ -1392,13 +1391,14 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "(\n  sum(rate(image_builder_worker_total_jobs{type=~\"osbuild:.*\", status=\"5xx\"}[$interval]))\n  /\n  sum(rate(image_builder_worker_total_jobs{type=~\"osbuild:.*\", status!=\"4xx\"}[$interval]))\n)\nOR on() vector(0) # set fallback incase the above query result is empty",
+              "expr": "(\n  sum(rate(image_builder_worker_total_jobs{type=\"depsolve\", status=\"5xx\"}[$interval]))\n  / \n  sum(rate(image_builder_worker_total_jobs{type=\"depsolve\", status!=\"4xx\"}[$interval]))\n)\nOR on() vector(0) # set fallback incase the above query result is empty",
+              "instant": false,
               "interval": "",
               "legendFormat": "",
               "refId": "A"
             }
           ],
-          "title": "Build Job Error Rate",
+          "title": "Depsolve Job Error Rate",
           "type": "timeseries"
         },
         {
@@ -2743,5 +2743,5 @@ data:
       "timezone": "",
       "title": "Image Builder Worker",
       "uid": "image-builder-worker",
-      "version": 3
+      "version": 4
     }


### PR DESCRIPTION
The depsolve error rate had the incorrect query and was returning the error rate for the build
jobs. This has now been fixed.

Before:
![before](https://user-images.githubusercontent.com/20438192/155113466-243c8361-d6e0-4ee4-85c3-659a6599b632.png)

After:
![after](https://user-images.githubusercontent.com/20438192/155113482-c2577b3d-f616-4eba-8cac-5022f9dce743.png)

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
