### PR TITLE
FS minimum size

### DIFF
--- a/internal/distro/rhel85/distro.go
+++ b/internal/distro/rhel85/distro.go
@@ -466,9 +466,6 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 
 	invalidMountpoints := []string{}
 	for _, m := range mountpoints {
-		if m.Mountpoint == "/usr" && m.MinSize < 2147483648 {
-			m.MinSize = 2147483648
-		}
 		if !isMountpointAllowed(m.Mountpoint) {
 			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)
 		}

--- a/internal/distro/rhel86/distro.go
+++ b/internal/distro/rhel86/distro.go
@@ -549,9 +549,6 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 
 	invalidMountpoints := []string{}
 	for _, m := range mountpoints {
-		if m.Mountpoint == "/usr" && m.MinSize < 2147483648 {
-			m.MinSize = 2147483648
-		}
 		if !isMountpointAllowed(m.Mountpoint) {
 			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)
 		}

--- a/internal/distro/rhel86/distro.go
+++ b/internal/distro/rhel86/distro.go
@@ -37,7 +37,7 @@ const (
 )
 
 var mountpointAllowList = []string{
-	"/", "/var", "/opt", "/srv", "/usr", "/app", "/data", "/home",
+	"/", "/var", "/opt", "/srv", "/usr", "/app", "/data", "/home", "/tmp",
 }
 
 type distribution struct {

--- a/internal/distro/rhel90/distro.go
+++ b/internal/distro/rhel90/distro.go
@@ -537,9 +537,6 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 
 	invalidMountpoints := []string{}
 	for _, m := range mountpoints {
-		if m.Mountpoint == "/usr" && m.MinSize < 2147483648 {
-			m.MinSize = 2147483648
-		}
 		if !isMountpointAllowed(m.Mountpoint) {
 			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)
 		}

--- a/internal/distro/rhel90/distro.go
+++ b/internal/distro/rhel90/distro.go
@@ -37,7 +37,7 @@ const (
 )
 
 var mountpointAllowList = []string{
-	"/", "/var", "/opt", "/srv", "/usr", "/app", "/data", "/home",
+	"/", "/var", "/opt", "/srv", "/usr", "/app", "/data", "/home", "/tmp",
 }
 
 type distribution struct {

--- a/internal/distro/rhel90beta/distro.go
+++ b/internal/distro/rhel90beta/distro.go
@@ -492,9 +492,6 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 
 	invalidMountpoints := []string{}
 	for _, m := range mountpoints {
-		if m.Mountpoint == "/usr" && m.MinSize < 2147483648 {
-			m.MinSize = 2147483648
-		}
 		if !isMountpointAllowed(m.Mountpoint) {
 			invalidMountpoints = append(invalidMountpoints, m.Mountpoint)
 		}

--- a/test/cases/filesystem.sh
+++ b/test/cases/filesystem.sh
@@ -147,11 +147,11 @@ mountpoint = "/"
 size = 2147483648
 
 [[customizations.filesystem]]
-mountpoint = "/var"
+mountpoint = "/tmp"
 size = 131072000
 
 [[customizations.filesystem]]
-mountpoint = "/var/log"
+mountpoint = "/var/tmp"
 size = 131072000
 
 [[customizations.filesystem]]
@@ -175,7 +175,7 @@ greenprint "💬 Checking mountpoints"
 INFO="$(sudo /usr/libexec/osbuild-composer-test/image-info "${IMAGE_FILENAME}")"
 FAILED_MOUNTPOINTS=()
 
-for MOUNTPOINT in '/' '/var' '/var/log' '/var/log/audit' '/usr'; do
+for MOUNTPOINT in '/' '/tmp' '/var/tmp' '/var/log/audit' '/usr'; do
   EXISTS=$(jq -e --arg m "$MOUNTPOINT" 'any(.fstab[] | .[] == $m; .)' <<< "${INFO}")
   if $EXISTS; then
     greenprint "INFO: mountpoint $MOUNTPOINT exists"


### PR DESCRIPTION
This pull request includes:
- enable `/tmp` mountpoint for rhel86 & rhel90
- ensure minimum size of 1GB for all file systems, except `/usr` which is set to 2GB (fixes #2347)



- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
