### PR TITLE
test/manifest/image-installer: fix conflicting merge

### DIFF
--- a/test/data/manifests/centos_8-aarch64-image_installer-boot.json
+++ b/test/data/manifests/centos_8-aarch64-image_installer-boot.json
@@ -2062,7 +2062,8 @@
               "filename": "installer.iso",
               "volid": "CentOS-Stream-8-aarch64-dvd",
               "sysid": "LINUX",
-              "efi": "images/efiboot.img"
+              "efi": "images/efiboot.img",
+              "isolevel": 3
             }
           },
           {

--- a/test/data/manifests/centos_9-aarch64-image_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-image_installer-boot.json
@@ -2018,7 +2018,8 @@
               "filename": "installer.iso",
               "volid": "CentOS-Stream-9-BaseOS-aarch64",
               "sysid": "LINUX",
-              "efi": "images/efiboot.img"
+              "efi": "images/efiboot.img",
+              "isolevel": 3
             }
           },
           {

--- a/test/data/manifests/rhel_86-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-image_installer-boot.json
@@ -2093,7 +2093,8 @@
               "filename": "installer.iso",
               "volid": "RHEL-8-6-0-BaseOS-aarch64",
               "sysid": "LINUX",
-              "efi": "images/efiboot.img"
+              "efi": "images/efiboot.img",
+              "isolevel": 3
             }
           },
           {

--- a/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
@@ -2041,7 +2041,8 @@
               "filename": "installer.iso",
               "volid": "RHEL-9-0-0-BaseOS-aarch64",
               "sysid": "LINUX",
-              "efi": "images/efiboot.img"
+              "efi": "images/efiboot.img",
+              "isolevel": 3
             }
           },
           {


### PR DESCRIPTION
The new image-installer tests were merged at the same time as the isolevel support. Adjust the test cases.