### PR TITLE
internal/cloudapi: Allow bp.Customizations being nil

### DIFF
--- a/internal/cloudapi/v2/v2.go
+++ b/internal/cloudapi/v2/v2.go
@@ -173,7 +173,6 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 	if err != nil {
 		return HTTPErrorWithInternal(ErrorFailedToInitializeBlueprint, err)
 	}
-	bp.Customizations = &blueprint.Customizations{}
 
 	// Set the blueprint customisation to take care of the user
 	if request.Customizations != nil && request.Customizations.Users != nil {
@@ -193,7 +192,13 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 				},
 			)
 		}
-		bp.Customizations.User = userCustomizations
+		if bp.Customizations == nil {
+			bp.Customizations = &blueprint.Customizations{
+				User: userCustomizations,
+			}
+		} else {
+			bp.Customizations.User = userCustomizations
+		}
 	}
 
 	if request.Customizations != nil && request.Customizations.Packages != nil {
@@ -215,7 +220,13 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 				},
 			)
 		}
-		bp.Customizations.Filesystem = fsCustomizations
+		if bp.Customizations == nil {
+			bp.Customizations = &blueprint.Customizations{
+				Filesystem: fsCustomizations,
+			}
+		} else {
+			bp.Customizations.Filesystem = fsCustomizations
+		}
 	}
 
 	// add the user-defined repositories only to the depsolve job for the


### PR DESCRIPTION
Customizations being nil isn't the same as an empty object. The
edge-installer types require customizations equalling nil.

This partially reverts bb486bcccb5abf6b96e9e8b76c7226a693d08172.
