### PR TITLE
RHEL-90: use C.UTF-8 for images that only have glibc-minimal-langpack

### DIFF
--- a/internal/distro/rhel90/distro.go
+++ b/internal/distro/rhel90/distro.go
@@ -57,7 +57,7 @@ type distribution struct {
 // RHEL-based OS image configuration defaults
 var defaultDistroImageConfig = &distro.ImageConfig{
 	Timezone: "America/New_York",
-	Locale:   "en_US.UTF-8",
+	Locale:   "C.UTF-8",
 	Sysconfig: []*osbuild.SysconfigStageOptions{
 		{
 			Kernel: &osbuild.SysconfigKernelOptions{
@@ -695,6 +695,9 @@ func newDistro(distroName string) distro.Distro {
 		packageSets: map[string]packageSetFunc{
 			buildPkgsKey: edgeRawImageBuildPackageSet,
 		},
+		defaultImageConfig: &distro.ImageConfig{
+			Locale: "en_US.UTF-8",
+		},
 		defaultSize:         10 * GigaByte,
 		rpmOstree:           true,
 		bootable:            true,
@@ -724,6 +727,7 @@ func newDistro(distroName string) distro.Distro {
 			installerPkgsKey: edgeInstallerPackageSet,
 		},
 		defaultImageConfig: &distro.ImageConfig{
+			Locale:          "en_US.UTF-8",
 			EnabledServices: edgeServices,
 		},
 		rpmOstree:        true,
@@ -806,6 +810,7 @@ func newDistro(distroName string) distro.Distro {
 			osPkgsKey:    vhdCommonPackageSet,
 		},
 		defaultImageConfig: &distro.ImageConfig{
+			Locale: "en_US.UTF-8",
 			EnabledServices: []string{
 				"sshd",
 				"waagent",
@@ -830,6 +835,9 @@ func newDistro(distroName string) distro.Distro {
 			buildPkgsKey: distroBuildPackageSet,
 			osPkgsKey:    vmdkCommonPackageSet,
 		},
+		defaultImageConfig: &distro.ImageConfig{
+			Locale: "en_US.UTF-8",
+		},
 		kernelOptions:       "ro net.ifnames=0",
 		bootable:            true,
 		defaultSize:         4 * GigaByte,
@@ -848,6 +856,9 @@ func newDistro(distroName string) distro.Distro {
 			buildPkgsKey: distroBuildPackageSet,
 			osPkgsKey:    openstackCommonPackageSet,
 		},
+		defaultImageConfig: &distro.ImageConfig{
+			Locale: "en_US.UTF-8",
+		},
 		kernelOptions:       "ro net.ifnames=0",
 		bootable:            true,
 		defaultSize:         4 * GigaByte,
@@ -860,6 +871,7 @@ func newDistro(distroName string) distro.Distro {
 
 	// default EC2 images config (common for all architectures)
 	defaultEc2ImageConfig := &distro.ImageConfig{
+		Locale:   "en_US.UTF-8",
 		Timezone: "UTC",
 		TimeSynchronization: &osbuild.ChronyStageOptions{
 			Servers: []osbuild.ChronyConfigServer{

--- a/internal/distro/rhel90/pipelines.go
+++ b/internal/distro/rhel90/pipelines.go
@@ -795,7 +795,7 @@ func simplifiedInstallerTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.
 	p.Build = "name:build"
 	p.AddStage(osbuild.NewRPMStage(rpmStageOptions(repos), osbuild.NewRpmStageSourceFilesInputs(packages)))
 	p.AddStage(osbuild.NewBuildstampStage(buildStampStageOptions(arch, product, osVersion, variant)))
-	p.AddStage(osbuild.NewLocaleStage(&osbuild.LocaleStageOptions{Language: "en_US.UTF-8"}))
+	p.AddStage(osbuild.NewLocaleStage(&osbuild.LocaleStageOptions{Language: "C.UTF-8"}))
 	dracutStageOptions := dracutStageOptions(kernelVer, arch, []string{
 		"coreos-installer",
 		"fdo",

--- a/test/data/manifests/centos_9-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_commit-boot.json
@@ -767,7 +767,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -9028,7 +9028,7 @@
       "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
     ],
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "os-release": {

--- a/test/data/manifests/centos_9-aarch64-edge_container-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_container-boot.json
@@ -767,7 +767,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {

--- a/test/data/manifests/centos_9-aarch64-image_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-image_installer-boot.json
@@ -918,7 +918,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {

--- a/test/data/manifests/centos_9-aarch64-qcow2-boot.json
+++ b/test/data/manifests/centos_9-aarch64-qcow2-boot.json
@@ -828,7 +828,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -9885,7 +9885,7 @@
       "type": "qcow2"
     },
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "modprobe": {

--- a/test/data/manifests/centos_9-aarch64-tar-boot.json
+++ b/test/data/manifests/centos_9-aarch64-tar-boot.json
@@ -565,7 +565,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -5977,7 +5977,7 @@
       "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
     ],
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "os-release": {

--- a/test/data/manifests/centos_9-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/centos_9-ppc64le-qcow2-boot.json
@@ -890,7 +890,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -10710,7 +10710,7 @@
       "type": "qcow2"
     },
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "modprobe": {

--- a/test/data/manifests/centos_9-ppc64le-tar-boot.json
+++ b/test/data/manifests/centos_9-ppc64le-tar-boot.json
@@ -578,7 +578,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -6153,7 +6153,7 @@
       "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
     ],
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "os-release": {

--- a/test/data/manifests/centos_9-s390x-qcow2-boot.json
+++ b/test/data/manifests/centos_9-s390x-qcow2-boot.json
@@ -976,7 +976,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -11718,7 +11718,7 @@
       "type": "qcow2"
     },
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "modprobe": {

--- a/test/data/manifests/centos_9-s390x-tar-boot.json
+++ b/test/data/manifests/centos_9-s390x-tar-boot.json
@@ -679,7 +679,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -7570,7 +7570,7 @@
       "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
     ],
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "os-release": {

--- a/test/data/manifests/centos_9-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit-boot.json
@@ -803,7 +803,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -9401,7 +9401,7 @@
       "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
     ],
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "os-release": {

--- a/test/data/manifests/centos_9-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit_rt-boot.json
@@ -917,7 +917,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -10655,7 +10655,7 @@
       "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
     ],
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "os-release": {

--- a/test/data/manifests/centos_9-x86_64-edge_container-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_container-boot.json
@@ -803,7 +803,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {

--- a/test/data/manifests/centos_9-x86_64-image_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-image_installer-boot.json
@@ -941,7 +941,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {

--- a/test/data/manifests/centos_9-x86_64-qcow2-boot.json
+++ b/test/data/manifests/centos_9-x86_64-qcow2-boot.json
@@ -855,7 +855,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -10156,7 +10156,7 @@
       "type": "qcow2"
     },
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "modprobe": {

--- a/test/data/manifests/centos_9-x86_64-tar-boot.json
+++ b/test/data/manifests/centos_9-x86_64-tar-boot.json
@@ -587,7 +587,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -6181,7 +6181,7 @@
       "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
     ],
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "os-release": {

--- a/test/data/manifests/rhel_90-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_commit-boot.json
@@ -763,7 +763,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -8318,7 +8318,7 @@
       "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
     ],
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "os-release": {

--- a/test/data/manifests/rhel_90-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_container-boot.json
@@ -763,7 +763,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {

--- a/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
@@ -927,7 +927,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {

--- a/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
@@ -843,7 +843,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -9387,7 +9387,7 @@
       "type": "qcow2"
     },
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "modprobe": {

--- a/test/data/manifests/rhel_90-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-tar-boot.json
@@ -562,7 +562,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -5504,7 +5504,7 @@
       "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
     ],
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "os-release": {

--- a/test/data/manifests/rhel_90-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-qcow2-boot.json
@@ -907,7 +907,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -10176,7 +10176,7 @@
       "type": "qcow2"
     },
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "modprobe": {

--- a/test/data/manifests/rhel_90-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-tar-boot.json
@@ -575,7 +575,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -5667,7 +5667,7 @@
       "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
     ],
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "os-release": {

--- a/test/data/manifests/rhel_90-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2-boot.json
@@ -992,7 +992,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -11085,7 +11085,7 @@
       "type": "qcow2"
     },
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "modprobe": {

--- a/test/data/manifests/rhel_90-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_90-s390x-tar-boot.json
@@ -676,7 +676,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -6983,7 +6983,7 @@
       "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
     ],
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "os-release": {

--- a/test/data/manifests/rhel_90-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit-boot.json
@@ -801,7 +801,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -8665,7 +8665,7 @@
       "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
     ],
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "os-release": {

--- a/test/data/manifests/rhel_90-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit_rt-boot.json
@@ -1000,7 +1000,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -10711,7 +10711,7 @@
       "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
     ],
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "os-release": {

--- a/test/data/manifests/rhel_90-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_container-boot.json
@@ -791,7 +791,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {

--- a/test/data/manifests/rhel_90-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-image_installer-boot.json
@@ -943,7 +943,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {

--- a/test/data/manifests/rhel_90-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-qcow2-boot.json
@@ -863,7 +863,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -9644,7 +9644,7 @@
       "type": "qcow2"
     },
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "modprobe": {

--- a/test/data/manifests/rhel_90-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-tar-boot.json
@@ -576,7 +576,7 @@
           {
             "type": "org.osbuild.locale",
             "options": {
-              "language": "en_US.UTF-8"
+              "language": "C.UTF-8"
             }
           },
           {
@@ -5686,7 +5686,7 @@
       "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
     ],
     "locale": {
-      "LANG": "en_US.UTF-8"
+      "LANG": "C.UTF-8"
     },
     "machine-id": "",
     "os-release": {


### PR DESCRIPTION
Change the default locale to `C.UTF-8` for RHEL-9.0.
For all the images which install `langpack-en`, keep using the
`en_US.UTF-8` locale. `C.UTF-8` is used as the default for:
 - edge-commit
 - edge-container
 - image-installer
 - qcow2
 - tar

Also change the default locale for the edge-simplified-installer
installer-tree pipeline, since its package set contains only
`glibc-minimal-langpack`.

Regenerate RHEL-90 and c9s image tests.

Fix #2206

Signed-off-by: Tomas Hozza <thozza@redhat.com>

TODO:

- [x] regenerate image tests

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
