### PR TITLE
COMPOSER-1343: Revert "tests: Conditionally enable osbuild-dnf-json-tests"

### DIFF
--- a/test/cases/base_tests.sh
+++ b/test/cases/base_tests.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-source /usr/libexec/tests/osbuild-composer/shared_lib.sh
-
 WORKING_DIRECTORY=/usr/libexec/osbuild-composer
 TESTS_PATH=/usr/libexec/osbuild-composer-test
 mkdir --parents /tmp/logs
@@ -13,18 +11,11 @@ FAILED_TESTS=()
 
 TEST_CASES=(
   "osbuild-weldr-tests"
+  "osbuild-dnf-json-tests"
   "osbuild-composer-cli-tests"
   "osbuild-auth-tests"
   "osbuild-composer-dbjobqueue-tests"
 )
-
-if nvrGreaterOrEqual "osbuild-composer" "41"; then
-    # 0 - osbuild-composer == v41
-    # 11 - osbuild-composer > v41
-    # 12 - osbuild-composer < v41
-    echo "INFO: enabling osbuild-dnf-json-tests"
-    TEST_CASES+=("osbuild-dnf-json-tests")
-fi
 
 # Print out a nice test divider so we know when tests stop and start.
 test_divider () {


### PR DESCRIPTION
Current version is 45.

This reverts commit 966692be1122347a2668bee8e6ae88ee8f81f39b.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
