### PR TITLE
RHEL 8.6: Add lvm2 to build root

### DIFF
--- a/internal/distro/rhel86/package_sets.go
+++ b/internal/distro/rhel86/package_sets.go
@@ -21,6 +21,7 @@ func distroBuildPackageSet(t *imageType) rpmmd.PackageSet {
 			"glibc",
 			"lorax-templates-generic",
 			"lorax-templates-rhel",
+			"lvm2",
 			"policycoreutils",
 			"python36",
 			"python3-iniparse",

--- a/internal/distro/rhel86/package_sets.go
+++ b/internal/distro/rhel86/package_sets.go
@@ -15,10 +15,21 @@ import (
 func distroBuildPackageSet(t *imageType) rpmmd.PackageSet {
 	ps := rpmmd.PackageSet{
 		Include: []string{
-			"dnf", "dosfstools", "e2fsprogs", "glibc", "lorax-templates-generic",
-			"lorax-templates-rhel", "policycoreutils", "python36",
-			"python3-iniparse", "qemu-img", "selinux-policy-targeted", "systemd",
-			"tar", "xfsprogs", "xz",
+			"dnf",
+			"dosfstools",
+			"e2fsprogs",
+			"glibc",
+			"lorax-templates-generic",
+			"lorax-templates-rhel",
+			"policycoreutils",
+			"python36",
+			"python3-iniparse",
+			"qemu-img",
+			"selinux-policy-targeted",
+			"systemd",
+			"tar",
+			"xfsprogs",
+			"xz",
 		},
 	}
 

--- a/test/data/manifests/centos_8-aarch64-ami-boot.json
+++ b/test/data/manifests/centos_8-aarch64-ami-boot.json
@@ -62,7 +62,10 @@
                   "sha256:60a44cc0f7f0592cf43e62d4682ac9166b095031ec541de26746c421ead8f865",
                   "sha256:eeda2f4870339df12e346fd51871f5fc68d0fdd6c8c9d54018bef86377e09bd3",
                   "sha256:a8f80c18fec48fd84a0e573e3698f36184c489814a2e2c9a944a5361d99a0a9c",
+                  "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+                  "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
                   "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+                  "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
                   "sha256:8cbebc0fa970ceca4f479ee292eaad155084987be2cf7f97bbafe4a529319c98",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -171,6 +174,8 @@
                   "sha256:30327c94b9729602f0b4dd73ff67edc2b7269af782182a2c02f44246ffe7f10f",
                   "sha256:b560a8a185100a7c80e6c32f69ba65ce17004156f7218cf183249b15c13295cc",
                   "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+                  "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+                  "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
                   "sha256:db9075646bed11355faf8b425c655a40a55436715a9f401f60e205ddd66edfeb",
                   "sha256:6809839757bd05082ca1b8d23eac617898eda3ce34844a0d31b0a030c8cc6653",
                   "sha256:d243985eed87e395c99f05ecfda5a55884d1e7df6f02f5ee01fcc76f520c9f1a",
@@ -1449,6 +1454,9 @@
           "sha256:23e9ff009c2316652c3bcd96a8b69b5bc26f2acd46214f652a7ce26a572cbabb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libnghttp2-1.33.0-3.el8_2.1.aarch64.rpm"
           },
+          "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm"
+          },
           "sha256:2460f610a00c11b7070ff75d27fb22fab4b8d67c856da2ffb097cf3eff28f365": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libseccomp-2.5.2-1.el8.aarch64.rpm"
           },
@@ -1505,6 +1513,9 @@
           },
           "sha256:30b0267fb252a7caf69bdb4f2458327b6907b4ce166aa61ef42143fe6027bd1f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/grubby-8.40-42.el8.aarch64.rpm"
+          },
+          "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.aarch64.rpm"
           },
           "sha256:3401ccfb7fd08c12578b6257b4dac7e94ba5f4cd70fc6a234fd90bb99d1bb108": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libtasn1-4.13-3.el8.aarch64.rpm"
@@ -1661,6 +1672,9 @@
           },
           "sha256:5441222132ae52cd31063e9b9e3bb40f2e5711dfb0c84315b4aec2907278a075": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/nettle-3.4.1-7.el8.aarch64.rpm"
+          },
+          "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm"
           },
           "sha256:548f4a211a0f93bdc6793783b5ba3104fefcfe1deef922724b91da1d299e5110": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libtdb-1.4.4-1.el8.aarch64.rpm"
@@ -2499,6 +2513,9 @@
           "sha256:f8c835839c4bea45a028976dc5dc4fe72faac67d1fbf0e9b884d008dfef4ced1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/libfastjson-0.99.9-1.el8.aarch64.rpm"
           },
+          "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm"
+          },
           "sha256:f955f857cbf4324bab7c1e880576b734bc984cd9f8b9061294a186161941efe1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libcurl-7.61.1-22.el8.aarch64.rpm"
           },
@@ -2513,6 +2530,9 @@
           },
           "sha256:fd888e489ae944e957265393f6b2ada131569459e13f30a48528a2bbb4054e58": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/python3-kickstart-3.16.14-1.el8.noarch.rpm"
+          },
+          "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm"
           },
           "sha256:ff548f5930aab3925644fc7d63d3fc71fb2f932effbe7d83a9b72b612648e32e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/grub2-efi-aa64-2.02-106.el8.aarch64.rpm"
@@ -4456,6 +4476,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4463,6 +4503,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
         "check_gpg": true
       },
       {
@@ -5543,6 +5593,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_commit-boot.json
@@ -63,7 +63,10 @@
                   "sha256:60a44cc0f7f0592cf43e62d4682ac9166b095031ec541de26746c421ead8f865",
                   "sha256:eeda2f4870339df12e346fd51871f5fc68d0fdd6c8c9d54018bef86377e09bd3",
                   "sha256:a8f80c18fec48fd84a0e573e3698f36184c489814a2e2c9a944a5361d99a0a9c",
+                  "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+                  "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
                   "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+                  "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
                   "sha256:8cbebc0fa970ceca4f479ee292eaad155084987be2cf7f97bbafe4a529319c98",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -175,6 +178,8 @@
                   "sha256:30327c94b9729602f0b4dd73ff67edc2b7269af782182a2c02f44246ffe7f10f",
                   "sha256:b560a8a185100a7c80e6c32f69ba65ce17004156f7218cf183249b15c13295cc",
                   "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+                  "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+                  "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
                   "sha256:db9075646bed11355faf8b425c655a40a55436715a9f401f60e205ddd66edfeb",
                   "sha256:6809839757bd05082ca1b8d23eac617898eda3ce34844a0d31b0a030c8cc6653",
                   "sha256:d243985eed87e395c99f05ecfda5a55884d1e7df6f02f5ee01fcc76f520c9f1a",
@@ -4125,6 +4130,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4132,6 +4157,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
         "check_gpg": true
       },
       {
@@ -5242,6 +5277,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-aarch64-edge_container-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_container-boot.json
@@ -63,7 +63,10 @@
                   "sha256:60a44cc0f7f0592cf43e62d4682ac9166b095031ec541de26746c421ead8f865",
                   "sha256:eeda2f4870339df12e346fd51871f5fc68d0fdd6c8c9d54018bef86377e09bd3",
                   "sha256:a8f80c18fec48fd84a0e573e3698f36184c489814a2e2c9a944a5361d99a0a9c",
+                  "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+                  "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
                   "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+                  "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
                   "sha256:8cbebc0fa970ceca4f479ee292eaad155084987be2cf7f97bbafe4a529319c98",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -175,6 +178,8 @@
                   "sha256:30327c94b9729602f0b4dd73ff67edc2b7269af782182a2c02f44246ffe7f10f",
                   "sha256:b560a8a185100a7c80e6c32f69ba65ce17004156f7218cf183249b15c13295cc",
                   "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+                  "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+                  "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
                   "sha256:db9075646bed11355faf8b425c655a40a55436715a9f401f60e205ddd66edfeb",
                   "sha256:6809839757bd05082ca1b8d23eac617898eda3ce34844a0d31b0a030c8cc6653",
                   "sha256:d243985eed87e395c99f05ecfda5a55884d1e7df6f02f5ee01fcc76f520c9f1a",
@@ -4634,6 +4639,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4641,6 +4666,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
         "check_gpg": true
       },
       {
@@ -5751,6 +5786,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_installer-boot.json
@@ -69,7 +69,10 @@
                   "sha256:60a44cc0f7f0592cf43e62d4682ac9166b095031ec541de26746c421ead8f865",
                   "sha256:eeda2f4870339df12e346fd51871f5fc68d0fdd6c8c9d54018bef86377e09bd3",
                   "sha256:a8f80c18fec48fd84a0e573e3698f36184c489814a2e2c9a944a5361d99a0a9c",
+                  "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+                  "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
                   "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+                  "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
                   "sha256:8cbebc0fa970ceca4f479ee292eaad155084987be2cf7f97bbafe4a529319c98",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -195,6 +198,8 @@
                   "sha256:30327c94b9729602f0b4dd73ff67edc2b7269af782182a2c02f44246ffe7f10f",
                   "sha256:b560a8a185100a7c80e6c32f69ba65ce17004156f7218cf183249b15c13295cc",
                   "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+                  "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+                  "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
                   "sha256:db9075646bed11355faf8b425c655a40a55436715a9f401f60e205ddd66edfeb",
                   "sha256:6809839757bd05082ca1b8d23eac617898eda3ce34844a0d31b0a030c8cc6653",
                   "sha256:d63c7f3cd245637a07d73296d9242bef466b33be5bb3654671f70f2c42752582",
@@ -5999,6 +6004,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -6006,6 +6031,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
         "check_gpg": true
       },
       {
@@ -7256,6 +7291,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_simplified_installer-boot.json
@@ -77,7 +77,10 @@
                   "sha256:60a44cc0f7f0592cf43e62d4682ac9166b095031ec541de26746c421ead8f865",
                   "sha256:eeda2f4870339df12e346fd51871f5fc68d0fdd6c8c9d54018bef86377e09bd3",
                   "sha256:a8f80c18fec48fd84a0e573e3698f36184c489814a2e2c9a944a5361d99a0a9c",
+                  "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+                  "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
                   "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+                  "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
                   "sha256:8cbebc0fa970ceca4f479ee292eaad155084987be2cf7f97bbafe4a529319c98",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -203,6 +206,8 @@
                   "sha256:30327c94b9729602f0b4dd73ff67edc2b7269af782182a2c02f44246ffe7f10f",
                   "sha256:b560a8a185100a7c80e6c32f69ba65ce17004156f7218cf183249b15c13295cc",
                   "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+                  "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+                  "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
                   "sha256:db9075646bed11355faf8b425c655a40a55436715a9f401f60e205ddd66edfeb",
                   "sha256:6809839757bd05082ca1b8d23eac617898eda3ce34844a0d31b0a030c8cc6653",
                   "sha256:d63c7f3cd245637a07d73296d9242bef466b33be5bb3654671f70f2c42752582",
@@ -4483,6 +4488,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4490,6 +4515,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
         "check_gpg": true
       },
       {
@@ -5740,6 +5775,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-aarch64-image_installer-boot.json
+++ b/test/data/manifests/centos_8-aarch64-image_installer-boot.json
@@ -64,7 +64,10 @@
                   "sha256:60a44cc0f7f0592cf43e62d4682ac9166b095031ec541de26746c421ead8f865",
                   "sha256:eeda2f4870339df12e346fd51871f5fc68d0fdd6c8c9d54018bef86377e09bd3",
                   "sha256:a8f80c18fec48fd84a0e573e3698f36184c489814a2e2c9a944a5361d99a0a9c",
+                  "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+                  "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
                   "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+                  "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
                   "sha256:8cbebc0fa970ceca4f479ee292eaad155084987be2cf7f97bbafe4a529319c98",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -188,6 +191,8 @@
                   "sha256:30327c94b9729602f0b4dd73ff67edc2b7269af782182a2c02f44246ffe7f10f",
                   "sha256:b560a8a185100a7c80e6c32f69ba65ce17004156f7218cf183249b15c13295cc",
                   "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+                  "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+                  "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
                   "sha256:db9075646bed11355faf8b425c655a40a55436715a9f401f60e205ddd66edfeb",
                   "sha256:6809839757bd05082ca1b8d23eac617898eda3ce34844a0d31b0a030c8cc6653",
                   "sha256:d63c7f3cd245637a07d73296d9242bef466b33be5bb3654671f70f2c42752582",
@@ -6725,6 +6730,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -6732,6 +6757,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
         "check_gpg": true
       },
       {
@@ -7962,6 +7997,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-aarch64-openstack-boot.json
+++ b/test/data/manifests/centos_8-aarch64-openstack-boot.json
@@ -79,7 +79,10 @@
                   "sha256:60a44cc0f7f0592cf43e62d4682ac9166b095031ec541de26746c421ead8f865",
                   "sha256:eeda2f4870339df12e346fd51871f5fc68d0fdd6c8c9d54018bef86377e09bd3",
                   "sha256:a8f80c18fec48fd84a0e573e3698f36184c489814a2e2c9a944a5361d99a0a9c",
+                  "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+                  "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
                   "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+                  "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
                   "sha256:8cbebc0fa970ceca4f479ee292eaad155084987be2cf7f97bbafe4a529319c98",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -188,6 +191,8 @@
                   "sha256:30327c94b9729602f0b4dd73ff67edc2b7269af782182a2c02f44246ffe7f10f",
                   "sha256:b560a8a185100a7c80e6c32f69ba65ce17004156f7218cf183249b15c13295cc",
                   "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+                  "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+                  "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
                   "sha256:db9075646bed11355faf8b425c655a40a55436715a9f401f60e205ddd66edfeb",
                   "sha256:6809839757bd05082ca1b8d23eac617898eda3ce34844a0d31b0a030c8cc6653",
                   "sha256:d243985eed87e395c99f05ecfda5a55884d1e7df6f02f5ee01fcc76f520c9f1a",
@@ -1386,6 +1391,9 @@
           "sha256:23e9ff009c2316652c3bcd96a8b69b5bc26f2acd46214f652a7ce26a572cbabb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libnghttp2-1.33.0-3.el8_2.1.aarch64.rpm"
           },
+          "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm"
+          },
           "sha256:2460f610a00c11b7070ff75d27fb22fab4b8d67c856da2ffb097cf3eff28f365": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libseccomp-2.5.2-1.el8.aarch64.rpm"
           },
@@ -1451,6 +1459,9 @@
           },
           "sha256:30b0267fb252a7caf69bdb4f2458327b6907b4ce166aa61ef42143fe6027bd1f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/grubby-8.40-42.el8.aarch64.rpm"
+          },
+          "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.aarch64.rpm"
           },
           "sha256:3401ccfb7fd08c12578b6257b4dac7e94ba5f4cd70fc6a234fd90bb99d1bb108": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libtasn1-4.13-3.el8.aarch64.rpm"
@@ -1631,6 +1642,9 @@
           },
           "sha256:5441222132ae52cd31063e9b9e3bb40f2e5711dfb0c84315b4aec2907278a075": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/nettle-3.4.1-7.el8.aarch64.rpm"
+          },
+          "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm"
           },
           "sha256:548f4a211a0f93bdc6793783b5ba3104fefcfe1deef922724b91da1d299e5110": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libtdb-1.4.4-1.el8.aarch64.rpm"
@@ -2526,6 +2540,9 @@
           "sha256:f8c835839c4bea45a028976dc5dc4fe72faac67d1fbf0e9b884d008dfef4ced1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/libfastjson-0.99.9-1.el8.aarch64.rpm"
           },
+          "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm"
+          },
           "sha256:f955f857cbf4324bab7c1e880576b734bc984cd9f8b9061294a186161941efe1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libcurl-7.61.1-22.el8.aarch64.rpm"
           },
@@ -2540,6 +2557,9 @@
           },
           "sha256:fd888e489ae944e957265393f6b2ada131569459e13f30a48528a2bbb4054e58": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/python3-kickstart-3.16.14-1.el8.noarch.rpm"
+          },
+          "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm"
           },
           "sha256:ff548f5930aab3925644fc7d63d3fc71fb2f932effbe7d83a9b72b612648e32e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/grub2-efi-aa64-2.02-106.el8.aarch64.rpm"
@@ -4486,6 +4506,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4493,6 +4533,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
         "check_gpg": true
       },
       {
@@ -5573,6 +5623,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-aarch64-qcow2-boot.json
+++ b/test/data/manifests/centos_8-aarch64-qcow2-boot.json
@@ -76,7 +76,10 @@
                   "sha256:60a44cc0f7f0592cf43e62d4682ac9166b095031ec541de26746c421ead8f865",
                   "sha256:eeda2f4870339df12e346fd51871f5fc68d0fdd6c8c9d54018bef86377e09bd3",
                   "sha256:a8f80c18fec48fd84a0e573e3698f36184c489814a2e2c9a944a5361d99a0a9c",
+                  "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+                  "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
                   "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+                  "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
                   "sha256:8cbebc0fa970ceca4f479ee292eaad155084987be2cf7f97bbafe4a529319c98",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -185,6 +188,8 @@
                   "sha256:30327c94b9729602f0b4dd73ff67edc2b7269af782182a2c02f44246ffe7f10f",
                   "sha256:b560a8a185100a7c80e6c32f69ba65ce17004156f7218cf183249b15c13295cc",
                   "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+                  "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+                  "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
                   "sha256:db9075646bed11355faf8b425c655a40a55436715a9f401f60e205ddd66edfeb",
                   "sha256:6809839757bd05082ca1b8d23eac617898eda3ce34844a0d31b0a030c8cc6653",
                   "sha256:d243985eed87e395c99f05ecfda5a55884d1e7df6f02f5ee01fcc76f520c9f1a",
@@ -1361,6 +1366,9 @@
           "sha256:23e9ff009c2316652c3bcd96a8b69b5bc26f2acd46214f652a7ce26a572cbabb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libnghttp2-1.33.0-3.el8_2.1.aarch64.rpm"
           },
+          "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm"
+          },
           "sha256:2460f610a00c11b7070ff75d27fb22fab4b8d67c856da2ffb097cf3eff28f365": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libseccomp-2.5.2-1.el8.aarch64.rpm"
           },
@@ -1414,6 +1422,9 @@
           },
           "sha256:30b0267fb252a7caf69bdb4f2458327b6907b4ce166aa61ef42143fe6027bd1f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/grubby-8.40-42.el8.aarch64.rpm"
+          },
+          "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.aarch64.rpm"
           },
           "sha256:3187b5a82f1e6906539903c42b3bbd0b9979f00ae41d73c52e69e239f1090bf7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/cairo-1.15.12-3.el8.aarch64.rpm"
@@ -1579,6 +1590,9 @@
           },
           "sha256:5441222132ae52cd31063e9b9e3bb40f2e5711dfb0c84315b4aec2907278a075": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/nettle-3.4.1-7.el8.aarch64.rpm"
+          },
+          "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm"
           },
           "sha256:548f4a211a0f93bdc6793783b5ba3104fefcfe1deef922724b91da1d299e5110": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libtdb-1.4.4-1.el8.aarch64.rpm"
@@ -2462,6 +2476,9 @@
           "sha256:f8c835839c4bea45a028976dc5dc4fe72faac67d1fbf0e9b884d008dfef4ced1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/libfastjson-0.99.9-1.el8.aarch64.rpm"
           },
+          "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm"
+          },
           "sha256:f955f857cbf4324bab7c1e880576b734bc984cd9f8b9061294a186161941efe1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libcurl-7.61.1-22.el8.aarch64.rpm"
           },
@@ -2488,6 +2505,9 @@
           },
           "sha256:fe9e12b98655b4ccc8cae9ac2d9860709de999486a86456f8f9134840e70dfb3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libsoup-2.62.3-2.el8.aarch64.rpm"
+          },
+          "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm"
           },
           "sha256:ff548f5930aab3925644fc7d63d3fc71fb2f932effbe7d83a9b72b612648e32e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/grub2-efi-aa64-2.02-106.el8.aarch64.rpm"
@@ -4431,6 +4451,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4438,6 +4478,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
         "check_gpg": true
       },
       {
@@ -5518,6 +5568,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-aarch64-qcow2_customize-boot.json
@@ -134,7 +134,10 @@
                   "sha256:60a44cc0f7f0592cf43e62d4682ac9166b095031ec541de26746c421ead8f865",
                   "sha256:eeda2f4870339df12e346fd51871f5fc68d0fdd6c8c9d54018bef86377e09bd3",
                   "sha256:a8f80c18fec48fd84a0e573e3698f36184c489814a2e2c9a944a5361d99a0a9c",
+                  "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+                  "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
                   "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+                  "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
                   "sha256:8cbebc0fa970ceca4f479ee292eaad155084987be2cf7f97bbafe4a529319c98",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -243,6 +246,8 @@
                   "sha256:30327c94b9729602f0b4dd73ff67edc2b7269af782182a2c02f44246ffe7f10f",
                   "sha256:b560a8a185100a7c80e6c32f69ba65ce17004156f7218cf183249b15c13295cc",
                   "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+                  "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+                  "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
                   "sha256:db9075646bed11355faf8b425c655a40a55436715a9f401f60e205ddd66edfeb",
                   "sha256:6809839757bd05082ca1b8d23eac617898eda3ce34844a0d31b0a030c8cc6653",
                   "sha256:d243985eed87e395c99f05ecfda5a55884d1e7df6f02f5ee01fcc76f520c9f1a",
@@ -1673,6 +1678,9 @@
           "sha256:23e9ff009c2316652c3bcd96a8b69b5bc26f2acd46214f652a7ce26a572cbabb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libnghttp2-1.33.0-3.el8_2.1.aarch64.rpm"
           },
+          "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm"
+          },
           "sha256:2460f610a00c11b7070ff75d27fb22fab4b8d67c856da2ffb097cf3eff28f365": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libseccomp-2.5.2-1.el8.aarch64.rpm"
           },
@@ -1735,6 +1743,9 @@
           },
           "sha256:30b0267fb252a7caf69bdb4f2458327b6907b4ce166aa61ef42143fe6027bd1f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/grubby-8.40-42.el8.aarch64.rpm"
+          },
+          "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.aarch64.rpm"
           },
           "sha256:3187b5a82f1e6906539903c42b3bbd0b9979f00ae41d73c52e69e239f1090bf7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/cairo-1.15.12-3.el8.aarch64.rpm"
@@ -1912,6 +1923,9 @@
           },
           "sha256:5441222132ae52cd31063e9b9e3bb40f2e5711dfb0c84315b4aec2907278a075": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/nettle-3.4.1-7.el8.aarch64.rpm"
+          },
+          "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm"
           },
           "sha256:548f4a211a0f93bdc6793783b5ba3104fefcfe1deef922724b91da1d299e5110": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libtdb-1.4.4-1.el8.aarch64.rpm"
@@ -2861,6 +2875,9 @@
           "sha256:f8c835839c4bea45a028976dc5dc4fe72faac67d1fbf0e9b884d008dfef4ced1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/libfastjson-0.99.9-1.el8.aarch64.rpm"
           },
+          "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm"
+          },
           "sha256:f955f857cbf4324bab7c1e880576b734bc984cd9f8b9061294a186161941efe1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libcurl-7.61.1-22.el8.aarch64.rpm"
           },
@@ -2887,6 +2904,9 @@
           },
           "sha256:fe9e12b98655b4ccc8cae9ac2d9860709de999486a86456f8f9134840e70dfb3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libsoup-2.62.3-2.el8.aarch64.rpm"
+          },
+          "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm"
           },
           "sha256:ff548f5930aab3925644fc7d63d3fc71fb2f932effbe7d83a9b72b612648e32e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/grub2-efi-aa64-2.02-106.el8.aarch64.rpm"
@@ -6690,6 +6710,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -6697,6 +6737,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
         "check_gpg": true
       },
       {
@@ -7777,6 +7827,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-aarch64-tar-boot.json
+++ b/test/data/manifests/centos_8-aarch64-tar-boot.json
@@ -84,7 +84,10 @@
                   "sha256:60a44cc0f7f0592cf43e62d4682ac9166b095031ec541de26746c421ead8f865",
                   "sha256:eeda2f4870339df12e346fd51871f5fc68d0fdd6c8c9d54018bef86377e09bd3",
                   "sha256:a8f80c18fec48fd84a0e573e3698f36184c489814a2e2c9a944a5361d99a0a9c",
+                  "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+                  "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
                   "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+                  "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
                   "sha256:8cbebc0fa970ceca4f479ee292eaad155084987be2cf7f97bbafe4a529319c98",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -193,6 +196,8 @@
                   "sha256:30327c94b9729602f0b4dd73ff67edc2b7269af782182a2c02f44246ffe7f10f",
                   "sha256:b560a8a185100a7c80e6c32f69ba65ce17004156f7218cf183249b15c13295cc",
                   "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+                  "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+                  "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
                   "sha256:db9075646bed11355faf8b425c655a40a55436715a9f401f60e205ddd66edfeb",
                   "sha256:6809839757bd05082ca1b8d23eac617898eda3ce34844a0d31b0a030c8cc6653",
                   "sha256:d243985eed87e395c99f05ecfda5a55884d1e7df6f02f5ee01fcc76f520c9f1a",
@@ -839,6 +844,9 @@
           "sha256:23e9ff009c2316652c3bcd96a8b69b5bc26f2acd46214f652a7ce26a572cbabb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libnghttp2-1.33.0-3.el8_2.1.aarch64.rpm"
           },
+          "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm"
+          },
           "sha256:2460f610a00c11b7070ff75d27fb22fab4b8d67c856da2ffb097cf3eff28f365": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libseccomp-2.5.2-1.el8.aarch64.rpm"
           },
@@ -886,6 +894,9 @@
           },
           "sha256:30b0267fb252a7caf69bdb4f2458327b6907b4ce166aa61ef42143fe6027bd1f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/grubby-8.40-42.el8.aarch64.rpm"
+          },
+          "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.aarch64.rpm"
           },
           "sha256:3401ccfb7fd08c12578b6257b4dac7e94ba5f4cd70fc6a234fd90bb99d1bb108": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libtasn1-4.13-3.el8.aarch64.rpm"
@@ -985,6 +996,9 @@
           },
           "sha256:5441222132ae52cd31063e9b9e3bb40f2e5711dfb0c84315b4aec2907278a075": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/nettle-3.4.1-7.el8.aarch64.rpm"
+          },
+          "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm"
           },
           "sha256:54efb853142572e1c2872e351838fc3657b662722ff6b2913d1872d4752a0eb8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/cracklib-2.9.6-15.el8.aarch64.rpm"
@@ -1457,6 +1471,9 @@
           "sha256:f758b3e76f41ecb5340e7def046acd9f91242ebe7060ad2d509381584075ead8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/openssl-pkcs11-0.4.10-2.el8.aarch64.rpm"
           },
+          "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm"
+          },
           "sha256:f955f857cbf4324bab7c1e880576b734bc984cd9f8b9061294a186161941efe1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libcurl-7.61.1-22.el8.aarch64.rpm"
           },
@@ -1465,6 +1482,9 @@
           },
           "sha256:fd888e489ae944e957265393f6b2ada131569459e13f30a48528a2bbb4054e58": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/python3-kickstart-3.16.14-1.el8.noarch.rpm"
+          },
+          "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm"
           }
         }
       }
@@ -3425,6 +3445,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -3432,6 +3472,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
         "check_gpg": true
       },
       {
@@ -4512,6 +4562,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/centos_8-ppc64le-qcow2-boot.json
@@ -76,7 +76,10 @@
                   "sha256:59e910f892580bb2b86f3035a34c3ad7b5ff9c7b70a4aa81b5db970729111337",
                   "sha256:91c956afb1260fbe9ee5565c6e0efb1c7c7cc4bc586f8177f7675c78c7466b2f",
                   "sha256:694860d31a89109386570e6e665acf2a718ca11c8148df9cefbee5d537d61538",
+                  "sha256:6b897357e022602a5a5c15910ee7b6f9acb7a100ea3e11fbe63552215109b862",
+                  "sha256:136916d6ce7b0320af5b5f7e4f60b7b8878097a928c062b09632783432887019",
                   "sha256:3c1e923ff80b166ff14022502aeeec2125160495961e50e349e610f8282fe63d",
+                  "sha256:565fcd17f9a518079f39a9dbad051efd12a69d2f83a06dabab666ee610597fb1",
                   "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -191,6 +194,8 @@
                   "sha256:8904fdb492f34e5242ba483fb6b7b158342662575b3d5ac9abbc380568840d4a",
                   "sha256:6bfc201a12dc7bba21069a663aa692a96c5e8920b0d94a4e355c332d7ead15ba",
                   "sha256:e25d8b411317be99b4db057a6eb1a536866458cb16a51dec1b8eea550bbc2e8b",
+                  "sha256:cffdd3a0187e37f64f4d8f7e94ea55f17029cf89988d9bf4303590b168075d74",
+                  "sha256:fc1db576d1c7580fcbb40d0c58d5d0b6c684cf85acaa0beb30786f4efa5dff6d",
                   "sha256:f24bce642ec88622490b2f09a45fa3985da7f6511a1aae131853c4ea4c309e6b",
                   "sha256:4c5aabda0cd9edb40e141066d400d2e4b232bc22ab60e806a6399691c391cabc",
                   "sha256:9936485ac7111967d6962bc539de7b08807e310117adb78b11c21a5db0f0f890",
@@ -1306,6 +1311,9 @@
           "sha256:12fda64dea45a7b085a35a816a7d8035be6600cae38f7df04a3bc22ced4d4502": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20220208/Packages/pinentry-1.1.0-2.el8.ppc64le.rpm"
           },
+          "sha256:136916d6ce7b0320af5b5f7e4f60b7b8878097a928c062b09632783432887019": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.ppc64le.rpm"
+          },
           "sha256:14e81676d77fcc53bba97e26e90b0cedb9400343a79d0dc24237ffa6cb2dbbb6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/python3-rpm-4.14.3-21.el8.ppc64le.rpm"
           },
@@ -1654,6 +1662,9 @@
           "sha256:55f7e96bd8c560806bd26f4867a54e37eef89d6bf1a7599a335eb901cb78f991": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/polkit-libs-0.115-13.el8_5.1.ppc64le.rpm"
           },
+          "sha256:565fcd17f9a518079f39a9dbad051efd12a69d2f83a06dabab666ee610597fb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.ppc64le.rpm"
+          },
           "sha256:56c3d429ea949467dc0bca882646cf40a58fb6f27750f5664ff2919f5d38ada5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/bzip2-libs-1.0.6-26.el8.ppc64le.rpm"
           },
@@ -1824,6 +1835,9 @@
           },
           "sha256:6b588ff47d46d33b02bc296e6e5cc263d6c8ff51ee97b59ca8b34d5c45d57912": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/perl-PathTools-3.74-1.el8.ppc64le.rpm"
+          },
+          "sha256:6b897357e022602a5a5c15910ee7b6f9acb7a100ea3e11fbe63552215109b862": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.ppc64le.rpm"
           },
           "sha256:6b9875495111bcd2d3c5e9e380b3be17fb0a730891468fb45bdba3b3692b00ea": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/libusbx-1.0.23-4.el8.ppc64le.rpm"
@@ -2374,6 +2388,9 @@
           "sha256:cff4b4ac50fed2ceab6add52a66513ed9ca04b024f07a25c53df49f762eea2d2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/groff-base-1.22.3-18.el8.ppc64le.rpm"
           },
+          "sha256:cffdd3a0187e37f64f4d8f7e94ea55f17029cf89988d9bf4303590b168075d74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lvm2-2.03.14-3.el8.ppc64le.rpm"
+          },
           "sha256:d03b9f4b9848e3a88d62bcf6e536d659c325b2dc03b2136be7342b5fe5e2b6a9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/perl-Carp-1.42-396.el8.noarch.rpm"
           },
@@ -2622,6 +2639,9 @@
           },
           "sha256:fb6e437a24450106c03f25dc1c3f6b78549b82c2d0bd4387dce1350ca3c5f1f5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/libpath_utils-0.2.1-39.el8.ppc64le.rpm"
+          },
+          "sha256:fc1db576d1c7580fcbb40d0c58d5d0b6c684cf85acaa0beb30786f4efa5dff6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.ppc64le.rpm"
           },
           "sha256:fc8e4e96da6ee6201a5126473666831314938e98bf699677be296e7811f6b7dd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20220208/Packages/libXext-1.3.4-1.el8.ppc64le.rpm"
@@ -4605,6 +4625,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.ppc64le.rpm",
+        "checksum": "sha256:6b897357e022602a5a5c15910ee7b6f9acb7a100ea3e11fbe63552215109b862",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.ppc64le.rpm",
+        "checksum": "sha256:136916d6ce7b0320af5b5f7e4f60b7b8878097a928c062b09632783432887019",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4612,6 +4652,16 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.ppc64le.rpm",
         "checksum": "sha256:3c1e923ff80b166ff14022502aeeec2125160495961e50e349e610f8282fe63d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.ppc64le.rpm",
+        "checksum": "sha256:565fcd17f9a518079f39a9dbad051efd12a69d2f83a06dabab666ee610597fb1",
         "check_gpg": true
       },
       {
@@ -5752,6 +5802,26 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.ppc64le.rpm",
         "checksum": "sha256:e25d8b411317be99b4db057a6eb1a536866458cb16a51dec1b8eea550bbc2e8b",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lvm2-2.03.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:cffdd3a0187e37f64f4d8f7e94ea55f17029cf89988d9bf4303590b168075d74",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:fc1db576d1c7580fcbb40d0c58d5d0b6c684cf85acaa0beb30786f4efa5dff6d",
         "check_gpg": true
       },
       {
@@ -11622,6 +11692,15 @@
     },
     "default-target": "multi-user.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "contentdir": "centos",
         "infra": "stock",
@@ -12379,6 +12458,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -12593,6 +12715,165 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-NFV.repo": {
+          "nfv": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=NFV&infra=$infra",
+            "name": "CentOS Stream $releasever - NFV"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        },
+        "CentOS-Stream-ResilientStorage.repo": {
+          "resilientstorage": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=ResilientStorage&infra=$infra",
+            "name": "CentOS Stream $releasever - ResilientStorage"
+          }
+        },
+        "CentOS-Stream-Sources.repo": {
+          "appstream-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/AppStream/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - AppStream - Source"
+          },
+          "baseos-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/BaseOS/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - BaseOS - Source"
+          },
+          "extras-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/extras/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Extras - Source"
+          },
+          "ha-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/HighAvailability/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - HighAvailability - Source"
+          },
+          "nfv-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/NFV/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - NFV - Source"
+          },
+          "powertools-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/PowerTools/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - PowerTools - Source"
+          },
+          "resilientstorage-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/ResilientStorage/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - ResilientStorage - Source"
+          },
+          "rt-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/RT/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - RT - Source"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/centos_8-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-ppc64le-qcow2_customize-boot.json
@@ -134,7 +134,10 @@
                   "sha256:59e910f892580bb2b86f3035a34c3ad7b5ff9c7b70a4aa81b5db970729111337",
                   "sha256:91c956afb1260fbe9ee5565c6e0efb1c7c7cc4bc586f8177f7675c78c7466b2f",
                   "sha256:694860d31a89109386570e6e665acf2a718ca11c8148df9cefbee5d537d61538",
+                  "sha256:6b897357e022602a5a5c15910ee7b6f9acb7a100ea3e11fbe63552215109b862",
+                  "sha256:136916d6ce7b0320af5b5f7e4f60b7b8878097a928c062b09632783432887019",
                   "sha256:3c1e923ff80b166ff14022502aeeec2125160495961e50e349e610f8282fe63d",
+                  "sha256:565fcd17f9a518079f39a9dbad051efd12a69d2f83a06dabab666ee610597fb1",
                   "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -249,6 +252,8 @@
                   "sha256:8904fdb492f34e5242ba483fb6b7b158342662575b3d5ac9abbc380568840d4a",
                   "sha256:6bfc201a12dc7bba21069a663aa692a96c5e8920b0d94a4e355c332d7ead15ba",
                   "sha256:e25d8b411317be99b4db057a6eb1a536866458cb16a51dec1b8eea550bbc2e8b",
+                  "sha256:cffdd3a0187e37f64f4d8f7e94ea55f17029cf89988d9bf4303590b168075d74",
+                  "sha256:fc1db576d1c7580fcbb40d0c58d5d0b6c684cf85acaa0beb30786f4efa5dff6d",
                   "sha256:f24bce642ec88622490b2f09a45fa3985da7f6511a1aae131853c4ea4c309e6b",
                   "sha256:4c5aabda0cd9edb40e141066d400d2e4b232bc22ab60e806a6399691c391cabc",
                   "sha256:9936485ac7111967d6962bc539de7b08807e310117adb78b11c21a5db0f0f890",
@@ -1663,6 +1668,9 @@
           "sha256:12fda64dea45a7b085a35a816a7d8035be6600cae38f7df04a3bc22ced4d4502": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20220208/Packages/pinentry-1.1.0-2.el8.ppc64le.rpm"
           },
+          "sha256:136916d6ce7b0320af5b5f7e4f60b7b8878097a928c062b09632783432887019": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.ppc64le.rpm"
+          },
           "sha256:14e81676d77fcc53bba97e26e90b0cedb9400343a79d0dc24237ffa6cb2dbbb6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/python3-rpm-4.14.3-21.el8.ppc64le.rpm"
           },
@@ -2032,6 +2040,9 @@
           "sha256:563b3741d26b6af963fdb7b0634e0791445a707d0b6093ac71c3224299241639": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/python3-slip-dbus-0.6.4-11.el8.noarch.rpm"
           },
+          "sha256:565fcd17f9a518079f39a9dbad051efd12a69d2f83a06dabab666ee610597fb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.ppc64le.rpm"
+          },
           "sha256:56c3d429ea949467dc0bca882646cf40a58fb6f27750f5664ff2919f5d38ada5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/bzip2-libs-1.0.6-26.el8.ppc64le.rpm"
           },
@@ -2205,6 +2216,9 @@
           },
           "sha256:6b588ff47d46d33b02bc296e6e5cc263d6c8ff51ee97b59ca8b34d5c45d57912": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/perl-PathTools-3.74-1.el8.ppc64le.rpm"
+          },
+          "sha256:6b897357e022602a5a5c15910ee7b6f9acb7a100ea3e11fbe63552215109b862": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.ppc64le.rpm"
           },
           "sha256:6b9875495111bcd2d3c5e9e380b3be17fb0a730891468fb45bdba3b3692b00ea": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/libusbx-1.0.23-4.el8.ppc64le.rpm"
@@ -2812,6 +2826,9 @@
           "sha256:cff4b4ac50fed2ceab6add52a66513ed9ca04b024f07a25c53df49f762eea2d2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/groff-base-1.22.3-18.el8.ppc64le.rpm"
           },
+          "sha256:cffdd3a0187e37f64f4d8f7e94ea55f17029cf89988d9bf4303590b168075d74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lvm2-2.03.14-3.el8.ppc64le.rpm"
+          },
           "sha256:d03b9f4b9848e3a88d62bcf6e536d659c325b2dc03b2136be7342b5fe5e2b6a9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/perl-Carp-1.42-396.el8.noarch.rpm"
           },
@@ -3072,6 +3089,9 @@
           },
           "sha256:fba747b31faa9163410b9569c780ef7da697cbbcb3556907e3f1740768895444": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20220208/Packages/plymouth-core-libs-0.9.4-10.20200615git1e36e30.el8.ppc64le.rpm"
+          },
+          "sha256:fc1db576d1c7580fcbb40d0c58d5d0b6c684cf85acaa0beb30786f4efa5dff6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.ppc64le.rpm"
           },
           "sha256:fc8e4e96da6ee6201a5126473666831314938e98bf699677be296e7811f6b7dd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20220208/Packages/libXext-1.3.4-1.el8.ppc64le.rpm"
@@ -7425,6 +7445,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.ppc64le.rpm",
+        "checksum": "sha256:6b897357e022602a5a5c15910ee7b6f9acb7a100ea3e11fbe63552215109b862",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.ppc64le.rpm",
+        "checksum": "sha256:136916d6ce7b0320af5b5f7e4f60b7b8878097a928c062b09632783432887019",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -7432,6 +7472,16 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.ppc64le.rpm",
         "checksum": "sha256:3c1e923ff80b166ff14022502aeeec2125160495961e50e349e610f8282fe63d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.ppc64le.rpm",
+        "checksum": "sha256:565fcd17f9a518079f39a9dbad051efd12a69d2f83a06dabab666ee610597fb1",
         "check_gpg": true
       },
       {
@@ -8572,6 +8622,26 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.ppc64le.rpm",
         "checksum": "sha256:e25d8b411317be99b4db057a6eb1a536866458cb16a51dec1b8eea550bbc2e8b",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lvm2-2.03.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:cffdd3a0187e37f64f4d8f7e94ea55f17029cf89988d9bf4303590b168075d74",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:fc1db576d1c7580fcbb40d0c58d5d0b6c684cf85acaa0beb30786f4efa5dff6d",
         "check_gpg": true
       },
       {
@@ -14453,6 +14523,15 @@
     },
     "default-target": "multi-user.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "contentdir": "centos",
         "infra": "stock",
@@ -15270,6 +15349,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -15484,6 +15606,165 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-NFV.repo": {
+          "nfv": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=NFV&infra=$infra",
+            "name": "CentOS Stream $releasever - NFV"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        },
+        "CentOS-Stream-ResilientStorage.repo": {
+          "resilientstorage": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=ResilientStorage&infra=$infra",
+            "name": "CentOS Stream $releasever - ResilientStorage"
+          }
+        },
+        "CentOS-Stream-Sources.repo": {
+          "appstream-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/AppStream/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - AppStream - Source"
+          },
+          "baseos-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/BaseOS/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - BaseOS - Source"
+          },
+          "extras-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/extras/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Extras - Source"
+          },
+          "ha-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/HighAvailability/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - HighAvailability - Source"
+          },
+          "nfv-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/NFV/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - NFV - Source"
+          },
+          "powertools-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/PowerTools/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - PowerTools - Source"
+          },
+          "resilientstorage-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/ResilientStorage/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - ResilientStorage - Source"
+          },
+          "rt-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/RT/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - RT - Source"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/centos_8-ppc64le-tar-boot.json
+++ b/test/data/manifests/centos_8-ppc64le-tar-boot.json
@@ -84,7 +84,10 @@
                   "sha256:59e910f892580bb2b86f3035a34c3ad7b5ff9c7b70a4aa81b5db970729111337",
                   "sha256:91c956afb1260fbe9ee5565c6e0efb1c7c7cc4bc586f8177f7675c78c7466b2f",
                   "sha256:694860d31a89109386570e6e665acf2a718ca11c8148df9cefbee5d537d61538",
+                  "sha256:6b897357e022602a5a5c15910ee7b6f9acb7a100ea3e11fbe63552215109b862",
+                  "sha256:136916d6ce7b0320af5b5f7e4f60b7b8878097a928c062b09632783432887019",
                   "sha256:3c1e923ff80b166ff14022502aeeec2125160495961e50e349e610f8282fe63d",
+                  "sha256:565fcd17f9a518079f39a9dbad051efd12a69d2f83a06dabab666ee610597fb1",
                   "sha256:4f92835a6e4ee4276df49019e068d1871b75821f52b405c699bd9f199df58b80",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -199,6 +202,8 @@
                   "sha256:8904fdb492f34e5242ba483fb6b7b158342662575b3d5ac9abbc380568840d4a",
                   "sha256:6bfc201a12dc7bba21069a663aa692a96c5e8920b0d94a4e355c332d7ead15ba",
                   "sha256:e25d8b411317be99b4db057a6eb1a536866458cb16a51dec1b8eea550bbc2e8b",
+                  "sha256:cffdd3a0187e37f64f4d8f7e94ea55f17029cf89988d9bf4303590b168075d74",
+                  "sha256:fc1db576d1c7580fcbb40d0c58d5d0b6c684cf85acaa0beb30786f4efa5dff6d",
                   "sha256:f24bce642ec88622490b2f09a45fa3985da7f6511a1aae131853c4ea4c309e6b",
                   "sha256:4c5aabda0cd9edb40e141066d400d2e4b232bc22ab60e806a6399691c391cabc",
                   "sha256:9936485ac7111967d6962bc539de7b08807e310117adb78b11c21a5db0f0f890",
@@ -808,6 +813,9 @@
           "sha256:12fda64dea45a7b085a35a816a7d8035be6600cae38f7df04a3bc22ced4d4502": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-appstream-20220208/Packages/pinentry-1.1.0-2.el8.ppc64le.rpm"
           },
+          "sha256:136916d6ce7b0320af5b5f7e4f60b7b8878097a928c062b09632783432887019": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.ppc64le.rpm"
+          },
           "sha256:14e81676d77fcc53bba97e26e90b0cedb9400343a79d0dc24237ffa6cb2dbbb6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/python3-rpm-4.14.3-21.el8.ppc64le.rpm"
           },
@@ -988,6 +996,9 @@
           "sha256:55f7e96bd8c560806bd26f4867a54e37eef89d6bf1a7599a335eb901cb78f991": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/polkit-libs-0.115-13.el8_5.1.ppc64le.rpm"
           },
+          "sha256:565fcd17f9a518079f39a9dbad051efd12a69d2f83a06dabab666ee610597fb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.ppc64le.rpm"
+          },
           "sha256:56c3d429ea949467dc0bca882646cf40a58fb6f27750f5664ff2919f5d38ada5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/bzip2-libs-1.0.6-26.el8.ppc64le.rpm"
           },
@@ -1059,6 +1070,9 @@
           },
           "sha256:6b312faed4a0508da2f15d3f31a6daccfc0ec6621e5fb7b20956027dce5fa395": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/libkcapi-hmaccalc-1.2.0-2.el8.ppc64le.rpm"
+          },
+          "sha256:6b897357e022602a5a5c15910ee7b6f9acb7a100ea3e11fbe63552215109b862": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.ppc64le.rpm"
           },
           "sha256:6b9875495111bcd2d3c5e9e380b3be17fb0a730891468fb45bdba3b3692b00ea": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/libusbx-1.0.23-4.el8.ppc64le.rpm"
@@ -1354,6 +1368,9 @@
           "sha256:cdbc8f738d5b78a29b0ea4b1c5758f35f092e0c3d4df6864b79452e3ce818125": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/selinux-policy-targeted-3.14.3-89.el8.noarch.rpm"
           },
+          "sha256:cffdd3a0187e37f64f4d8f7e94ea55f17029cf89988d9bf4303590b168075d74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lvm2-2.03.14-3.el8.ppc64le.rpm"
+          },
           "sha256:d1cf2d973db2f1af46f124776b9ab4bd782e7065c8c8428a4ddef60989e4225d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/freetype-2.9.1-4.el8_3.1.ppc64le.rpm"
           },
@@ -1476,6 +1493,9 @@
           },
           "sha256:fb3fdf24f8e8e31cf23a91e1eb02c85616d9af944f7e139b19ab94f8bfa5da89": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/kmod-25-19.el8.ppc64le.rpm"
+          },
+          "sha256:fc1db576d1c7580fcbb40d0c58d5d0b6c684cf85acaa0beb30786f4efa5dff6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.ppc64le.rpm"
           },
           "sha256:fd6e1803ff367036da5b52b2183e1408691b379cc1320971bb664737507f89a4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/libkcapi-1.2.0-2.el8.ppc64le.rpm"
@@ -3461,6 +3481,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.ppc64le.rpm",
+        "checksum": "sha256:6b897357e022602a5a5c15910ee7b6f9acb7a100ea3e11fbe63552215109b862",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.ppc64le.rpm",
+        "checksum": "sha256:136916d6ce7b0320af5b5f7e4f60b7b8878097a928c062b09632783432887019",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -3468,6 +3508,16 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.ppc64le.rpm",
         "checksum": "sha256:3c1e923ff80b166ff14022502aeeec2125160495961e50e349e610f8282fe63d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.ppc64le.rpm",
+        "checksum": "sha256:565fcd17f9a518079f39a9dbad051efd12a69d2f83a06dabab666ee610597fb1",
         "check_gpg": true
       },
       {
@@ -4608,6 +4658,26 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.ppc64le.rpm",
         "checksum": "sha256:e25d8b411317be99b4db057a6eb1a536866458cb16a51dec1b8eea550bbc2e8b",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lvm2-2.03.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:cffdd3a0187e37f64f4d8f7e94ea55f17029cf89988d9bf4303590b168075d74",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:fc1db576d1c7580fcbb40d0c58d5d0b6c684cf85acaa0beb30786f4efa5dff6d",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-ami-boot.json
+++ b/test/data/manifests/centos_8-x86_64-ami-boot.json
@@ -62,7 +62,10 @@
                   "sha256:f060a852fe69fd60727d8f13054dee778f40803a6a945bf0c4da1eb4322aae0e",
                   "sha256:e9d060063165b110317d6450e20d563b3f1f9fff3026396b19ea37cf119b9709",
                   "sha256:b17f66c328688e7fc41c4833f26e7427afd76fe22abc245ef3bc00e51e950868",
+                  "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+                  "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
                   "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+                  "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
                   "sha256:c515d78c64a93d8b469593bff5800eccd50f24b16697ab13bdce81238c38eb77",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -176,6 +179,8 @@
                   "sha256:00d537a434b1c2896dada83deb359d71fd005772031c73499c72f2cbd34521c5",
                   "sha256:7c2dc6044f13fe4ae04a4c1620da822a6be591b5129bf68ba98a3d8e9092f83b",
                   "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+                  "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+                  "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
                   "sha256:8ecac05bb0ec99f91026f2361f7443b9be3272582193a7836884ec473bf8f423",
                   "sha256:5c68635cb03533a38d4a42f6547c21a1d5f9952351bb01f3cf865d2621a6e634",
                   "sha256:efac6a249e1ab6e6e586db6d1f16c22c299667f464874a9612e280945077bf53",
@@ -1232,6 +1237,9 @@
           "sha256:08b76b0af07db4d3b27776a96bb7d0dc0f02b7219569676ac79036190d731d5b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libedit-3.1-23.20170329cvs.el8.x86_64.rpm"
           },
+          "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm"
+          },
           "sha256:09f91e371deb818112b4688896020b0dacf921a30087e9f26e2a17ae2f52e269": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libss-1.45.6-3.el8.x86_64.rpm"
           },
@@ -1249,6 +1257,9 @@
           },
           "sha256:0b2b79d9f8cd01090816386ad89852662b5489bbd43fbd04760f0e57c28bce4c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libusal-1.1.11-39.el8.x86_64.rpm"
+          },
+          "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm"
           },
           "sha256:0ba4d2ab0e7f3e339baf86e9bf5c78dcf918126ddff38c2e277ea29a51c2384d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/librepo-1.14.2-1.el8.x86_64.rpm"
@@ -1397,6 +1408,9 @@
           "sha256:2fbf7e0ba8e8249b45392720a851905a42de547e1b760d461a799e2d1273cd97": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/oddjob-0.34.7-1.el8.x86_64.rpm"
           },
+          "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm"
+          },
           "sha256:30fab73ee155f03dbbd99c1e30fe59dfba4ae8fdb2e7213451ccc36d6918bfcc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libmnl-1.0.4-6.el8.x86_64.rpm"
           },
@@ -1534,6 +1548,9 @@
           },
           "sha256:50f9fe79b42e27421e2709cae89d2329d16b3b31804b846ba1d0b727743c21f9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/glibc-common-2.28-189.el8.x86_64.rpm"
+          },
+          "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:51bae480875ce4f8dd76b0af177c88eb1bd33faa910dbd64e574ef8c7ada1d03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/gnutls-3.6.16-4.el8.x86_64.rpm"
@@ -1711,6 +1728,9 @@
           },
           "sha256:79e1c8b506bc6b41616c86e10cb8204a71000daf938a354b960b925f525cfe24": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libcom_err-1.45.6-3.el8.x86_64.rpm"
+          },
+          "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:7bc2e2a25b04b52a4ec5de2858e75eb07f16495d4de5f7ce926777130302cfe3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libestr-0.1.10-1.el8.x86_64.rpm"
@@ -4296,6 +4316,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4303,6 +4343,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
         "check_gpg": true
       },
       {
@@ -5433,6 +5483,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit-boot.json
@@ -63,7 +63,10 @@
                   "sha256:f060a852fe69fd60727d8f13054dee778f40803a6a945bf0c4da1eb4322aae0e",
                   "sha256:e9d060063165b110317d6450e20d563b3f1f9fff3026396b19ea37cf119b9709",
                   "sha256:b17f66c328688e7fc41c4833f26e7427afd76fe22abc245ef3bc00e51e950868",
+                  "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+                  "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
                   "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+                  "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
                   "sha256:c515d78c64a93d8b469593bff5800eccd50f24b16697ab13bdce81238c38eb77",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -180,6 +183,8 @@
                   "sha256:00d537a434b1c2896dada83deb359d71fd005772031c73499c72f2cbd34521c5",
                   "sha256:7c2dc6044f13fe4ae04a4c1620da822a6be591b5129bf68ba98a3d8e9092f83b",
                   "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+                  "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+                  "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
                   "sha256:8ecac05bb0ec99f91026f2361f7443b9be3272582193a7836884ec473bf8f423",
                   "sha256:5c68635cb03533a38d4a42f6547c21a1d5f9952351bb01f3cf865d2621a6e634",
                   "sha256:efac6a249e1ab6e6e586db6d1f16c22c299667f464874a9612e280945077bf53",
@@ -4202,6 +4207,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4209,6 +4234,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
         "check_gpg": true
       },
       {
@@ -5369,6 +5404,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit_rt-boot.json
@@ -69,7 +69,10 @@
                   "sha256:f060a852fe69fd60727d8f13054dee778f40803a6a945bf0c4da1eb4322aae0e",
                   "sha256:e9d060063165b110317d6450e20d563b3f1f9fff3026396b19ea37cf119b9709",
                   "sha256:b17f66c328688e7fc41c4833f26e7427afd76fe22abc245ef3bc00e51e950868",
+                  "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+                  "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
                   "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+                  "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
                   "sha256:c515d78c64a93d8b469593bff5800eccd50f24b16697ab13bdce81238c38eb77",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -186,6 +189,8 @@
                   "sha256:00d537a434b1c2896dada83deb359d71fd005772031c73499c72f2cbd34521c5",
                   "sha256:7c2dc6044f13fe4ae04a4c1620da822a6be591b5129bf68ba98a3d8e9092f83b",
                   "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+                  "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+                  "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
                   "sha256:8ecac05bb0ec99f91026f2361f7443b9be3272582193a7836884ec473bf8f423",
                   "sha256:5c68635cb03533a38d4a42f6547c21a1d5f9952351bb01f3cf865d2621a6e634",
                   "sha256:efac6a249e1ab6e6e586db6d1f16c22c299667f464874a9612e280945077bf53",
@@ -4178,6 +4183,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4185,6 +4210,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
         "check_gpg": true
       },
       {
@@ -5345,6 +5380,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-edge_container-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_container-boot.json
@@ -63,7 +63,10 @@
                   "sha256:f060a852fe69fd60727d8f13054dee778f40803a6a945bf0c4da1eb4322aae0e",
                   "sha256:e9d060063165b110317d6450e20d563b3f1f9fff3026396b19ea37cf119b9709",
                   "sha256:b17f66c328688e7fc41c4833f26e7427afd76fe22abc245ef3bc00e51e950868",
+                  "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+                  "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
                   "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+                  "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
                   "sha256:c515d78c64a93d8b469593bff5800eccd50f24b16697ab13bdce81238c38eb77",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -180,6 +183,8 @@
                   "sha256:00d537a434b1c2896dada83deb359d71fd005772031c73499c72f2cbd34521c5",
                   "sha256:7c2dc6044f13fe4ae04a4c1620da822a6be591b5129bf68ba98a3d8e9092f83b",
                   "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+                  "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+                  "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
                   "sha256:8ecac05bb0ec99f91026f2361f7443b9be3272582193a7836884ec473bf8f423",
                   "sha256:5c68635cb03533a38d4a42f6547c21a1d5f9952351bb01f3cf865d2621a6e634",
                   "sha256:efac6a249e1ab6e6e586db6d1f16c22c299667f464874a9612e280945077bf53",
@@ -4711,6 +4716,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4718,6 +4743,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
         "check_gpg": true
       },
       {
@@ -5878,6 +5913,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_installer-boot.json
@@ -69,7 +69,10 @@
                   "sha256:f060a852fe69fd60727d8f13054dee778f40803a6a945bf0c4da1eb4322aae0e",
                   "sha256:e9d060063165b110317d6450e20d563b3f1f9fff3026396b19ea37cf119b9709",
                   "sha256:b17f66c328688e7fc41c4833f26e7427afd76fe22abc245ef3bc00e51e950868",
+                  "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+                  "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
                   "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+                  "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
                   "sha256:c515d78c64a93d8b469593bff5800eccd50f24b16697ab13bdce81238c38eb77",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -199,6 +202,8 @@
                   "sha256:00d537a434b1c2896dada83deb359d71fd005772031c73499c72f2cbd34521c5",
                   "sha256:7c2dc6044f13fe4ae04a4c1620da822a6be591b5129bf68ba98a3d8e9092f83b",
                   "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+                  "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+                  "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
                   "sha256:8ecac05bb0ec99f91026f2361f7443b9be3272582193a7836884ec473bf8f423",
                   "sha256:5c68635cb03533a38d4a42f6547c21a1d5f9952351bb01f3cf865d2621a6e634",
                   "sha256:0e66d6845fe5c7304f4fd64575c48a528a8cdd20ffbda650ba9b37fadebdc622",
@@ -6076,6 +6081,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -6083,6 +6108,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
         "check_gpg": true
       },
       {
@@ -7373,6 +7408,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_simplified_installer-boot.json
@@ -77,7 +77,10 @@
                   "sha256:f060a852fe69fd60727d8f13054dee778f40803a6a945bf0c4da1eb4322aae0e",
                   "sha256:e9d060063165b110317d6450e20d563b3f1f9fff3026396b19ea37cf119b9709",
                   "sha256:b17f66c328688e7fc41c4833f26e7427afd76fe22abc245ef3bc00e51e950868",
+                  "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+                  "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
                   "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+                  "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
                   "sha256:c515d78c64a93d8b469593bff5800eccd50f24b16697ab13bdce81238c38eb77",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -207,6 +210,8 @@
                   "sha256:00d537a434b1c2896dada83deb359d71fd005772031c73499c72f2cbd34521c5",
                   "sha256:7c2dc6044f13fe4ae04a4c1620da822a6be591b5129bf68ba98a3d8e9092f83b",
                   "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+                  "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+                  "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
                   "sha256:8ecac05bb0ec99f91026f2361f7443b9be3272582193a7836884ec473bf8f423",
                   "sha256:5c68635cb03533a38d4a42f6547c21a1d5f9952351bb01f3cf865d2621a6e634",
                   "sha256:0e66d6845fe5c7304f4fd64575c48a528a8cdd20ffbda650ba9b37fadebdc622",
@@ -4559,6 +4564,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4566,6 +4591,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
         "check_gpg": true
       },
       {
@@ -5856,6 +5891,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-image_installer-boot.json
+++ b/test/data/manifests/centos_8-x86_64-image_installer-boot.json
@@ -64,7 +64,10 @@
                   "sha256:f060a852fe69fd60727d8f13054dee778f40803a6a945bf0c4da1eb4322aae0e",
                   "sha256:e9d060063165b110317d6450e20d563b3f1f9fff3026396b19ea37cf119b9709",
                   "sha256:b17f66c328688e7fc41c4833f26e7427afd76fe22abc245ef3bc00e51e950868",
+                  "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+                  "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
                   "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+                  "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
                   "sha256:c515d78c64a93d8b469593bff5800eccd50f24b16697ab13bdce81238c38eb77",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -192,6 +195,8 @@
                   "sha256:00d537a434b1c2896dada83deb359d71fd005772031c73499c72f2cbd34521c5",
                   "sha256:7c2dc6044f13fe4ae04a4c1620da822a6be591b5129bf68ba98a3d8e9092f83b",
                   "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+                  "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+                  "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
                   "sha256:8ecac05bb0ec99f91026f2361f7443b9be3272582193a7836884ec473bf8f423",
                   "sha256:5c68635cb03533a38d4a42f6547c21a1d5f9952351bb01f3cf865d2621a6e634",
                   "sha256:0e66d6845fe5c7304f4fd64575c48a528a8cdd20ffbda650ba9b37fadebdc622",
@@ -6812,6 +6817,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -6819,6 +6844,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
         "check_gpg": true
       },
       {
@@ -8089,6 +8124,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-openstack-boot.json
+++ b/test/data/manifests/centos_8-x86_64-openstack-boot.json
@@ -79,7 +79,10 @@
                   "sha256:f060a852fe69fd60727d8f13054dee778f40803a6a945bf0c4da1eb4322aae0e",
                   "sha256:e9d060063165b110317d6450e20d563b3f1f9fff3026396b19ea37cf119b9709",
                   "sha256:b17f66c328688e7fc41c4833f26e7427afd76fe22abc245ef3bc00e51e950868",
+                  "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+                  "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
                   "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+                  "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
                   "sha256:c515d78c64a93d8b469593bff5800eccd50f24b16697ab13bdce81238c38eb77",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -193,6 +196,8 @@
                   "sha256:00d537a434b1c2896dada83deb359d71fd005772031c73499c72f2cbd34521c5",
                   "sha256:7c2dc6044f13fe4ae04a4c1620da822a6be591b5129bf68ba98a3d8e9092f83b",
                   "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+                  "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+                  "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
                   "sha256:8ecac05bb0ec99f91026f2361f7443b9be3272582193a7836884ec473bf8f423",
                   "sha256:5c68635cb03533a38d4a42f6547c21a1d5f9952351bb01f3cf865d2621a6e634",
                   "sha256:efac6a249e1ab6e6e586db6d1f16c22c299667f464874a9612e280945077bf53",
@@ -1270,6 +1275,9 @@
           "sha256:08b76b0af07db4d3b27776a96bb7d0dc0f02b7219569676ac79036190d731d5b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libedit-3.1-23.20170329cvs.el8.x86_64.rpm"
           },
+          "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm"
+          },
           "sha256:09f91e371deb818112b4688896020b0dacf921a30087e9f26e2a17ae2f52e269": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libss-1.45.6-3.el8.x86_64.rpm"
           },
@@ -1284,6 +1292,9 @@
           },
           "sha256:0b2b79d9f8cd01090816386ad89852662b5489bbd43fbd04760f0e57c28bce4c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libusal-1.1.11-39.el8.x86_64.rpm"
+          },
+          "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm"
           },
           "sha256:0ba4d2ab0e7f3e339baf86e9bf5c78dcf918126ddff38c2e277ea29a51c2384d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/librepo-1.14.2-1.el8.x86_64.rpm"
@@ -1477,6 +1488,9 @@
           "sha256:2f056611d9f9f262946d31c60c0d16158936c83f11089dd45f08d50a3781dcd4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
           },
+          "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm"
+          },
           "sha256:30fab73ee155f03dbbd99c1e30fe59dfba4ae8fdb2e7213451ccc36d6918bfcc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libmnl-1.0.4-6.el8.x86_64.rpm"
           },
@@ -1650,6 +1664,9 @@
           },
           "sha256:50f9fe79b42e27421e2709cae89d2329d16b3b31804b846ba1d0b727743c21f9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/glibc-common-2.28-189.el8.x86_64.rpm"
+          },
+          "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:51bae480875ce4f8dd76b0af177c88eb1bd33faa910dbd64e574ef8c7ada1d03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/gnutls-3.6.16-4.el8.x86_64.rpm"
@@ -1857,6 +1874,9 @@
           },
           "sha256:7a8468bde9ee0a4bff77fdbe0add8706586ce3999eb65b91f83e805610afd276": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/iwl6050-firmware-41.28.5.1-105.el8.1.noarch.rpm"
+          },
+          "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:7bc2e2a25b04b52a4ec5de2858e75eb07f16495d4de5f7ce926777130302cfe3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libestr-0.1.10-1.el8.x86_64.rpm"
@@ -4550,6 +4570,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4557,6 +4597,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
         "check_gpg": true
       },
       {
@@ -5687,6 +5737,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-qcow2-boot.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2-boot.json
@@ -76,7 +76,10 @@
                   "sha256:f060a852fe69fd60727d8f13054dee778f40803a6a945bf0c4da1eb4322aae0e",
                   "sha256:e9d060063165b110317d6450e20d563b3f1f9fff3026396b19ea37cf119b9709",
                   "sha256:b17f66c328688e7fc41c4833f26e7427afd76fe22abc245ef3bc00e51e950868",
+                  "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+                  "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
                   "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+                  "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
                   "sha256:c515d78c64a93d8b469593bff5800eccd50f24b16697ab13bdce81238c38eb77",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -190,6 +193,8 @@
                   "sha256:00d537a434b1c2896dada83deb359d71fd005772031c73499c72f2cbd34521c5",
                   "sha256:7c2dc6044f13fe4ae04a4c1620da822a6be591b5129bf68ba98a3d8e9092f83b",
                   "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+                  "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+                  "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
                   "sha256:8ecac05bb0ec99f91026f2361f7443b9be3272582193a7836884ec473bf8f423",
                   "sha256:5c68635cb03533a38d4a42f6547c21a1d5f9952351bb01f3cf865d2621a6e634",
                   "sha256:efac6a249e1ab6e6e586db6d1f16c22c299667f464874a9612e280945077bf53",
@@ -1258,6 +1263,9 @@
           "sha256:08b76b0af07db4d3b27776a96bb7d0dc0f02b7219569676ac79036190d731d5b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libedit-3.1-23.20170329cvs.el8.x86_64.rpm"
           },
+          "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm"
+          },
           "sha256:09f91e371deb818112b4688896020b0dacf921a30087e9f26e2a17ae2f52e269": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libss-1.45.6-3.el8.x86_64.rpm"
           },
@@ -1269,6 +1277,9 @@
           },
           "sha256:0b2b79d9f8cd01090816386ad89852662b5489bbd43fbd04760f0e57c28bce4c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libusal-1.1.11-39.el8.x86_64.rpm"
+          },
+          "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm"
           },
           "sha256:0ba4d2ab0e7f3e339baf86e9bf5c78dcf918126ddff38c2e277ea29a51c2384d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/librepo-1.14.2-1.el8.x86_64.rpm"
@@ -1456,6 +1467,9 @@
           "sha256:2fcd7a063cab2e103fd4fdf8f4c63d09b9f3d60759c3b0982c75ed9a9e57bdf8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/cairo-1.15.12-3.el8.x86_64.rpm"
           },
+          "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm"
+          },
           "sha256:30fab73ee155f03dbbd99c1e30fe59dfba4ae8fdb2e7213451ccc36d6918bfcc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libmnl-1.0.4-6.el8.x86_64.rpm"
           },
@@ -1611,6 +1625,9 @@
           },
           "sha256:50f9fe79b42e27421e2709cae89d2329d16b3b31804b846ba1d0b727743c21f9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/glibc-common-2.28-189.el8.x86_64.rpm"
+          },
+          "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:51bae480875ce4f8dd76b0af177c88eb1bd33faa910dbd64e574ef8c7ada1d03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/gnutls-3.6.16-4.el8.x86_64.rpm"
@@ -1812,6 +1829,9 @@
           },
           "sha256:79e1c8b506bc6b41616c86e10cb8204a71000daf938a354b960b925f525cfe24": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libcom_err-1.45.6-3.el8.x86_64.rpm"
+          },
+          "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:7bc2e2a25b04b52a4ec5de2858e75eb07f16495d4de5f7ce926777130302cfe3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libestr-0.1.10-1.el8.x86_64.rpm"
@@ -4487,6 +4507,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4494,6 +4534,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
         "check_gpg": true
       },
       {
@@ -5624,6 +5674,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2_customize-boot.json
@@ -134,7 +134,10 @@
                   "sha256:f060a852fe69fd60727d8f13054dee778f40803a6a945bf0c4da1eb4322aae0e",
                   "sha256:e9d060063165b110317d6450e20d563b3f1f9fff3026396b19ea37cf119b9709",
                   "sha256:b17f66c328688e7fc41c4833f26e7427afd76fe22abc245ef3bc00e51e950868",
+                  "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+                  "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
                   "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+                  "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
                   "sha256:c515d78c64a93d8b469593bff5800eccd50f24b16697ab13bdce81238c38eb77",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -248,6 +251,8 @@
                   "sha256:00d537a434b1c2896dada83deb359d71fd005772031c73499c72f2cbd34521c5",
                   "sha256:7c2dc6044f13fe4ae04a4c1620da822a6be591b5129bf68ba98a3d8e9092f83b",
                   "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+                  "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+                  "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
                   "sha256:8ecac05bb0ec99f91026f2361f7443b9be3272582193a7836884ec473bf8f423",
                   "sha256:5c68635cb03533a38d4a42f6547c21a1d5f9952351bb01f3cf865d2621a6e634",
                   "sha256:efac6a249e1ab6e6e586db6d1f16c22c299667f464874a9612e280945077bf53",
@@ -1557,6 +1562,9 @@
           "sha256:08b76b0af07db4d3b27776a96bb7d0dc0f02b7219569676ac79036190d731d5b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libedit-3.1-23.20170329cvs.el8.x86_64.rpm"
           },
+          "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm"
+          },
           "sha256:09f91e371deb818112b4688896020b0dacf921a30087e9f26e2a17ae2f52e269": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libss-1.45.6-3.el8.x86_64.rpm"
           },
@@ -1568,6 +1576,9 @@
           },
           "sha256:0b2b79d9f8cd01090816386ad89852662b5489bbd43fbd04760f0e57c28bce4c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libusal-1.1.11-39.el8.x86_64.rpm"
+          },
+          "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm"
           },
           "sha256:0ba4d2ab0e7f3e339baf86e9bf5c78dcf918126ddff38c2e277ea29a51c2384d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/librepo-1.14.2-1.el8.x86_64.rpm"
@@ -1779,6 +1790,9 @@
           "sha256:2fcd7a063cab2e103fd4fdf8f4c63d09b9f3d60759c3b0982c75ed9a9e57bdf8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/cairo-1.15.12-3.el8.x86_64.rpm"
           },
+          "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm"
+          },
           "sha256:30fab73ee155f03dbbd99c1e30fe59dfba4ae8fdb2e7213451ccc36d6918bfcc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libmnl-1.0.4-6.el8.x86_64.rpm"
           },
@@ -1940,6 +1954,9 @@
           },
           "sha256:50f9fe79b42e27421e2709cae89d2329d16b3b31804b846ba1d0b727743c21f9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/glibc-common-2.28-189.el8.x86_64.rpm"
+          },
+          "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:51bae480875ce4f8dd76b0af177c88eb1bd33faa910dbd64e574ef8c7ada1d03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/gnutls-3.6.16-4.el8.x86_64.rpm"
@@ -2165,6 +2182,9 @@
           },
           "sha256:7a8468bde9ee0a4bff77fdbe0add8706586ce3999eb65b91f83e805610afd276": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/iwl6050-firmware-41.28.5.1-105.el8.1.noarch.rpm"
+          },
+          "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:7bc2e2a25b04b52a4ec5de2858e75eb07f16495d4de5f7ce926777130302cfe3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libestr-0.1.10-1.el8.x86_64.rpm"
@@ -6771,6 +6791,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -6778,6 +6818,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
         "check_gpg": true
       },
       {
@@ -7908,6 +7958,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
         "check_gpg": true
       },
       {
@@ -13373,6 +13443,15 @@
     },
     "default-target": "multi-user.target",
     "dnf": {
+      "dnf.conf": {
+        "main": {
+          "best": "True",
+          "clean_requirements_on_remove": "True",
+          "gpgcheck": "1",
+          "installonly_limit": "3",
+          "skip_if_unavailable": "False"
+        }
+      },
       "vars": {
         "contentdir": "centos",
         "infra": "stock",
@@ -14165,6 +14244,49 @@
       "tuned.service",
       "unbound-anchor.timer"
     ],
+    "ssh_config": {
+      "/etc/ssh": {
+        "ssh_config": [
+          "Include /etc/ssh/ssh_config.d/*.conf"
+        ]
+      },
+      "/etc/ssh/ssh_config.d": {
+        "05-redhat.conf": [
+          "Match final all",
+          "Include /etc/crypto-policies/back-ends/openssh.config",
+          "GSSAPIAuthentication yes",
+          "ForwardX11Trusted yes",
+          "SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "SendEnv XMODIFIERS"
+        ]
+      }
+    },
+    "sshd_config": {
+      "/etc/ssh": {
+        "sshd_config": [
+          "HostKey /etc/ssh/ssh_host_rsa_key",
+          "HostKey /etc/ssh/ssh_host_ecdsa_key",
+          "HostKey /etc/ssh/ssh_host_ed25519_key",
+          "SyslogFacility AUTHPRIV",
+          "PermitRootLogin yes",
+          "AuthorizedKeysFile\t.ssh/authorized_keys",
+          "PasswordAuthentication yes",
+          "ChallengeResponseAuthentication no",
+          "GSSAPIAuthentication yes",
+          "GSSAPICleanupCredentials no",
+          "UsePAM yes",
+          "X11Forwarding yes",
+          "PrintMotd no",
+          "AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES",
+          "AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT",
+          "AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE",
+          "AcceptEnv XMODIFIERS",
+          "Subsystem\tsftp\t/usr/libexec/openssh/sftp-server"
+        ]
+      }
+    },
     "sudoers": {
       "/etc/sudoers": [
         "Defaults   !visiblepw",
@@ -14379,6 +14501,165 @@
           "D! /tmp/.Test-unix 1777 root root 10d",
           "r! /tmp/.X[0-9]*-lock"
         ]
+      }
+    },
+    "yum_repos": {
+      "/etc/yum.repos.d": {
+        "CentOS-Stream-AppStream.repo": {
+          "appstream": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra",
+            "name": "CentOS Stream $releasever - AppStream"
+          }
+        },
+        "CentOS-Stream-BaseOS.repo": {
+          "baseos": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra",
+            "name": "CentOS Stream $releasever - BaseOS"
+          }
+        },
+        "CentOS-Stream-Debuginfo.repo": {
+          "debuginfo": {
+            "baseurl": "http://debuginfo.centos.org/$stream/$basearch/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Debuginfo"
+          }
+        },
+        "CentOS-Stream-Extras.repo": {
+          "extras": {
+            "enabled": "1",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra",
+            "name": "CentOS Stream $releasever - Extras"
+          }
+        },
+        "CentOS-Stream-HighAvailability.repo": {
+          "ha": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra",
+            "name": "CentOS Stream $releasever - HighAvailability"
+          }
+        },
+        "CentOS-Stream-Media.repo": {
+          "media-appstream": {
+            "baseurl": "file:///media/CentOS/AppStream\nfile:///media/cdrom/AppStream\nfile:///media/cdrecorder/AppStream",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - AppStream"
+          },
+          "media-baseos": {
+            "baseurl": "file:///media/CentOS/BaseOS\nfile:///media/cdrom/BaseOS\nfile:///media/cdrecorder/BaseOS",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Media - BaseOS"
+          }
+        },
+        "CentOS-Stream-NFV.repo": {
+          "nfv": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=NFV&infra=$infra",
+            "name": "CentOS Stream $releasever - NFV"
+          }
+        },
+        "CentOS-Stream-PowerTools.repo": {
+          "powertools": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra",
+            "name": "CentOS Stream $releasever - PowerTools"
+          }
+        },
+        "CentOS-Stream-RealTime.repo": {
+          "rt": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra",
+            "name": "CentOS Stream $releasever - RealTime"
+          }
+        },
+        "CentOS-Stream-ResilientStorage.repo": {
+          "resilientstorage": {
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "mirrorlist": "http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=ResilientStorage&infra=$infra",
+            "name": "CentOS Stream $releasever - ResilientStorage"
+          }
+        },
+        "CentOS-Stream-Sources.repo": {
+          "appstream-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/AppStream/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - AppStream - Source"
+          },
+          "baseos-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/BaseOS/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - BaseOS - Source"
+          },
+          "extras-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/extras/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - Extras - Source"
+          },
+          "ha-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/HighAvailability/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - HighAvailability - Source"
+          },
+          "nfv-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/NFV/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - NFV - Source"
+          },
+          "powertools-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/PowerTools/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - PowerTools - Source"
+          },
+          "resilientstorage-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/ResilientStorage/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - ResilientStorage - Source"
+          },
+          "rt-source": {
+            "baseurl": "http://vault.centos.org/$contentdir/$stream/RT/Source/",
+            "enabled": "0",
+            "gpgcheck": "1",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+            "name": "CentOS Stream $releasever - RT - Source"
+          }
+        }
       }
     }
   }

--- a/test/data/manifests/centos_8-x86_64-tar-boot.json
+++ b/test/data/manifests/centos_8-x86_64-tar-boot.json
@@ -84,7 +84,10 @@
                   "sha256:f060a852fe69fd60727d8f13054dee778f40803a6a945bf0c4da1eb4322aae0e",
                   "sha256:e9d060063165b110317d6450e20d563b3f1f9fff3026396b19ea37cf119b9709",
                   "sha256:b17f66c328688e7fc41c4833f26e7427afd76fe22abc245ef3bc00e51e950868",
+                  "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+                  "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
                   "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+                  "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
                   "sha256:c515d78c64a93d8b469593bff5800eccd50f24b16697ab13bdce81238c38eb77",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -198,6 +201,8 @@
                   "sha256:00d537a434b1c2896dada83deb359d71fd005772031c73499c72f2cbd34521c5",
                   "sha256:7c2dc6044f13fe4ae04a4c1620da822a6be591b5129bf68ba98a3d8e9092f83b",
                   "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+                  "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+                  "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
                   "sha256:8ecac05bb0ec99f91026f2361f7443b9be3272582193a7836884ec473bf8f423",
                   "sha256:5c68635cb03533a38d4a42f6547c21a1d5f9952351bb01f3cf865d2621a6e634",
                   "sha256:efac6a249e1ab6e6e586db6d1f16c22c299667f464874a9612e280945077bf53",
@@ -784,6 +789,9 @@
           "sha256:06e3b40456f9be68076d03cf7181cbe0d73bf0a9424ab9e3abb7abf634ad3c47": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/kbd-2.0.4-10.el8.x86_64.rpm"
           },
+          "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm"
+          },
           "sha256:09f91e371deb818112b4688896020b0dacf921a30087e9f26e2a17ae2f52e269": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libss-1.45.6-3.el8.x86_64.rpm"
           },
@@ -792,6 +800,9 @@
           },
           "sha256:0b2b79d9f8cd01090816386ad89852662b5489bbd43fbd04760f0e57c28bce4c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libusal-1.1.11-39.el8.x86_64.rpm"
+          },
+          "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm"
           },
           "sha256:0ba4d2ab0e7f3e339baf86e9bf5c78dcf918126ddff38c2e277ea29a51c2384d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/librepo-1.14.2-1.el8.x86_64.rpm"
@@ -876,6 +887,9 @@
           },
           "sha256:2f056611d9f9f262946d31c60c0d16158936c83f11089dd45f08d50a3781dcd4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
+          },
+          "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm"
           },
           "sha256:33996f2476ed82d68353ac5c6d22c204db4ee76821eefc4c0cc2dafcf44ae16b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/syslinux-6.04-5.el8.x86_64.rpm"
@@ -984,6 +998,9 @@
           },
           "sha256:50f9fe79b42e27421e2709cae89d2329d16b3b31804b846ba1d0b727743c21f9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/glibc-common-2.28-189.el8.x86_64.rpm"
+          },
+          "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:51bae480875ce4f8dd76b0af177c88eb1bd33faa910dbd64e574ef8c7ada1d03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/gnutls-3.6.16-4.el8.x86_64.rpm"
@@ -1101,6 +1118,9 @@
           },
           "sha256:79e1c8b506bc6b41616c86e10cb8204a71000daf938a354b960b925f525cfe24": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libcom_err-1.45.6-3.el8.x86_64.rpm"
+          },
+          "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:7c2dc6044f13fe4ae04a4c1620da822a6be591b5129bf68ba98a3d8e9092f83b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libzstd-1.4.4-1.el8.x86_64.rpm"
@@ -3457,6 +3477,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -3464,6 +3504,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
         "check_gpg": true
       },
       {
@@ -4594,6 +4644,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-vhd-boot.json
+++ b/test/data/manifests/centos_8-x86_64-vhd-boot.json
@@ -76,7 +76,10 @@
                   "sha256:f060a852fe69fd60727d8f13054dee778f40803a6a945bf0c4da1eb4322aae0e",
                   "sha256:e9d060063165b110317d6450e20d563b3f1f9fff3026396b19ea37cf119b9709",
                   "sha256:b17f66c328688e7fc41c4833f26e7427afd76fe22abc245ef3bc00e51e950868",
+                  "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+                  "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
                   "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+                  "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
                   "sha256:c515d78c64a93d8b469593bff5800eccd50f24b16697ab13bdce81238c38eb77",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -190,6 +193,8 @@
                   "sha256:00d537a434b1c2896dada83deb359d71fd005772031c73499c72f2cbd34521c5",
                   "sha256:7c2dc6044f13fe4ae04a4c1620da822a6be591b5129bf68ba98a3d8e9092f83b",
                   "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+                  "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+                  "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
                   "sha256:8ecac05bb0ec99f91026f2361f7443b9be3272582193a7836884ec473bf8f423",
                   "sha256:5c68635cb03533a38d4a42f6547c21a1d5f9952351bb01f3cf865d2621a6e634",
                   "sha256:efac6a249e1ab6e6e586db6d1f16c22c299667f464874a9612e280945077bf53",
@@ -1272,6 +1277,9 @@
           "sha256:08b76b0af07db4d3b27776a96bb7d0dc0f02b7219569676ac79036190d731d5b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libedit-3.1-23.20170329cvs.el8.x86_64.rpm"
           },
+          "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm"
+          },
           "sha256:09f91e371deb818112b4688896020b0dacf921a30087e9f26e2a17ae2f52e269": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libss-1.45.6-3.el8.x86_64.rpm"
           },
@@ -1286,6 +1294,9 @@
           },
           "sha256:0b2b79d9f8cd01090816386ad89852662b5489bbd43fbd04760f0e57c28bce4c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libusal-1.1.11-39.el8.x86_64.rpm"
+          },
+          "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm"
           },
           "sha256:0ba4d2ab0e7f3e339baf86e9bf5c78dcf918126ddff38c2e277ea29a51c2384d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/librepo-1.14.2-1.el8.x86_64.rpm"
@@ -1473,6 +1484,9 @@
           "sha256:2f056611d9f9f262946d31c60c0d16158936c83f11089dd45f08d50a3781dcd4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
           },
+          "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm"
+          },
           "sha256:30fab73ee155f03dbbd99c1e30fe59dfba4ae8fdb2e7213451ccc36d6918bfcc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libmnl-1.0.4-6.el8.x86_64.rpm"
           },
@@ -1640,6 +1654,9 @@
           },
           "sha256:50f9fe79b42e27421e2709cae89d2329d16b3b31804b846ba1d0b727743c21f9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/glibc-common-2.28-189.el8.x86_64.rpm"
+          },
+          "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:51bae480875ce4f8dd76b0af177c88eb1bd33faa910dbd64e574ef8c7ada1d03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/gnutls-3.6.16-4.el8.x86_64.rpm"
@@ -1841,6 +1858,9 @@
           },
           "sha256:7a8468bde9ee0a4bff77fdbe0add8706586ce3999eb65b91f83e805610afd276": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/iwl6050-firmware-41.28.5.1-105.el8.1.noarch.rpm"
+          },
+          "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:7bc2e2a25b04b52a4ec5de2858e75eb07f16495d4de5f7ce926777130302cfe3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libestr-0.1.10-1.el8.x86_64.rpm"
@@ -4531,6 +4551,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4538,6 +4578,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
         "check_gpg": true
       },
       {
@@ -5668,6 +5718,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_8-x86_64-vmdk-boot.json
+++ b/test/data/manifests/centos_8-x86_64-vmdk-boot.json
@@ -76,7 +76,10 @@
                   "sha256:f060a852fe69fd60727d8f13054dee778f40803a6a945bf0c4da1eb4322aae0e",
                   "sha256:e9d060063165b110317d6450e20d563b3f1f9fff3026396b19ea37cf119b9709",
                   "sha256:b17f66c328688e7fc41c4833f26e7427afd76fe22abc245ef3bc00e51e950868",
+                  "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+                  "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
                   "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+                  "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
                   "sha256:c515d78c64a93d8b469593bff5800eccd50f24b16697ab13bdce81238c38eb77",
                   "sha256:c5f76d4032450cc3fed58ec54604c64fb102a2442eaea44929863dba3f07a727",
                   "sha256:74028102daef17fb520fd7f373da7153b4ea5faeab77da8f4be3c422bc21acac",
@@ -190,6 +193,8 @@
                   "sha256:00d537a434b1c2896dada83deb359d71fd005772031c73499c72f2cbd34521c5",
                   "sha256:7c2dc6044f13fe4ae04a4c1620da822a6be591b5129bf68ba98a3d8e9092f83b",
                   "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+                  "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+                  "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
                   "sha256:8ecac05bb0ec99f91026f2361f7443b9be3272582193a7836884ec473bf8f423",
                   "sha256:5c68635cb03533a38d4a42f6547c21a1d5f9952351bb01f3cf865d2621a6e634",
                   "sha256:efac6a249e1ab6e6e586db6d1f16c22c299667f464874a9612e280945077bf53",
@@ -1220,6 +1225,9 @@
           "sha256:08b76b0af07db4d3b27776a96bb7d0dc0f02b7219569676ac79036190d731d5b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libedit-3.1-23.20170329cvs.el8.x86_64.rpm"
           },
+          "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm"
+          },
           "sha256:09f91e371deb818112b4688896020b0dacf921a30087e9f26e2a17ae2f52e269": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libss-1.45.6-3.el8.x86_64.rpm"
           },
@@ -1234,6 +1242,9 @@
           },
           "sha256:0b2b79d9f8cd01090816386ad89852662b5489bbd43fbd04760f0e57c28bce4c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libusal-1.1.11-39.el8.x86_64.rpm"
+          },
+          "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm"
           },
           "sha256:0ba4d2ab0e7f3e339baf86e9bf5c78dcf918126ddff38c2e277ea29a51c2384d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/librepo-1.14.2-1.el8.x86_64.rpm"
@@ -1406,6 +1417,9 @@
           "sha256:2f056611d9f9f262946d31c60c0d16158936c83f11089dd45f08d50a3781dcd4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/openssl-pkcs11-0.4.10-2.el8.x86_64.rpm"
           },
+          "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm"
+          },
           "sha256:30fab73ee155f03dbbd99c1e30fe59dfba4ae8fdb2e7213451ccc36d6918bfcc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libmnl-1.0.4-6.el8.x86_64.rpm"
           },
@@ -1573,6 +1587,9 @@
           },
           "sha256:50f9fe79b42e27421e2709cae89d2329d16b3b31804b846ba1d0b727743c21f9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/glibc-common-2.28-189.el8.x86_64.rpm"
+          },
+          "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:51bae480875ce4f8dd76b0af177c88eb1bd33faa910dbd64e574ef8c7ada1d03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/gnutls-3.6.16-4.el8.x86_64.rpm"
@@ -1771,6 +1788,9 @@
           },
           "sha256:7a8468bde9ee0a4bff77fdbe0add8706586ce3999eb65b91f83e805610afd276": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/iwl6050-firmware-41.28.5.1-105.el8.1.noarch.rpm"
+          },
+          "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:7bc2e2a25b04b52a4ec5de2858e75eb07f16495d4de5f7ce926777130302cfe3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libestr-0.1.10-1.el8.x86_64.rpm"
@@ -4413,6 +4433,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4420,6 +4460,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
         "check_gpg": true
       },
       {
@@ -5550,6 +5600,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_86-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ami-boot.json
@@ -57,7 +57,10 @@
                   "sha256:e5aa0c453d330eb249f1c606b77c0e5cfde0624e75a25df54faf15ba3a2ac772",
                   "sha256:bdd0a5d8438c217f4d46817b6b84c49bc4a6ed9b56157ccc2ef90fc8058a950c",
                   "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c",
+                  "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10",
+                  "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b",
                   "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190",
+                  "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779",
                   "sha256:3a684fd5f1b1d417c6c3e9d1f0d5b846138aa06450ff246425d43d4a20bd619e",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -168,6 +171,8 @@
                   "sha256:7864fbc866ae5a3e59b4f0f114b77ff52b55e76c5388a917f82a6097f02a4db7",
                   "sha256:19d1de27d2f62b4a55735233807f70a1e8ff7551fed97ee8650dbd09c1ef50ea",
                   "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f",
+                  "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7",
+                  "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b",
                   "sha256:ab64a4ccc6b3f930aebb6413ece0031ceacdfba8ac7ee06c196b29df2f761ca1",
                   "sha256:f237a314daeeb228f767e1521edffa9e9b15b07695ba1008b0f2b6807085b9cb",
                   "sha256:a3d6ab413ed56c64f62ff28ca1f5fbfa6e6acc11faedc601a1d5268cc618b2cf",
@@ -1410,6 +1415,9 @@
           "sha256:14df7263bcc35cb6633321f36149ddadd479ca334798bb33544109a2c61a6213": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/brotli-1.0.6-3.el8.aarch64.rpm"
           },
+          "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm"
+          },
           "sha256:15225cbee50ceb615517d5e7f452123ae224c905fa298affeab24877d82089b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/qemu-img-6.2.0-5.module+el8.6.0+14025+ca131e0a.aarch64.rpm"
           },
@@ -1466,6 +1474,9 @@
           },
           "sha256:1fbb9fed42dff3f9dbc9e4fd929281408f77506423424759c2ac57b76afc3cdb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libpng-1.6.34-5.el8.aarch64.rpm"
+          },
+          "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm"
           },
           "sha256:21685a7b79484a6d684efd86af6fb23dc13aaadc534cc4c4ae3edc0ceb84051b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/ipcalc-0.2.4-4.el8.aarch64.rpm"
@@ -1577,6 +1588,9 @@
           },
           "sha256:35a0ed6756beb693895afb57e01712f38ea20bcad54a92dc8cebf3f502cd05db": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/iproute-5.15.0-2.el8.aarch64.rpm"
+          },
+          "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm"
           },
           "sha256:364478819dde1fba2deaa24ebbe617cd02321765f3c1c548e34c56596674b255": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/which-2.21-17.el8.aarch64.rpm"
@@ -1820,6 +1834,9 @@
           },
           "sha256:6b5a7bff2397ce6187ae3675e1c3d81793c1992d9ebd044a378a139536b07153": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/redhat-release-eula-8.6-0.0.el8.aarch64.rpm"
+          },
+          "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm"
           },
           "sha256:6b9830bf1e1066fcf0037e824fec6400872b68e69d40ecb2f17a6ce02432b3df": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/libblockdev-fs-2.24-8.el8.aarch64.rpm"
@@ -2591,6 +2608,9 @@
           },
           "sha256:fddf61e9024c41073442ccff0c9990fa004e9b183f391c4e3cf3853e5ae6062c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/gettext-0.19.8.1-17.el8.aarch64.rpm"
+          },
+          "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm"
           },
           "sha256:fe1a3e821eab7aafd11152c5d5b9f6cf57de36d8ef3b517e0e2f2315b062742c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-jwt-1.6.1-2.el8.noarch.rpm"
@@ -4305,6 +4325,24 @@
         "checksum": "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4312,6 +4350,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779"
       },
       {
         "name": "diffutils",
@@ -5302,6 +5349,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ec2-boot.json
@@ -65,7 +65,10 @@
                   "sha256:e5aa0c453d330eb249f1c606b77c0e5cfde0624e75a25df54faf15ba3a2ac772",
                   "sha256:bdd0a5d8438c217f4d46817b6b84c49bc4a6ed9b56157ccc2ef90fc8058a950c",
                   "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c",
+                  "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10",
+                  "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b",
                   "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190",
+                  "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779",
                   "sha256:3a684fd5f1b1d417c6c3e9d1f0d5b846138aa06450ff246425d43d4a20bd619e",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -176,6 +179,8 @@
                   "sha256:7864fbc866ae5a3e59b4f0f114b77ff52b55e76c5388a917f82a6097f02a4db7",
                   "sha256:19d1de27d2f62b4a55735233807f70a1e8ff7551fed97ee8650dbd09c1ef50ea",
                   "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f",
+                  "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7",
+                  "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b",
                   "sha256:ab64a4ccc6b3f930aebb6413ece0031ceacdfba8ac7ee06c196b29df2f761ca1",
                   "sha256:f237a314daeeb228f767e1521edffa9e9b15b07695ba1008b0f2b6807085b9cb",
                   "sha256:a3d6ab413ed56c64f62ff28ca1f5fbfa6e6acc11faedc601a1d5268cc618b2cf",
@@ -1447,6 +1452,9 @@
           "sha256:14df7263bcc35cb6633321f36149ddadd479ca334798bb33544109a2c61a6213": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/brotli-1.0.6-3.el8.aarch64.rpm"
           },
+          "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm"
+          },
           "sha256:15225cbee50ceb615517d5e7f452123ae224c905fa298affeab24877d82089b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/qemu-img-6.2.0-5.module+el8.6.0+14025+ca131e0a.aarch64.rpm"
           },
@@ -1503,6 +1511,9 @@
           },
           "sha256:1fbb9fed42dff3f9dbc9e4fd929281408f77506423424759c2ac57b76afc3cdb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libpng-1.6.34-5.el8.aarch64.rpm"
+          },
+          "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm"
           },
           "sha256:21685a7b79484a6d684efd86af6fb23dc13aaadc534cc4c4ae3edc0ceb84051b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/ipcalc-0.2.4-4.el8.aarch64.rpm"
@@ -1614,6 +1625,9 @@
           },
           "sha256:35a0ed6756beb693895afb57e01712f38ea20bcad54a92dc8cebf3f502cd05db": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/iproute-5.15.0-2.el8.aarch64.rpm"
+          },
+          "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm"
           },
           "sha256:364478819dde1fba2deaa24ebbe617cd02321765f3c1c548e34c56596674b255": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/which-2.21-17.el8.aarch64.rpm"
@@ -1857,6 +1871,9 @@
           },
           "sha256:6b5a7bff2397ce6187ae3675e1c3d81793c1992d9ebd044a378a139536b07153": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/redhat-release-eula-8.6-0.0.el8.aarch64.rpm"
+          },
+          "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm"
           },
           "sha256:6b9830bf1e1066fcf0037e824fec6400872b68e69d40ecb2f17a6ce02432b3df": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/libblockdev-fs-2.24-8.el8.aarch64.rpm"
@@ -2631,6 +2648,9 @@
           },
           "sha256:fddf61e9024c41073442ccff0c9990fa004e9b183f391c4e3cf3853e5ae6062c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/gettext-0.19.8.1-17.el8.aarch64.rpm"
+          },
+          "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm"
           },
           "sha256:fe1a3e821eab7aafd11152c5d5b9f6cf57de36d8ef3b517e0e2f2315b062742c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-jwt-1.6.1-2.el8.noarch.rpm"
@@ -4345,6 +4365,24 @@
         "checksum": "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4352,6 +4390,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779"
       },
       {
         "name": "diffutils",
@@ -5342,6 +5389,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_commit-boot.json
@@ -58,7 +58,10 @@
                   "sha256:e5aa0c453d330eb249f1c606b77c0e5cfde0624e75a25df54faf15ba3a2ac772",
                   "sha256:bdd0a5d8438c217f4d46817b6b84c49bc4a6ed9b56157ccc2ef90fc8058a950c",
                   "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c",
+                  "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10",
+                  "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b",
                   "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190",
+                  "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779",
                   "sha256:3a684fd5f1b1d417c6c3e9d1f0d5b846138aa06450ff246425d43d4a20bd619e",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -171,6 +174,8 @@
                   "sha256:7864fbc866ae5a3e59b4f0f114b77ff52b55e76c5388a917f82a6097f02a4db7",
                   "sha256:19d1de27d2f62b4a55735233807f70a1e8ff7551fed97ee8650dbd09c1ef50ea",
                   "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f",
+                  "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7",
+                  "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b",
                   "sha256:ab64a4ccc6b3f930aebb6413ece0031ceacdfba8ac7ee06c196b29df2f761ca1",
                   "sha256:f237a314daeeb228f767e1521edffa9e9b15b07695ba1008b0f2b6807085b9cb",
                   "sha256:a3d6ab413ed56c64f62ff28ca1f5fbfa6e6acc11faedc601a1d5268cc618b2cf",
@@ -3895,6 +3900,24 @@
         "checksum": "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -3902,6 +3925,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779"
       },
       {
         "name": "diffutils",
@@ -4910,6 +4942,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_container-boot.json
@@ -58,7 +58,10 @@
                   "sha256:e5aa0c453d330eb249f1c606b77c0e5cfde0624e75a25df54faf15ba3a2ac772",
                   "sha256:bdd0a5d8438c217f4d46817b6b84c49bc4a6ed9b56157ccc2ef90fc8058a950c",
                   "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c",
+                  "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10",
+                  "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b",
                   "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190",
+                  "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779",
                   "sha256:3a684fd5f1b1d417c6c3e9d1f0d5b846138aa06450ff246425d43d4a20bd619e",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -171,6 +174,8 @@
                   "sha256:7864fbc866ae5a3e59b4f0f114b77ff52b55e76c5388a917f82a6097f02a4db7",
                   "sha256:19d1de27d2f62b4a55735233807f70a1e8ff7551fed97ee8650dbd09c1ef50ea",
                   "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f",
+                  "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7",
+                  "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b",
                   "sha256:ab64a4ccc6b3f930aebb6413ece0031ceacdfba8ac7ee06c196b29df2f761ca1",
                   "sha256:f237a314daeeb228f767e1521edffa9e9b15b07695ba1008b0f2b6807085b9cb",
                   "sha256:a3d6ab413ed56c64f62ff28ca1f5fbfa6e6acc11faedc601a1d5268cc618b2cf",
@@ -4403,6 +4408,24 @@
         "checksum": "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4410,6 +4433,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779"
       },
       {
         "name": "diffutils",
@@ -5418,6 +5450,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_installer-boot.json
@@ -64,7 +64,10 @@
                   "sha256:e5aa0c453d330eb249f1c606b77c0e5cfde0624e75a25df54faf15ba3a2ac772",
                   "sha256:bdd0a5d8438c217f4d46817b6b84c49bc4a6ed9b56157ccc2ef90fc8058a950c",
                   "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c",
+                  "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10",
+                  "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b",
                   "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190",
+                  "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779",
                   "sha256:3a684fd5f1b1d417c6c3e9d1f0d5b846138aa06450ff246425d43d4a20bd619e",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -191,6 +194,8 @@
                   "sha256:7864fbc866ae5a3e59b4f0f114b77ff52b55e76c5388a917f82a6097f02a4db7",
                   "sha256:19d1de27d2f62b4a55735233807f70a1e8ff7551fed97ee8650dbd09c1ef50ea",
                   "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f",
+                  "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7",
+                  "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b",
                   "sha256:ab64a4ccc6b3f930aebb6413ece0031ceacdfba8ac7ee06c196b29df2f761ca1",
                   "sha256:f237a314daeeb228f767e1521edffa9e9b15b07695ba1008b0f2b6807085b9cb",
                   "sha256:c2644257a8e281196ba4d57dde208802f4144e0d8342a0332a926aba1717cab4",
@@ -5815,6 +5820,24 @@
         "checksum": "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -5822,6 +5845,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779"
       },
       {
         "name": "diffutils",
@@ -6956,6 +6988,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_simplified_installer-boot.json
@@ -72,7 +72,10 @@
                   "sha256:e5aa0c453d330eb249f1c606b77c0e5cfde0624e75a25df54faf15ba3a2ac772",
                   "sha256:bdd0a5d8438c217f4d46817b6b84c49bc4a6ed9b56157ccc2ef90fc8058a950c",
                   "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c",
+                  "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10",
+                  "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b",
                   "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190",
+                  "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779",
                   "sha256:3a684fd5f1b1d417c6c3e9d1f0d5b846138aa06450ff246425d43d4a20bd619e",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -199,6 +202,8 @@
                   "sha256:7864fbc866ae5a3e59b4f0f114b77ff52b55e76c5388a917f82a6097f02a4db7",
                   "sha256:19d1de27d2f62b4a55735233807f70a1e8ff7551fed97ee8650dbd09c1ef50ea",
                   "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f",
+                  "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7",
+                  "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b",
                   "sha256:ab64a4ccc6b3f930aebb6413ece0031ceacdfba8ac7ee06c196b29df2f761ca1",
                   "sha256:f237a314daeeb228f767e1521edffa9e9b15b07695ba1008b0f2b6807085b9cb",
                   "sha256:c2644257a8e281196ba4d57dde208802f4144e0d8342a0332a926aba1717cab4",
@@ -4250,6 +4255,24 @@
         "checksum": "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4257,6 +4280,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779"
       },
       {
         "name": "diffutils",
@@ -5391,6 +5423,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-image_installer-boot.json
@@ -59,7 +59,10 @@
                   "sha256:e5aa0c453d330eb249f1c606b77c0e5cfde0624e75a25df54faf15ba3a2ac772",
                   "sha256:bdd0a5d8438c217f4d46817b6b84c49bc4a6ed9b56157ccc2ef90fc8058a950c",
                   "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c",
+                  "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10",
+                  "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b",
                   "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190",
+                  "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779",
                   "sha256:3a684fd5f1b1d417c6c3e9d1f0d5b846138aa06450ff246425d43d4a20bd619e",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -184,6 +187,8 @@
                   "sha256:7864fbc866ae5a3e59b4f0f114b77ff52b55e76c5388a917f82a6097f02a4db7",
                   "sha256:19d1de27d2f62b4a55735233807f70a1e8ff7551fed97ee8650dbd09c1ef50ea",
                   "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f",
+                  "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7",
+                  "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b",
                   "sha256:ab64a4ccc6b3f930aebb6413ece0031ceacdfba8ac7ee06c196b29df2f761ca1",
                   "sha256:f237a314daeeb228f767e1521edffa9e9b15b07695ba1008b0f2b6807085b9cb",
                   "sha256:c2644257a8e281196ba4d57dde208802f4144e0d8342a0332a926aba1717cab4",
@@ -6570,6 +6575,24 @@
         "checksum": "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -6577,6 +6600,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779"
       },
       {
         "name": "diffutils",
@@ -7693,6 +7725,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-openstack-boot.json
@@ -74,7 +74,10 @@
                   "sha256:e5aa0c453d330eb249f1c606b77c0e5cfde0624e75a25df54faf15ba3a2ac772",
                   "sha256:bdd0a5d8438c217f4d46817b6b84c49bc4a6ed9b56157ccc2ef90fc8058a950c",
                   "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c",
+                  "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10",
+                  "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b",
                   "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190",
+                  "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779",
                   "sha256:3a684fd5f1b1d417c6c3e9d1f0d5b846138aa06450ff246425d43d4a20bd619e",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -185,6 +188,8 @@
                   "sha256:7864fbc866ae5a3e59b4f0f114b77ff52b55e76c5388a917f82a6097f02a4db7",
                   "sha256:19d1de27d2f62b4a55735233807f70a1e8ff7551fed97ee8650dbd09c1ef50ea",
                   "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f",
+                  "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7",
+                  "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b",
                   "sha256:ab64a4ccc6b3f930aebb6413ece0031ceacdfba8ac7ee06c196b29df2f761ca1",
                   "sha256:f237a314daeeb228f767e1521edffa9e9b15b07695ba1008b0f2b6807085b9cb",
                   "sha256:a3d6ab413ed56c64f62ff28ca1f5fbfa6e6acc11faedc601a1d5268cc618b2cf",
@@ -1318,6 +1323,9 @@
           "sha256:14df7263bcc35cb6633321f36149ddadd479ca334798bb33544109a2c61a6213": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/brotli-1.0.6-3.el8.aarch64.rpm"
           },
+          "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm"
+          },
           "sha256:15225cbee50ceb615517d5e7f452123ae224c905fa298affeab24877d82089b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/qemu-img-6.2.0-5.module+el8.6.0+14025+ca131e0a.aarch64.rpm"
           },
@@ -1383,6 +1391,9 @@
           },
           "sha256:1fbb9fed42dff3f9dbc9e4fd929281408f77506423424759c2ac57b76afc3cdb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libpng-1.6.34-5.el8.aarch64.rpm"
+          },
+          "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm"
           },
           "sha256:209c40d69eb21395ec9d6397b1c149fbd3ade25cfb4a95b0d4b280ebbf4221b4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/plymouth-scripts-0.9.4-10.20200615git1e36e30.el8.aarch64.rpm"
@@ -1500,6 +1511,9 @@
           },
           "sha256:35a0ed6756beb693895afb57e01712f38ea20bcad54a92dc8cebf3f502cd05db": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/iproute-5.15.0-2.el8.aarch64.rpm"
+          },
+          "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm"
           },
           "sha256:364478819dde1fba2deaa24ebbe617cd02321765f3c1c548e34c56596674b255": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/which-2.21-17.el8.aarch64.rpm"
@@ -1779,6 +1793,9 @@
           },
           "sha256:6b5a7bff2397ce6187ae3675e1c3d81793c1992d9ebd044a378a139536b07153": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/redhat-release-eula-8.6-0.0.el8.aarch64.rpm"
+          },
+          "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm"
           },
           "sha256:6b9830bf1e1066fcf0037e824fec6400872b68e69d40ecb2f17a6ce02432b3df": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/libblockdev-fs-2.24-8.el8.aarch64.rpm"
@@ -2595,6 +2612,9 @@
           },
           "sha256:fddf61e9024c41073442ccff0c9990fa004e9b183f391c4e3cf3853e5ae6062c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/gettext-0.19.8.1-17.el8.aarch64.rpm"
+          },
+          "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm"
           },
           "sha256:fe1a3e821eab7aafd11152c5d5b9f6cf57de36d8ef3b517e0e2f2315b062742c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-jwt-1.6.1-2.el8.noarch.rpm"
@@ -4309,6 +4329,24 @@
         "checksum": "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4316,6 +4354,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779"
       },
       {
         "name": "diffutils",
@@ -5306,6 +5353,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-qcow2-boot.json
@@ -71,7 +71,10 @@
                   "sha256:e5aa0c453d330eb249f1c606b77c0e5cfde0624e75a25df54faf15ba3a2ac772",
                   "sha256:bdd0a5d8438c217f4d46817b6b84c49bc4a6ed9b56157ccc2ef90fc8058a950c",
                   "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c",
+                  "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10",
+                  "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b",
                   "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190",
+                  "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779",
                   "sha256:3a684fd5f1b1d417c6c3e9d1f0d5b846138aa06450ff246425d43d4a20bd619e",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -182,6 +185,8 @@
                   "sha256:7864fbc866ae5a3e59b4f0f114b77ff52b55e76c5388a917f82a6097f02a4db7",
                   "sha256:19d1de27d2f62b4a55735233807f70a1e8ff7551fed97ee8650dbd09c1ef50ea",
                   "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f",
+                  "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7",
+                  "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b",
                   "sha256:ab64a4ccc6b3f930aebb6413ece0031ceacdfba8ac7ee06c196b29df2f761ca1",
                   "sha256:f237a314daeeb228f767e1521edffa9e9b15b07695ba1008b0f2b6807085b9cb",
                   "sha256:a3d6ab413ed56c64f62ff28ca1f5fbfa6e6acc11faedc601a1d5268cc618b2cf",
@@ -1330,6 +1335,9 @@
           "sha256:14df7263bcc35cb6633321f36149ddadd479ca334798bb33544109a2c61a6213": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/brotli-1.0.6-3.el8.aarch64.rpm"
           },
+          "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm"
+          },
           "sha256:15225cbee50ceb615517d5e7f452123ae224c905fa298affeab24877d82089b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/qemu-img-6.2.0-5.module+el8.6.0+14025+ca131e0a.aarch64.rpm"
           },
@@ -1392,6 +1400,9 @@
           },
           "sha256:1fbb9fed42dff3f9dbc9e4fd929281408f77506423424759c2ac57b76afc3cdb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libpng-1.6.34-5.el8.aarch64.rpm"
+          },
+          "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm"
           },
           "sha256:21685a7b79484a6d684efd86af6fb23dc13aaadc534cc4c4ae3edc0ceb84051b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/ipcalc-0.2.4-4.el8.aarch64.rpm"
@@ -1512,6 +1523,9 @@
           },
           "sha256:35a0ed6756beb693895afb57e01712f38ea20bcad54a92dc8cebf3f502cd05db": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/iproute-5.15.0-2.el8.aarch64.rpm"
+          },
+          "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm"
           },
           "sha256:364478819dde1fba2deaa24ebbe617cd02321765f3c1c548e34c56596674b255": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/which-2.21-17.el8.aarch64.rpm"
@@ -1764,6 +1778,9 @@
           },
           "sha256:6b5a7bff2397ce6187ae3675e1c3d81793c1992d9ebd044a378a139536b07153": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/redhat-release-eula-8.6-0.0.el8.aarch64.rpm"
+          },
+          "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm"
           },
           "sha256:6bceb3f3d036395f00699a5ad6f6bf26b44bff1b0cfe1624a7c2fa03d3909613": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/rpcbind-1.2.5-8.el8.aarch64.rpm"
@@ -2574,6 +2591,9 @@
           },
           "sha256:fddf61e9024c41073442ccff0c9990fa004e9b183f391c4e3cf3853e5ae6062c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/gettext-0.19.8.1-17.el8.aarch64.rpm"
+          },
+          "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm"
           },
           "sha256:fe1a3e821eab7aafd11152c5d5b9f6cf57de36d8ef3b517e0e2f2315b062742c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-jwt-1.6.1-2.el8.noarch.rpm"
@@ -4291,6 +4311,24 @@
         "checksum": "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4298,6 +4336,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779"
       },
       {
         "name": "diffutils",
@@ -5288,6 +5335,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-qcow2_customize-boot.json
@@ -129,7 +129,10 @@
                   "sha256:e5aa0c453d330eb249f1c606b77c0e5cfde0624e75a25df54faf15ba3a2ac772",
                   "sha256:bdd0a5d8438c217f4d46817b6b84c49bc4a6ed9b56157ccc2ef90fc8058a950c",
                   "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c",
+                  "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10",
+                  "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b",
                   "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190",
+                  "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779",
                   "sha256:3a684fd5f1b1d417c6c3e9d1f0d5b846138aa06450ff246425d43d4a20bd619e",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -240,6 +243,8 @@
                   "sha256:7864fbc866ae5a3e59b4f0f114b77ff52b55e76c5388a917f82a6097f02a4db7",
                   "sha256:19d1de27d2f62b4a55735233807f70a1e8ff7551fed97ee8650dbd09c1ef50ea",
                   "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f",
+                  "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7",
+                  "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b",
                   "sha256:ab64a4ccc6b3f930aebb6413ece0031ceacdfba8ac7ee06c196b29df2f761ca1",
                   "sha256:f237a314daeeb228f767e1521edffa9e9b15b07695ba1008b0f2b6807085b9cb",
                   "sha256:a3d6ab413ed56c64f62ff28ca1f5fbfa6e6acc11faedc601a1d5268cc618b2cf",
@@ -1653,6 +1658,9 @@
           "sha256:14df7263bcc35cb6633321f36149ddadd479ca334798bb33544109a2c61a6213": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/brotli-1.0.6-3.el8.aarch64.rpm"
           },
+          "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm"
+          },
           "sha256:15225cbee50ceb615517d5e7f452123ae224c905fa298affeab24877d82089b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/qemu-img-6.2.0-5.module+el8.6.0+14025+ca131e0a.aarch64.rpm"
           },
@@ -1721,6 +1729,9 @@
           },
           "sha256:1fbb9fed42dff3f9dbc9e4fd929281408f77506423424759c2ac57b76afc3cdb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libpng-1.6.34-5.el8.aarch64.rpm"
+          },
+          "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm"
           },
           "sha256:209c40d69eb21395ec9d6397b1c149fbd3ade25cfb4a95b0d4b280ebbf4221b4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/plymouth-scripts-0.9.4-10.20200615git1e36e30.el8.aarch64.rpm"
@@ -1847,6 +1858,9 @@
           },
           "sha256:35a0ed6756beb693895afb57e01712f38ea20bcad54a92dc8cebf3f502cd05db": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/iproute-5.15.0-2.el8.aarch64.rpm"
+          },
+          "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm"
           },
           "sha256:364478819dde1fba2deaa24ebbe617cd02321765f3c1c548e34c56596674b255": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/which-2.21-17.el8.aarch64.rpm"
@@ -2132,6 +2146,9 @@
           },
           "sha256:6b5a7bff2397ce6187ae3675e1c3d81793c1992d9ebd044a378a139536b07153": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/redhat-release-eula-8.6-0.0.el8.aarch64.rpm"
+          },
+          "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm"
           },
           "sha256:6bceb3f3d036395f00699a5ad6f6bf26b44bff1b0cfe1624a7c2fa03d3909613": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/rpcbind-1.2.5-8.el8.aarch64.rpm"
@@ -2993,6 +3010,9 @@
           },
           "sha256:fddf61e9024c41073442ccff0c9990fa004e9b183f391c4e3cf3853e5ae6062c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/gettext-0.19.8.1-17.el8.aarch64.rpm"
+          },
+          "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm"
           },
           "sha256:fe1a3e821eab7aafd11152c5d5b9f6cf57de36d8ef3b517e0e2f2315b062742c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-jwt-1.6.1-2.el8.noarch.rpm"
@@ -6591,6 +6611,24 @@
         "checksum": "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -6598,6 +6636,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779"
       },
       {
         "name": "diffutils",
@@ -7588,6 +7635,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-tar-boot.json
@@ -79,7 +79,10 @@
                   "sha256:e5aa0c453d330eb249f1c606b77c0e5cfde0624e75a25df54faf15ba3a2ac772",
                   "sha256:bdd0a5d8438c217f4d46817b6b84c49bc4a6ed9b56157ccc2ef90fc8058a950c",
                   "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c",
+                  "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10",
+                  "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b",
                   "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190",
+                  "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779",
                   "sha256:3a684fd5f1b1d417c6c3e9d1f0d5b846138aa06450ff246425d43d4a20bd619e",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -190,6 +193,8 @@
                   "sha256:7864fbc866ae5a3e59b4f0f114b77ff52b55e76c5388a917f82a6097f02a4db7",
                   "sha256:19d1de27d2f62b4a55735233807f70a1e8ff7551fed97ee8650dbd09c1ef50ea",
                   "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f",
+                  "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7",
+                  "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b",
                   "sha256:ab64a4ccc6b3f930aebb6413ece0031ceacdfba8ac7ee06c196b29df2f761ca1",
                   "sha256:f237a314daeeb228f767e1521edffa9e9b15b07695ba1008b0f2b6807085b9cb",
                   "sha256:a3d6ab413ed56c64f62ff28ca1f5fbfa6e6acc11faedc601a1d5268cc618b2cf",
@@ -818,6 +823,9 @@
           "sha256:14df7263bcc35cb6633321f36149ddadd479ca334798bb33544109a2c61a6213": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/brotli-1.0.6-3.el8.aarch64.rpm"
           },
+          "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm"
+          },
           "sha256:15225cbee50ceb615517d5e7f452123ae224c905fa298affeab24877d82089b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/qemu-img-6.2.0-5.module+el8.6.0+14025+ca131e0a.aarch64.rpm"
           },
@@ -847,6 +855,9 @@
           },
           "sha256:1ed3940c0466986fa38fe9d3bd5fc6370b5e62edba51f7a8359eab786b4b81ec": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-setuptools-wheel-39.2.0-6.el8.noarch.rpm"
+          },
+          "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm"
           },
           "sha256:21fc110a2347f3ecb1f5528876efc6d247b4112eec012ee86fefb68d04a9c823": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/platform-python-3.6.8-45.el8.aarch64.rpm"
@@ -919,6 +930,9 @@
           },
           "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
+          },
+          "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm"
           },
           "sha256:364478819dde1fba2deaa24ebbe617cd02321765f3c1c548e34c56596674b255": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/which-2.21-17.el8.aarch64.rpm"
@@ -1042,6 +1056,9 @@
           },
           "sha256:6b5a7bff2397ce6187ae3675e1c3d81793c1992d9ebd044a378a139536b07153": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/redhat-release-eula-8.6-0.0.el8.aarch64.rpm"
+          },
+          "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm"
           },
           "sha256:6c7897bc200eaafae407b8034db5a93d981e00dedfa1c3104ebd4405ebd21b3b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/python3-gpg-1.13.1-9.el8.aarch64.rpm"
@@ -1465,6 +1482,9 @@
           },
           "sha256:fddf61e9024c41073442ccff0c9990fa004e9b183f391c4e3cf3853e5ae6062c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/gettext-0.19.8.1-17.el8.aarch64.rpm"
+          },
+          "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm"
           }
         }
       }
@@ -3194,6 +3214,24 @@
         "checksum": "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -3201,6 +3239,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779"
       },
       {
         "name": "diffutils",
@@ -4191,6 +4238,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_86-ppc64le-qcow2-boot.json
@@ -71,7 +71,10 @@
                   "sha256:3c160aa9b6f7da7875c4ebe55c15b82522f7641b90f4e65f638f69a36058a12c",
                   "sha256:9b19502888916ac8d29dc726bfd3593dfb14dc656db28f7bc9ff5ca2911fe178",
                   "sha256:e66ce7c32295a681e3490622fb248b3d9051222b9823a3e3cb949f90bc0af52d",
+                  "sha256:5d85a1597bf6f700cca5c04578ffb9e7b31ec12978037571451d9201f9cb7925",
+                  "sha256:bf434762c1fd10027fadc23d1faf042b455c12b7d2a0482de35a1884a0459f5e",
                   "sha256:937db0c8b6f98bb907bc302bc6386f01f25e9122c0f588dad9ab38e9f8315fe4",
+                  "sha256:1b665ac7d65e2858875ffab4b613a864d3933a2c7e181f772f10de59669f1da5",
                   "sha256:e811b0abd14d296513d7900092e66d06736d42e46db06d06d845dcd260fbc665",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -188,6 +191,8 @@
                   "sha256:9f1810ee304c2827027a4dadb0142f6940c28991b5371cbe302593eece6c25e4",
                   "sha256:0143da5903a3053bbd62714904db5a7c1aba3b9ff77c97d9126a4479d3047c58",
                   "sha256:3fedcb5f53f536aef83384e91606ab2281393997095707ea723f2e9f80a3e417",
+                  "sha256:eab3bbfcaa04c6e4f277410d71ab6f1da33e2a89f6b03dacc46e02929efc369d",
+                  "sha256:a08aa2b7a53b18f540fb609dfcce1c8e70dd757e79a22cff74dae05a404f4a23",
                   "sha256:eacfb3a0ad76aadb67c4103a188c35a69d69f91dcfd6272de238cbaa087bf264",
                   "sha256:793641f96b3d5b0e67a2ffccea6f8d928ef3d4877636b6c3852341b230242cc1",
                   "sha256:487206a8846b954db51f126a8446be28c7da860864ed8e1e6397f5a3d5fdb9be",
@@ -1398,6 +1403,9 @@
           "sha256:1b54167d0c46b84f46524037038c3190876993c8a8c4f3ea2bc5864207504aad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/libsoup-2.62.3-2.el8.ppc64le.rpm"
           },
+          "sha256:1b665ac7d65e2858875ffab4b613a864d3933a2c7e181f772f10de59669f1da5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.ppc64le.rpm"
+          },
           "sha256:1c342a52b451a832c477d4b1a9ec40477f6f56a9928a807b4ab7254e7796acec": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/coreutils-8.30-12.el8.ppc64le.rpm"
           },
@@ -1811,6 +1819,9 @@
           },
           "sha256:5cff75607eb15fc00208a96a802234380667df6ac2444b2b0c81804b85c9e7af": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/libselinux-utils-2.9-5.el8.ppc64le.rpm"
+          },
+          "sha256:5d85a1597bf6f700cca5c04578ffb9e7b31ec12978037571451d9201f9cb7925": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.ppc64le.rpm"
           },
           "sha256:5d9c5b3341e9b10091a5bc66c08455ce7d9c62911fac6b759b847a46749a1adf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-appstream-n8.6-20220201/Packages/python3-jsonpointer-1.10-11.el8.noarch.rpm"
@@ -2232,6 +2243,9 @@
           "sha256:9f1810ee304c2827027a4dadb0142f6940c28991b5371cbe302593eece6c25e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/libyaml-0.1.7-5.el8.ppc64le.rpm"
           },
+          "sha256:a08aa2b7a53b18f540fb609dfcce1c8e70dd757e79a22cff74dae05a404f4a23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.ppc64le.rpm"
+          },
           "sha256:a0ea7e9b266e2499f8b47a4b30a5d55dc3d6764d276529c8995593f88147d9a6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/grubby-8.40-42.el8.ppc64le.rpm"
           },
@@ -2390,6 +2404,9 @@
           },
           "sha256:be44b47bbd3f227e25f645728e55022bbe5206afa76a955f6629bc50fe9abc53": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/libpkgconf-1.4.2-1.el8.ppc64le.rpm"
+          },
+          "sha256:bf434762c1fd10027fadc23d1faf042b455c12b7d2a0482de35a1884a0459f5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.ppc64le.rpm"
           },
           "sha256:bfb73aa106b83f03cc53bebf241b250ebcde5dd12b857d9ea74455e590f8afe5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/ethtool-5.13-1.el8.ppc64le.rpm"
@@ -2618,6 +2635,9 @@
           },
           "sha256:ea8d6dd8c5e592d79229541874e6c2521e456e0efa5386a1fde95a7ed93ee4bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/hardlink-1.3-6.el8.ppc64le.rpm"
+          },
+          "sha256:eab3bbfcaa04c6e4f277410d71ab6f1da33e2a89f6b03dacc46e02929efc369d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.ppc64le.rpm"
           },
           "sha256:eacfb3a0ad76aadb67c4103a188c35a69d69f91dcfd6272de238cbaa087bf264": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lz4-libs-1.8.3-3.el8_4.ppc64le.rpm"
@@ -4464,6 +4484,24 @@
         "checksum": "sha256:e66ce7c32295a681e3490622fb248b3d9051222b9823a3e3cb949f90bc0af52d"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.ppc64le.rpm",
+        "checksum": "sha256:5d85a1597bf6f700cca5c04578ffb9e7b31ec12978037571451d9201f9cb7925"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.ppc64le.rpm",
+        "checksum": "sha256:bf434762c1fd10027fadc23d1faf042b455c12b7d2a0482de35a1884a0459f5e"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4471,6 +4509,15 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.ppc64le.rpm",
         "checksum": "sha256:937db0c8b6f98bb907bc302bc6386f01f25e9122c0f588dad9ab38e9f8315fe4"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.ppc64le.rpm",
+        "checksum": "sha256:1b665ac7d65e2858875ffab4b613a864d3933a2c7e181f772f10de59669f1da5"
       },
       {
         "name": "diffutils",
@@ -5515,6 +5562,24 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.ppc64le.rpm",
         "checksum": "sha256:3fedcb5f53f536aef83384e91606ab2281393997095707ea723f2e9f80a3e417"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:eab3bbfcaa04c6e4f277410d71ab6f1da33e2a89f6b03dacc46e02929efc369d"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:a08aa2b7a53b18f540fb609dfcce1c8e70dd757e79a22cff74dae05a404f4a23"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-ppc64le-qcow2_customize-boot.json
@@ -129,7 +129,10 @@
                   "sha256:3c160aa9b6f7da7875c4ebe55c15b82522f7641b90f4e65f638f69a36058a12c",
                   "sha256:9b19502888916ac8d29dc726bfd3593dfb14dc656db28f7bc9ff5ca2911fe178",
                   "sha256:e66ce7c32295a681e3490622fb248b3d9051222b9823a3e3cb949f90bc0af52d",
+                  "sha256:5d85a1597bf6f700cca5c04578ffb9e7b31ec12978037571451d9201f9cb7925",
+                  "sha256:bf434762c1fd10027fadc23d1faf042b455c12b7d2a0482de35a1884a0459f5e",
                   "sha256:937db0c8b6f98bb907bc302bc6386f01f25e9122c0f588dad9ab38e9f8315fe4",
+                  "sha256:1b665ac7d65e2858875ffab4b613a864d3933a2c7e181f772f10de59669f1da5",
                   "sha256:e811b0abd14d296513d7900092e66d06736d42e46db06d06d845dcd260fbc665",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -246,6 +249,8 @@
                   "sha256:9f1810ee304c2827027a4dadb0142f6940c28991b5371cbe302593eece6c25e4",
                   "sha256:0143da5903a3053bbd62714904db5a7c1aba3b9ff77c97d9126a4479d3047c58",
                   "sha256:3fedcb5f53f536aef83384e91606ab2281393997095707ea723f2e9f80a3e417",
+                  "sha256:eab3bbfcaa04c6e4f277410d71ab6f1da33e2a89f6b03dacc46e02929efc369d",
+                  "sha256:a08aa2b7a53b18f540fb609dfcce1c8e70dd757e79a22cff74dae05a404f4a23",
                   "sha256:eacfb3a0ad76aadb67c4103a188c35a69d69f91dcfd6272de238cbaa087bf264",
                   "sha256:793641f96b3d5b0e67a2ffccea6f8d928ef3d4877636b6c3852341b230242cc1",
                   "sha256:487206a8846b954db51f126a8446be28c7da860864ed8e1e6397f5a3d5fdb9be",
@@ -1778,6 +1783,9 @@
           "sha256:1b54167d0c46b84f46524037038c3190876993c8a8c4f3ea2bc5864207504aad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/libsoup-2.62.3-2.el8.ppc64le.rpm"
           },
+          "sha256:1b665ac7d65e2858875ffab4b613a864d3933a2c7e181f772f10de59669f1da5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.ppc64le.rpm"
+          },
           "sha256:1c342a52b451a832c477d4b1a9ec40477f6f56a9928a807b4ab7254e7796acec": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/coreutils-8.30-12.el8.ppc64le.rpm"
           },
@@ -2231,6 +2239,9 @@
           "sha256:5cff75607eb15fc00208a96a802234380667df6ac2444b2b0c81804b85c9e7af": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/libselinux-utils-2.9-5.el8.ppc64le.rpm"
           },
+          "sha256:5d85a1597bf6f700cca5c04578ffb9e7b31ec12978037571451d9201f9cb7925": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.ppc64le.rpm"
+          },
           "sha256:5d9c5b3341e9b10091a5bc66c08455ce7d9c62911fac6b759b847a46749a1adf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-appstream-n8.6-20220201/Packages/python3-jsonpointer-1.10-11.el8.noarch.rpm"
           },
@@ -2678,6 +2689,9 @@
           "sha256:9f54cc44ce49dc437533bc809e794a92ae568dacb3696d2e2ee226a5ed74c7f1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/libnfnetlink-1.0.1-13.el8.ppc64le.rpm"
           },
+          "sha256:a08aa2b7a53b18f540fb609dfcce1c8e70dd757e79a22cff74dae05a404f4a23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.ppc64le.rpm"
+          },
           "sha256:a0ea7e9b266e2499f8b47a4b30a5d55dc3d6764d276529c8995593f88147d9a6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/grubby-8.40-42.el8.ppc64le.rpm"
           },
@@ -2842,6 +2856,9 @@
           },
           "sha256:be44b47bbd3f227e25f645728e55022bbe5206afa76a955f6629bc50fe9abc53": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/libpkgconf-1.4.2-1.el8.ppc64le.rpm"
+          },
+          "sha256:bf434762c1fd10027fadc23d1faf042b455c12b7d2a0482de35a1884a0459f5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.ppc64le.rpm"
           },
           "sha256:bfb73aa106b83f03cc53bebf241b250ebcde5dd12b857d9ea74455e590f8afe5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/ethtool-5.13-1.el8.ppc64le.rpm"
@@ -3085,6 +3102,9 @@
           },
           "sha256:ea8d6dd8c5e592d79229541874e6c2521e456e0efa5386a1fde95a7ed93ee4bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/hardlink-1.3-6.el8.ppc64le.rpm"
+          },
+          "sha256:eab3bbfcaa04c6e4f277410d71ab6f1da33e2a89f6b03dacc46e02929efc369d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.ppc64le.rpm"
           },
           "sha256:eacfb3a0ad76aadb67c4103a188c35a69d69f91dcfd6272de238cbaa087bf264": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lz4-libs-1.8.3-3.el8_4.ppc64le.rpm"
@@ -7274,6 +7294,24 @@
         "checksum": "sha256:e66ce7c32295a681e3490622fb248b3d9051222b9823a3e3cb949f90bc0af52d"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.ppc64le.rpm",
+        "checksum": "sha256:5d85a1597bf6f700cca5c04578ffb9e7b31ec12978037571451d9201f9cb7925"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.ppc64le.rpm",
+        "checksum": "sha256:bf434762c1fd10027fadc23d1faf042b455c12b7d2a0482de35a1884a0459f5e"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -7281,6 +7319,15 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.ppc64le.rpm",
         "checksum": "sha256:937db0c8b6f98bb907bc302bc6386f01f25e9122c0f588dad9ab38e9f8315fe4"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.ppc64le.rpm",
+        "checksum": "sha256:1b665ac7d65e2858875ffab4b613a864d3933a2c7e181f772f10de59669f1da5"
       },
       {
         "name": "diffutils",
@@ -8325,6 +8372,24 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.ppc64le.rpm",
         "checksum": "sha256:3fedcb5f53f536aef83384e91606ab2281393997095707ea723f2e9f80a3e417"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:eab3bbfcaa04c6e4f277410d71ab6f1da33e2a89f6b03dacc46e02929efc369d"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:a08aa2b7a53b18f540fb609dfcce1c8e70dd757e79a22cff74dae05a404f4a23"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_86-ppc64le-tar-boot.json
@@ -79,7 +79,10 @@
                   "sha256:3c160aa9b6f7da7875c4ebe55c15b82522f7641b90f4e65f638f69a36058a12c",
                   "sha256:9b19502888916ac8d29dc726bfd3593dfb14dc656db28f7bc9ff5ca2911fe178",
                   "sha256:e66ce7c32295a681e3490622fb248b3d9051222b9823a3e3cb949f90bc0af52d",
+                  "sha256:5d85a1597bf6f700cca5c04578ffb9e7b31ec12978037571451d9201f9cb7925",
+                  "sha256:bf434762c1fd10027fadc23d1faf042b455c12b7d2a0482de35a1884a0459f5e",
                   "sha256:937db0c8b6f98bb907bc302bc6386f01f25e9122c0f588dad9ab38e9f8315fe4",
+                  "sha256:1b665ac7d65e2858875ffab4b613a864d3933a2c7e181f772f10de59669f1da5",
                   "sha256:e811b0abd14d296513d7900092e66d06736d42e46db06d06d845dcd260fbc665",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -196,6 +199,8 @@
                   "sha256:9f1810ee304c2827027a4dadb0142f6940c28991b5371cbe302593eece6c25e4",
                   "sha256:0143da5903a3053bbd62714904db5a7c1aba3b9ff77c97d9126a4479d3047c58",
                   "sha256:3fedcb5f53f536aef83384e91606ab2281393997095707ea723f2e9f80a3e417",
+                  "sha256:eab3bbfcaa04c6e4f277410d71ab6f1da33e2a89f6b03dacc46e02929efc369d",
+                  "sha256:a08aa2b7a53b18f540fb609dfcce1c8e70dd757e79a22cff74dae05a404f4a23",
                   "sha256:eacfb3a0ad76aadb67c4103a188c35a69d69f91dcfd6272de238cbaa087bf264",
                   "sha256:793641f96b3d5b0e67a2ffccea6f8d928ef3d4877636b6c3852341b230242cc1",
                   "sha256:487206a8846b954db51f126a8446be28c7da860864ed8e1e6397f5a3d5fdb9be",
@@ -829,6 +834,9 @@
           "sha256:19cea53697bfe8b119d5287cd23025a7d52afed7faaa8fa8f7ef9e0b7d18558d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/libcurl-7.61.1-22.el8.ppc64le.rpm"
           },
+          "sha256:1b665ac7d65e2858875ffab4b613a864d3933a2c7e181f772f10de59669f1da5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.ppc64le.rpm"
+          },
           "sha256:1c342a52b451a832c477d4b1a9ec40477f6f56a9928a807b4ab7254e7796acec": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/coreutils-8.30-12.el8.ppc64le.rpm"
           },
@@ -1047,6 +1055,9 @@
           },
           "sha256:5cff75607eb15fc00208a96a802234380667df6ac2444b2b0c81804b85c9e7af": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/libselinux-utils-2.9-5.el8.ppc64le.rpm"
+          },
+          "sha256:5d85a1597bf6f700cca5c04578ffb9e7b31ec12978037571451d9201f9cb7925": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.ppc64le.rpm"
           },
           "sha256:5e9e75ce8325c762aba35886179df3de9d4fbe14d63b5d7cfc210db63055f697": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/p11-kit-trust-0.23.22-1.el8.ppc64le.rpm"
@@ -1267,6 +1278,9 @@
           "sha256:9f1810ee304c2827027a4dadb0142f6940c28991b5371cbe302593eece6c25e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/libyaml-0.1.7-5.el8.ppc64le.rpm"
           },
+          "sha256:a08aa2b7a53b18f540fb609dfcce1c8e70dd757e79a22cff74dae05a404f4a23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.ppc64le.rpm"
+          },
           "sha256:a0ea7e9b266e2499f8b47a4b30a5d55dc3d6764d276529c8995593f88147d9a6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/grubby-8.40-42.el8.ppc64le.rpm"
           },
@@ -1323,6 +1337,9 @@
           },
           "sha256:bb81cc61e1afa34dc4bbf6ddf690ad6805c15d8489dfb17f17fb8d2eb5ec2b53": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/gnutls-3.6.16-4.el8.ppc64le.rpm"
+          },
+          "sha256:bf434762c1fd10027fadc23d1faf042b455c12b7d2a0482de35a1884a0459f5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.ppc64le.rpm"
           },
           "sha256:c2f85c9746f79cd848329f46d348deca481b09fb4b4bc71cd7ab42b57e1c2a20": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/python3-idna-2.5-5.el8.noarch.rpm"
@@ -1425,6 +1442,9 @@
           },
           "sha256:ea8d6dd8c5e592d79229541874e6c2521e456e0efa5386a1fde95a7ed93ee4bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/hardlink-1.3-6.el8.ppc64le.rpm"
+          },
+          "sha256:eab3bbfcaa04c6e4f277410d71ab6f1da33e2a89f6b03dacc46e02929efc369d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.ppc64le.rpm"
           },
           "sha256:eacfb3a0ad76aadb67c4103a188c35a69d69f91dcfd6272de238cbaa087bf264": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lz4-libs-1.8.3-3.el8_4.ppc64le.rpm"
@@ -3229,6 +3249,24 @@
         "checksum": "sha256:e66ce7c32295a681e3490622fb248b3d9051222b9823a3e3cb949f90bc0af52d"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.ppc64le.rpm",
+        "checksum": "sha256:5d85a1597bf6f700cca5c04578ffb9e7b31ec12978037571451d9201f9cb7925"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.ppc64le.rpm",
+        "checksum": "sha256:bf434762c1fd10027fadc23d1faf042b455c12b7d2a0482de35a1884a0459f5e"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -3236,6 +3274,15 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.ppc64le.rpm",
         "checksum": "sha256:937db0c8b6f98bb907bc302bc6386f01f25e9122c0f588dad9ab38e9f8315fe4"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.ppc64le.rpm",
+        "checksum": "sha256:1b665ac7d65e2858875ffab4b613a864d3933a2c7e181f772f10de59669f1da5"
       },
       {
         "name": "diffutils",
@@ -4280,6 +4327,24 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.ppc64le.rpm",
         "checksum": "sha256:3fedcb5f53f536aef83384e91606ab2281393997095707ea723f2e9f80a3e417"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:eab3bbfcaa04c6e4f277410d71ab6f1da33e2a89f6b03dacc46e02929efc369d"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:a08aa2b7a53b18f540fb609dfcce1c8e70dd757e79a22cff74dae05a404f4a23"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_86-s390x-qcow2-boot.json
@@ -72,9 +72,12 @@
                   "sha256:a63feee90e0306d1149c8843d42b5b82dca247c1d17aafd018fea5344b0ec1d2",
                   "sha256:ae3acca48fb15a14ab71dbc719ef46bd3a8372f303ead085be7b664127f9d488",
                   "sha256:146bb65ce0209b7c9b66fcb9aebcab8026f76f64d1951c00ce69569d0323c00d",
+                  "sha256:8ade9d97e56e637c419e7cffb75b791d68e643f1de119255810ceff0dd51bce5",
+                  "sha256:23a5d79206aa634b2b5e7f4e1562c41c0d15790c99502b7d3504b81488fde2ec",
                   "sha256:f946ed7843095bec3e9a92c1977268a669561b7c04025acd0045312d9ee12adc",
                   "sha256:78eb0751ba931c431a0e6bc150a8715f3dc1f1c49a99b6bcf3a24a1c3e38fa8d",
                   "sha256:31b1921c733806f9c89002d34c3e6959e671857ccc688acecf5871294fafe3be",
+                  "sha256:fdf4cf3aec01335d5cfe309acfe1cb9befa4726de6724cd53bddf407e206f988",
                   "sha256:f0f8b7ec4ec783f4e6310208926f54b0bceed5476b6cebb5be9b336faaeaab0a",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -182,6 +185,8 @@
                   "sha256:7cb3803b569daf0b47be6f13b1844690a8969c9114632d61ac67fe8d5fc22f84",
                   "sha256:f21088d1bec2817dbeea1c2e237e671f68bff0eea8a56b6cf07a0bf3b5939cbe",
                   "sha256:ccdee478e3f7be0e7072a53ac12a718e96b341a96067cad49ba4d3bfea8b8df3",
+                  "sha256:a6c6398e0ad2d90578d9c4fcab2528d455af63fd1b0e6eec413bd256c7df5537",
+                  "sha256:f4394cdb3b9de902bb49315f58c27e9fc9c357a767ddd7e80ec66b7d199b2f74",
                   "sha256:3cc27152e1f40c087ebdc8056f709d4fa2283e4950eff1cc1b2f5e7c34932a60",
                   "sha256:688aeafda1a81240a27f7f8697aa1217218fd7169adeefb5fab6bc5cc0c6414e",
                   "sha256:50f706979baa13d13c3486964f129ad824e90e5fa55576afa2c1074c9a19ab6d",
@@ -1519,6 +1524,9 @@
           "sha256:22b5e76301583ada04473e99d721f3561eee6c6304072b38eeb21ec5b5397e18": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/NetworkManager-tui-1.36.0-0.4.el8.s390x.rpm"
           },
+          "sha256:23a5d79206aa634b2b5e7f4e1562c41c0d15790c99502b7d3504b81488fde2ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.s390x.rpm"
+          },
           "sha256:2429abaf8afb74f4fdc8050e4c90e315316186d372a809e062a914808d02d907": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/fuse-libs-2.9.7-12.el8.s390x.rpm"
           },
@@ -2119,6 +2127,9 @@
           "sha256:89f88f664dd68bad43769774ae58e3aabc8eb79d4d00a66271e117f0fd9357af": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/mozjs60-60.9.0-4.el8.s390x.rpm"
           },
+          "sha256:8ade9d97e56e637c419e7cffb75b791d68e643f1de119255810ceff0dd51bce5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.s390x.rpm"
+          },
           "sha256:8b0245757c52f6934a1ce7671217835f1661dc4f52be75dd070975b080a033e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/newt-0.52.20-11.el8.s390x.rpm"
           },
@@ -2292,6 +2303,9 @@
           },
           "sha256:a675421ff8b29c3c237d0173bd3fb536e7ab3b70ea7fac81ee6116a855f9a963": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/keyutils-1.5.10-9.el8.s390x.rpm"
+          },
+          "sha256:a6c6398e0ad2d90578d9c4fcab2528d455af63fd1b0e6eec413bd256c7df5537": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.s390x.rpm"
           },
           "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
@@ -2746,6 +2760,9 @@
           "sha256:f3a3c456f1b10075b9977d68e81cccf111c854ef15e388d9c1ff7f20f5934c7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-appstream-n8.6-20220201/Packages/PackageKit-glib-1.1.12-6.el8.s390x.rpm"
           },
+          "sha256:f4394cdb3b9de902bb49315f58c27e9fc9c357a767ddd7e80ec66b7d199b2f74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.s390x.rpm"
+          },
           "sha256:f446646140cdc94ba1f4cd6942c4f4515bf64f38f4307962d252dbab47c82ef8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-appstream-n8.6-20220201/Packages/python3-markupsafe-0.23-19.el8.s390x.rpm"
           },
@@ -2799,6 +2816,9 @@
           },
           "sha256:fdeac34fd6667d2cfd7ffd3332e0444151d704430f9652ba2ede3cc112ab5b36": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/hdparm-9.54-4.el8.s390x.rpm"
+          },
+          "sha256:fdf4cf3aec01335d5cfe309acfe1cb9befa4726de6724cd53bddf407e206f988": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.s390x.rpm"
           },
           "sha256:fdfde1848ded3233eadd44c677269196ef72cd8e82fd372ba2c45df4fa36a140": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/libmnl-1.0.4-6.el8.s390x.rpm"
@@ -4900,6 +4920,24 @@
         "checksum": "sha256:146bb65ce0209b7c9b66fcb9aebcab8026f76f64d1951c00ce69569d0323c00d"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.s390x.rpm",
+        "checksum": "sha256:8ade9d97e56e637c419e7cffb75b791d68e643f1de119255810ceff0dd51bce5"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.s390x.rpm",
+        "checksum": "sha256:23a5d79206aa634b2b5e7f4e1562c41c0d15790c99502b7d3504b81488fde2ec"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4925,6 +4963,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-multipath-libs-0.8.4-21.el8.s390x.rpm",
         "checksum": "sha256:31b1921c733806f9c89002d34c3e6959e671857ccc688acecf5871294fafe3be"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.s390x.rpm",
+        "checksum": "sha256:fdf4cf3aec01335d5cfe309acfe1cb9befa4726de6724cd53bddf407e206f988"
       },
       {
         "name": "diffutils",
@@ -5888,6 +5935,24 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.s390x.rpm",
         "checksum": "sha256:ccdee478e3f7be0e7072a53ac12a718e96b341a96067cad49ba4d3bfea8b8df3"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.s390x.rpm",
+        "checksum": "sha256:a6c6398e0ad2d90578d9c4fcab2528d455af63fd1b0e6eec413bd256c7df5537"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.s390x.rpm",
+        "checksum": "sha256:f4394cdb3b9de902bb49315f58c27e9fc9c357a767ddd7e80ec66b7d199b2f74"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-s390x-qcow2_customize-boot.json
@@ -130,9 +130,12 @@
                   "sha256:a63feee90e0306d1149c8843d42b5b82dca247c1d17aafd018fea5344b0ec1d2",
                   "sha256:ae3acca48fb15a14ab71dbc719ef46bd3a8372f303ead085be7b664127f9d488",
                   "sha256:146bb65ce0209b7c9b66fcb9aebcab8026f76f64d1951c00ce69569d0323c00d",
+                  "sha256:8ade9d97e56e637c419e7cffb75b791d68e643f1de119255810ceff0dd51bce5",
+                  "sha256:23a5d79206aa634b2b5e7f4e1562c41c0d15790c99502b7d3504b81488fde2ec",
                   "sha256:f946ed7843095bec3e9a92c1977268a669561b7c04025acd0045312d9ee12adc",
                   "sha256:78eb0751ba931c431a0e6bc150a8715f3dc1f1c49a99b6bcf3a24a1c3e38fa8d",
                   "sha256:31b1921c733806f9c89002d34c3e6959e671857ccc688acecf5871294fafe3be",
+                  "sha256:fdf4cf3aec01335d5cfe309acfe1cb9befa4726de6724cd53bddf407e206f988",
                   "sha256:f0f8b7ec4ec783f4e6310208926f54b0bceed5476b6cebb5be9b336faaeaab0a",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -240,6 +243,8 @@
                   "sha256:7cb3803b569daf0b47be6f13b1844690a8969c9114632d61ac67fe8d5fc22f84",
                   "sha256:f21088d1bec2817dbeea1c2e237e671f68bff0eea8a56b6cf07a0bf3b5939cbe",
                   "sha256:ccdee478e3f7be0e7072a53ac12a718e96b341a96067cad49ba4d3bfea8b8df3",
+                  "sha256:a6c6398e0ad2d90578d9c4fcab2528d455af63fd1b0e6eec413bd256c7df5537",
+                  "sha256:f4394cdb3b9de902bb49315f58c27e9fc9c357a767ddd7e80ec66b7d199b2f74",
                   "sha256:3cc27152e1f40c087ebdc8056f709d4fa2283e4950eff1cc1b2f5e7c34932a60",
                   "sha256:688aeafda1a81240a27f7f8697aa1217218fd7169adeefb5fab6bc5cc0c6414e",
                   "sha256:50f706979baa13d13c3486964f129ad824e90e5fa55576afa2c1074c9a19ab6d",
@@ -1839,6 +1844,9 @@
           "sha256:22b5e76301583ada04473e99d721f3561eee6c6304072b38eeb21ec5b5397e18": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/NetworkManager-tui-1.36.0-0.4.el8.s390x.rpm"
           },
+          "sha256:23a5d79206aa634b2b5e7f4e1562c41c0d15790c99502b7d3504b81488fde2ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.s390x.rpm"
+          },
           "sha256:2429abaf8afb74f4fdc8050e4c90e315316186d372a809e062a914808d02d907": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/fuse-libs-2.9.7-12.el8.s390x.rpm"
           },
@@ -2493,6 +2501,9 @@
           "sha256:89f88f664dd68bad43769774ae58e3aabc8eb79d4d00a66271e117f0fd9357af": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/mozjs60-60.9.0-4.el8.s390x.rpm"
           },
+          "sha256:8ade9d97e56e637c419e7cffb75b791d68e643f1de119255810ceff0dd51bce5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.s390x.rpm"
+          },
           "sha256:8b0245757c52f6934a1ce7671217835f1661dc4f52be75dd070975b080a033e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/newt-0.52.20-11.el8.s390x.rpm"
           },
@@ -2675,6 +2686,9 @@
           },
           "sha256:a675421ff8b29c3c237d0173bd3fb536e7ab3b70ea7fac81ee6116a855f9a963": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/keyutils-1.5.10-9.el8.s390x.rpm"
+          },
+          "sha256:a6c6398e0ad2d90578d9c4fcab2528d455af63fd1b0e6eec413bd256c7df5537": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.s390x.rpm"
           },
           "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
@@ -3156,6 +3170,9 @@
           "sha256:f3a3c456f1b10075b9977d68e81cccf111c854ef15e388d9c1ff7f20f5934c7c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-appstream-n8.6-20220201/Packages/PackageKit-glib-1.1.12-6.el8.s390x.rpm"
           },
+          "sha256:f4394cdb3b9de902bb49315f58c27e9fc9c357a767ddd7e80ec66b7d199b2f74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.s390x.rpm"
+          },
           "sha256:f446646140cdc94ba1f4cd6942c4f4515bf64f38f4307962d252dbab47c82ef8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-appstream-n8.6-20220201/Packages/python3-markupsafe-0.23-19.el8.s390x.rpm"
           },
@@ -3209,6 +3226,9 @@
           },
           "sha256:fdeac34fd6667d2cfd7ffd3332e0444151d704430f9652ba2ede3cc112ab5b36": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/hdparm-9.54-4.el8.s390x.rpm"
+          },
+          "sha256:fdf4cf3aec01335d5cfe309acfe1cb9befa4726de6724cd53bddf407e206f988": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.s390x.rpm"
           },
           "sha256:fdfde1848ded3233eadd44c677269196ef72cd8e82fd372ba2c45df4fa36a140": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/libmnl-1.0.4-6.el8.s390x.rpm"
@@ -7110,6 +7130,24 @@
         "checksum": "sha256:146bb65ce0209b7c9b66fcb9aebcab8026f76f64d1951c00ce69569d0323c00d"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.s390x.rpm",
+        "checksum": "sha256:8ade9d97e56e637c419e7cffb75b791d68e643f1de119255810ceff0dd51bce5"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.s390x.rpm",
+        "checksum": "sha256:23a5d79206aa634b2b5e7f4e1562c41c0d15790c99502b7d3504b81488fde2ec"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -7135,6 +7173,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-multipath-libs-0.8.4-21.el8.s390x.rpm",
         "checksum": "sha256:31b1921c733806f9c89002d34c3e6959e671857ccc688acecf5871294fafe3be"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.s390x.rpm",
+        "checksum": "sha256:fdf4cf3aec01335d5cfe309acfe1cb9befa4726de6724cd53bddf407e206f988"
       },
       {
         "name": "diffutils",
@@ -8098,6 +8145,24 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.s390x.rpm",
         "checksum": "sha256:ccdee478e3f7be0e7072a53ac12a718e96b341a96067cad49ba4d3bfea8b8df3"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.s390x.rpm",
+        "checksum": "sha256:a6c6398e0ad2d90578d9c4fcab2528d455af63fd1b0e6eec413bd256c7df5537"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.s390x.rpm",
+        "checksum": "sha256:f4394cdb3b9de902bb49315f58c27e9fc9c357a767ddd7e80ec66b7d199b2f74"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_86-s390x-tar-boot.json
@@ -80,9 +80,12 @@
                   "sha256:a63feee90e0306d1149c8843d42b5b82dca247c1d17aafd018fea5344b0ec1d2",
                   "sha256:ae3acca48fb15a14ab71dbc719ef46bd3a8372f303ead085be7b664127f9d488",
                   "sha256:146bb65ce0209b7c9b66fcb9aebcab8026f76f64d1951c00ce69569d0323c00d",
+                  "sha256:8ade9d97e56e637c419e7cffb75b791d68e643f1de119255810ceff0dd51bce5",
+                  "sha256:23a5d79206aa634b2b5e7f4e1562c41c0d15790c99502b7d3504b81488fde2ec",
                   "sha256:f946ed7843095bec3e9a92c1977268a669561b7c04025acd0045312d9ee12adc",
                   "sha256:78eb0751ba931c431a0e6bc150a8715f3dc1f1c49a99b6bcf3a24a1c3e38fa8d",
                   "sha256:31b1921c733806f9c89002d34c3e6959e671857ccc688acecf5871294fafe3be",
+                  "sha256:fdf4cf3aec01335d5cfe309acfe1cb9befa4726de6724cd53bddf407e206f988",
                   "sha256:f0f8b7ec4ec783f4e6310208926f54b0bceed5476b6cebb5be9b336faaeaab0a",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -190,6 +193,8 @@
                   "sha256:7cb3803b569daf0b47be6f13b1844690a8969c9114632d61ac67fe8d5fc22f84",
                   "sha256:f21088d1bec2817dbeea1c2e237e671f68bff0eea8a56b6cf07a0bf3b5939cbe",
                   "sha256:ccdee478e3f7be0e7072a53ac12a718e96b341a96067cad49ba4d3bfea8b8df3",
+                  "sha256:a6c6398e0ad2d90578d9c4fcab2528d455af63fd1b0e6eec413bd256c7df5537",
+                  "sha256:f4394cdb3b9de902bb49315f58c27e9fc9c357a767ddd7e80ec66b7d199b2f74",
                   "sha256:3cc27152e1f40c087ebdc8056f709d4fa2283e4950eff1cc1b2f5e7c34932a60",
                   "sha256:688aeafda1a81240a27f7f8697aa1217218fd7169adeefb5fab6bc5cc0c6414e",
                   "sha256:50f706979baa13d13c3486964f129ad824e90e5fa55576afa2c1074c9a19ab6d",
@@ -1033,6 +1038,9 @@
           "sha256:229c8ccef2cc6563fe0f808b621d61ea746c92f22671596adb89b5a61be35fc6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/coreutils-8.30-12.el8.s390x.rpm"
           },
+          "sha256:23a5d79206aa634b2b5e7f4e1562c41c0d15790c99502b7d3504b81488fde2ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.s390x.rpm"
+          },
           "sha256:2429abaf8afb74f4fdc8050e4c90e315316186d372a809e062a914808d02d907": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/fuse-libs-2.9.7-12.el8.s390x.rpm"
           },
@@ -1375,6 +1383,9 @@
           "sha256:88ce53b48e4761260142bc3088736f417df014d32c3988a000745fadd91367a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/popt-1.18-1.el8.s390x.rpm"
           },
+          "sha256:8ade9d97e56e637c419e7cffb75b791d68e643f1de119255810ceff0dd51bce5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.s390x.rpm"
+          },
           "sha256:8c399d0969bcdb0e833ca0a2bf5d310c47b80f190663598a40a047889ca12dd7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/ncurses-libs-6.1-9.20180224.el8.s390x.rpm"
           },
@@ -1476,6 +1487,9 @@
           },
           "sha256:a660c78f704d3d22458c71d86605f51d62e3cc5306d22d66bb1df86c7274ad6c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/perl-Pod-Perldoc-3.28-396.el8.noarch.rpm"
+          },
+          "sha256:a6c6398e0ad2d90578d9c4fcab2528d455af63fd1b0e6eec413bd256c7df5537": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.s390x.rpm"
           },
           "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
@@ -1732,6 +1746,9 @@
           "sha256:f21088d1bec2817dbeea1c2e237e671f68bff0eea8a56b6cf07a0bf3b5939cbe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lsscsi-0.32-3.el8.s390x.rpm"
           },
+          "sha256:f4394cdb3b9de902bb49315f58c27e9fc9c357a767ddd7e80ec66b7d199b2f74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.s390x.rpm"
+          },
           "sha256:f446646140cdc94ba1f4cd6942c4f4515bf64f38f4307962d252dbab47c82ef8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-appstream-n8.6-20220201/Packages/python3-markupsafe-0.23-19.el8.s390x.rpm"
           },
@@ -1767,6 +1784,9 @@
           },
           "sha256:fdbce603c9cb7792728413638e4d5591f0d094a361e07ff4fe0b7014a61b0104": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/perl-threads-2.21-2.el8.s390x.rpm"
+          },
+          "sha256:fdf4cf3aec01335d5cfe309acfe1cb9befa4726de6724cd53bddf407e206f988": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.s390x.rpm"
           },
           "sha256:fdfde1848ded3233eadd44c677269196ef72cd8e82fd372ba2c45df4fa36a140": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/libmnl-1.0.4-6.el8.s390x.rpm"
@@ -3883,6 +3903,24 @@
         "checksum": "sha256:146bb65ce0209b7c9b66fcb9aebcab8026f76f64d1951c00ce69569d0323c00d"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.s390x.rpm",
+        "checksum": "sha256:8ade9d97e56e637c419e7cffb75b791d68e643f1de119255810ceff0dd51bce5"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.s390x.rpm",
+        "checksum": "sha256:23a5d79206aa634b2b5e7f4e1562c41c0d15790c99502b7d3504b81488fde2ec"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -3908,6 +3946,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-multipath-libs-0.8.4-21.el8.s390x.rpm",
         "checksum": "sha256:31b1921c733806f9c89002d34c3e6959e671857ccc688acecf5871294fafe3be"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.s390x.rpm",
+        "checksum": "sha256:fdf4cf3aec01335d5cfe309acfe1cb9befa4726de6724cd53bddf407e206f988"
       },
       {
         "name": "diffutils",
@@ -4871,6 +4918,24 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.s390x.rpm",
         "checksum": "sha256:ccdee478e3f7be0e7072a53ac12a718e96b341a96067cad49ba4d3bfea8b8df3"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.s390x.rpm",
+        "checksum": "sha256:a6c6398e0ad2d90578d9c4fcab2528d455af63fd1b0e6eec413bd256c7df5537"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.s390x.rpm",
+        "checksum": "sha256:f4394cdb3b9de902bb49315f58c27e9fc9c357a767ddd7e80ec66b7d199b2f74"
       },
       {
         "name": "lz4-libs",
@@ -8198,7 +8263,7 @@
         "id": "rhel-20220124154823-4.18.0-361.el8.s390x",
         "initrd": "/boot/initramfs-4.18.0-361.el8.s390x.img",
         "linux": "/boot/vmlinuz-4.18.0-361.el8.s390x",
-        "options": "root=/dev/mapper/cs_s390x--kvm--025-root crashkernel=1G-4G:192M,4G-64G:256M,64G-:512M rd.lvm.lv=cs_s390x-kvm-025/root rd.lvm.lv=cs_s390x-kvm-025/swap",
+        "options": "root=/dev/mapper/cs_s390x--kvm--061-root crashkernel=1G-4G:192M,4G-64G:256M,64G-:512M rd.lvm.lv=cs_s390x-kvm-061/root rd.lvm.lv=cs_s390x-kvm-061/swap",
         "title": "Red Hat Enterprise Linux (4.18.0-361.el8.s390x) 8.6 (Ootpa)",
         "version": "4.18.0-361.el8.s390x"
       }

--- a/test/data/manifests/rhel_86-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ami-boot.json
@@ -57,7 +57,10 @@
                   "sha256:ca6c80d3b1ce62b1b12f1a30ca4ec018855e92b0c447bdc831a0a0644accbb6e",
                   "sha256:933071dcdeccd57028cf1c28f034bc0a091d5904a80765dae6e491c15dad4411",
                   "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8",
+                  "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35",
+                  "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc",
                   "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613",
+                  "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba",
                   "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -173,6 +176,8 @@
                   "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf",
                   "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25",
                   "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0",
+                  "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3",
+                  "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e",
                   "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc",
                   "sha256:a3dedf8c077b4656d3cd4ef641e696397a3fff83ee8b14f0e3fc69d7c10cebcf",
                   "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd",
@@ -1436,6 +1441,9 @@
           "sha256:2b7a6aa5837347ac64fcdce693ea694b9f33a96be88e35defe666df16429f12b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/glibc-langpack-en-2.28-184.el8.x86_64.rpm"
           },
+          "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm"
+          },
           "sha256:2e175740ba876aa621422ed4971794320cde1115b01ff018de7ff8186e271e48": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/authselect-1.2.2-3.el8.x86_64.rpm"
           },
@@ -1499,6 +1507,9 @@
           "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
           },
+          "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm"
+          },
           "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-unbound-1.7.3-17.el8.x86_64.rpm"
           },
@@ -1558,6 +1569,9 @@
           },
           "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libzstd-1.4.4-1.el8.x86_64.rpm"
+          },
+          "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm"
           },
           "sha256:48e0e5143bf28f7220fc3c31db376c1ef0ed129fd3d2f82e3ce8531528924fd6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dnf-plugin-subscription-manager-1.28.25-1.el8.x86_64.rpm"
@@ -2009,6 +2023,9 @@
           "sha256:a707e53534ea5e52a149edeef20f1427d7644147324e7b101e34a4cc86c6bc69": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/lorax-templates-generic-28.14.65-1.el8.x86_64.rpm"
           },
+          "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
+          },
           "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
@@ -2266,6 +2283,9 @@
           },
           "sha256:d5f93aa67f44d44c7c17b73d8677d3ac2ce06214f4d123859a3e3cc9def75fe0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libldb-2.4.1-1.el8.x86_64.rpm"
+          },
+          "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm"
           },
           "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm"
@@ -4157,6 +4177,24 @@
         "checksum": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4164,6 +4202,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
       },
       {
         "name": "diffutils",
@@ -5199,6 +5246,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2-boot.json
@@ -67,7 +67,10 @@
                   "sha256:ca6c80d3b1ce62b1b12f1a30ca4ec018855e92b0c447bdc831a0a0644accbb6e",
                   "sha256:933071dcdeccd57028cf1c28f034bc0a091d5904a80765dae6e491c15dad4411",
                   "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8",
+                  "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35",
+                  "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc",
                   "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613",
+                  "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba",
                   "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -183,6 +186,8 @@
                   "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf",
                   "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25",
                   "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0",
+                  "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3",
+                  "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e",
                   "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc",
                   "sha256:a3dedf8c077b4656d3cd4ef641e696397a3fff83ee8b14f0e3fc69d7c10cebcf",
                   "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd",
@@ -1475,6 +1480,9 @@
           "sha256:2b7a6aa5837347ac64fcdce693ea694b9f33a96be88e35defe666df16429f12b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/glibc-langpack-en-2.28-184.el8.x86_64.rpm"
           },
+          "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm"
+          },
           "sha256:2e175740ba876aa621422ed4971794320cde1115b01ff018de7ff8186e271e48": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/authselect-1.2.2-3.el8.x86_64.rpm"
           },
@@ -1538,6 +1546,9 @@
           "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
           },
+          "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm"
+          },
           "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-unbound-1.7.3-17.el8.x86_64.rpm"
           },
@@ -1597,6 +1608,9 @@
           },
           "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libzstd-1.4.4-1.el8.x86_64.rpm"
+          },
+          "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm"
           },
           "sha256:48e0e5143bf28f7220fc3c31db376c1ef0ed129fd3d2f82e3ce8531528924fd6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dnf-plugin-subscription-manager-1.28.25-1.el8.x86_64.rpm"
@@ -2051,6 +2065,9 @@
           "sha256:a707e53534ea5e52a149edeef20f1427d7644147324e7b101e34a4cc86c6bc69": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/lorax-templates-generic-28.14.65-1.el8.x86_64.rpm"
           },
+          "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
+          },
           "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
@@ -2308,6 +2325,9 @@
           },
           "sha256:d5f93aa67f44d44c7c17b73d8677d3ac2ce06214f4d123859a3e3cc9def75fe0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libldb-2.4.1-1.el8.x86_64.rpm"
+          },
+          "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm"
           },
           "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm"
@@ -4199,6 +4219,24 @@
         "checksum": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4206,6 +4244,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
       },
       {
         "name": "diffutils",
@@ -5241,6 +5288,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
@@ -76,7 +76,10 @@
                   "sha256:ca6c80d3b1ce62b1b12f1a30ca4ec018855e92b0c447bdc831a0a0644accbb6e",
                   "sha256:933071dcdeccd57028cf1c28f034bc0a091d5904a80765dae6e491c15dad4411",
                   "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8",
+                  "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35",
+                  "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc",
                   "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613",
+                  "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba",
                   "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -192,6 +195,8 @@
                   "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf",
                   "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25",
                   "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0",
+                  "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3",
+                  "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e",
                   "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc",
                   "sha256:a3dedf8c077b4656d3cd4ef641e696397a3fff83ee8b14f0e3fc69d7c10cebcf",
                   "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd",
@@ -4894,6 +4899,24 @@
         "checksum": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4901,6 +4924,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
       },
       {
         "name": "diffutils",
@@ -5936,6 +5968,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
       },
       {
         "name": "lz4-libs",
@@ -12883,7 +12933,7 @@
         "fstype": "xfs",
         "label": "root",
         "partuuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
-        "size": 10735269888,
+        "size": 10735304192,
         "start": 2097152,
         "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
         "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"

--- a/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
@@ -100,7 +100,10 @@
                   "sha256:ca6c80d3b1ce62b1b12f1a30ca4ec018855e92b0c447bdc831a0a0644accbb6e",
                   "sha256:933071dcdeccd57028cf1c28f034bc0a091d5904a80765dae6e491c15dad4411",
                   "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8",
+                  "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35",
+                  "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc",
                   "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613",
+                  "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba",
                   "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -216,6 +219,8 @@
                   "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf",
                   "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25",
                   "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0",
+                  "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3",
+                  "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e",
                   "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc",
                   "sha256:a3dedf8c077b4656d3cd4ef641e696397a3fff83ee8b14f0e3fc69d7c10cebcf",
                   "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd",
@@ -1969,6 +1974,9 @@
           "sha256:2c13360d2023f8b5a2d4586c0b5386036e6970b084e17461f7b0816bd3708da4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/gsm-1.0.17-5.el8.x86_64.rpm"
           },
+          "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm"
+          },
           "sha256:2d3abde6a8de3e2b73933735daf067a57d627c43d90e65b7bb98cba4967bd2c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libX11-1.6.8-5.el8.x86_64.rpm"
           },
@@ -2071,6 +2079,9 @@
           "sha256:3af165df117910b7bb5047a736d9661ac01ee836ad039e8b78f539e2d2bbc616": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/gtk-update-icon-cache-3.22.30-8.el8.x86_64.rpm"
           },
+          "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm"
+          },
           "sha256:3d203f221eb11b5a0a216427dee391294b0fb3aa0bc3348fd0d4330556a9b011": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libthai-0.1.27-2.el8.x86_64.rpm"
           },
@@ -2163,6 +2174,9 @@
           },
           "sha256:4811ab95c1d50ef7380e2c5937ae4490f8e28f56cf787c189437d1709e4423fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/perl-podlators-4.11-1.el8.noarch.rpm"
+          },
+          "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm"
           },
           "sha256:48ae21938b17c6be1c14369b97f97c8a13c26f234446abdc0d73a3a932f2c665": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python38-cryptography-2.8-3.module+el8.4.0+8888+89bc7e79.x86_64.rpm"
@@ -2854,6 +2868,9 @@
           "sha256:a707e53534ea5e52a149edeef20f1427d7644147324e7b101e34a4cc86c6bc69": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/lorax-templates-generic-28.14.65-1.el8.x86_64.rpm"
           },
+          "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
+          },
           "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
@@ -3234,6 +3251,9 @@
           },
           "sha256:d649f6c55cdb75650e55852b1812a0ff3a5d689950abf2ae17fa094501037365": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/gdk-pixbuf2-2.36.12-5.el8.x86_64.rpm"
+          },
+          "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm"
           },
           "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm"
@@ -5242,6 +5262,24 @@
         "checksum": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -5249,6 +5287,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
       },
       {
         "name": "diffutils",
@@ -6284,6 +6331,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit-boot.json
@@ -66,7 +66,10 @@
                   "sha256:ca6c80d3b1ce62b1b12f1a30ca4ec018855e92b0c447bdc831a0a0644accbb6e",
                   "sha256:933071dcdeccd57028cf1c28f034bc0a091d5904a80765dae6e491c15dad4411",
                   "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8",
+                  "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35",
+                  "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc",
                   "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613",
+                  "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba",
                   "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -184,6 +187,8 @@
                   "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf",
                   "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25",
                   "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0",
+                  "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3",
+                  "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e",
                   "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc",
                   "sha256:a3dedf8c077b4656d3cd4ef641e696397a3fff83ee8b14f0e3fc69d7c10cebcf",
                   "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd",
@@ -3982,6 +3987,24 @@
         "checksum": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -3989,6 +4012,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
       },
       {
         "name": "diffutils",
@@ -5042,6 +5074,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit_rt-boot.json
@@ -72,7 +72,10 @@
                   "sha256:ca6c80d3b1ce62b1b12f1a30ca4ec018855e92b0c447bdc831a0a0644accbb6e",
                   "sha256:933071dcdeccd57028cf1c28f034bc0a091d5904a80765dae6e491c15dad4411",
                   "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8",
+                  "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35",
+                  "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc",
                   "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613",
+                  "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba",
                   "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -190,6 +193,8 @@
                   "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf",
                   "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25",
                   "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0",
+                  "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3",
+                  "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e",
                   "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc",
                   "sha256:a3dedf8c077b4656d3cd4ef641e696397a3fff83ee8b14f0e3fc69d7c10cebcf",
                   "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd",
@@ -4494,6 +4499,24 @@
         "checksum": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4501,6 +4524,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
       },
       {
         "name": "diffutils",
@@ -5554,6 +5586,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_container-boot.json
@@ -58,7 +58,10 @@
                   "sha256:ca6c80d3b1ce62b1b12f1a30ca4ec018855e92b0c447bdc831a0a0644accbb6e",
                   "sha256:933071dcdeccd57028cf1c28f034bc0a091d5904a80765dae6e491c15dad4411",
                   "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8",
+                  "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35",
+                  "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc",
                   "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613",
+                  "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba",
                   "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -176,6 +179,8 @@
                   "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf",
                   "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25",
                   "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0",
+                  "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3",
+                  "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e",
                   "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc",
                   "sha256:a3dedf8c077b4656d3cd4ef641e696397a3fff83ee8b14f0e3fc69d7c10cebcf",
                   "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd",
@@ -4480,6 +4485,24 @@
         "checksum": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4487,6 +4510,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
       },
       {
         "name": "diffutils",
@@ -5540,6 +5572,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_installer-boot.json
@@ -64,7 +64,10 @@
                   "sha256:ca6c80d3b1ce62b1b12f1a30ca4ec018855e92b0c447bdc831a0a0644accbb6e",
                   "sha256:933071dcdeccd57028cf1c28f034bc0a091d5904a80765dae6e491c15dad4411",
                   "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8",
+                  "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35",
+                  "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc",
                   "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613",
+                  "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba",
                   "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -195,6 +198,8 @@
                   "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf",
                   "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25",
                   "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0",
+                  "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3",
+                  "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e",
                   "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc",
                   "sha256:a3dedf8c077b4656d3cd4ef641e696397a3fff83ee8b14f0e3fc69d7c10cebcf",
                   "sha256:b6050db00772299f827781e272f3b93f17687d164ded25cf795128567b539032",
@@ -5900,6 +5905,24 @@
         "checksum": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -5907,6 +5930,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
       },
       {
         "name": "diffutils",
@@ -7077,6 +7109,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_simplified_installer-boot.json
@@ -72,7 +72,10 @@
                   "sha256:ca6c80d3b1ce62b1b12f1a30ca4ec018855e92b0c447bdc831a0a0644accbb6e",
                   "sha256:933071dcdeccd57028cf1c28f034bc0a091d5904a80765dae6e491c15dad4411",
                   "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8",
+                  "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35",
+                  "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc",
                   "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613",
+                  "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba",
                   "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -203,6 +206,8 @@
                   "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf",
                   "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25",
                   "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0",
+                  "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3",
+                  "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e",
                   "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc",
                   "sha256:a3dedf8c077b4656d3cd4ef641e696397a3fff83ee8b14f0e3fc69d7c10cebcf",
                   "sha256:b6050db00772299f827781e272f3b93f17687d164ded25cf795128567b539032",
@@ -4326,6 +4331,24 @@
         "checksum": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4333,6 +4356,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
       },
       {
         "name": "diffutils",
@@ -5503,6 +5535,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-image_installer-boot.json
@@ -59,7 +59,10 @@
                   "sha256:ca6c80d3b1ce62b1b12f1a30ca4ec018855e92b0c447bdc831a0a0644accbb6e",
                   "sha256:933071dcdeccd57028cf1c28f034bc0a091d5904a80765dae6e491c15dad4411",
                   "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8",
+                  "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35",
+                  "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc",
                   "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613",
+                  "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba",
                   "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -188,6 +191,8 @@
                   "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf",
                   "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25",
                   "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0",
+                  "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3",
+                  "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e",
                   "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc",
                   "sha256:a3dedf8c077b4656d3cd4ef641e696397a3fff83ee8b14f0e3fc69d7c10cebcf",
                   "sha256:b6050db00772299f827781e272f3b93f17687d164ded25cf795128567b539032",
@@ -6663,6 +6668,24 @@
         "checksum": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -6670,6 +6693,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
       },
       {
         "name": "diffutils",
@@ -7822,6 +7854,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-openstack-boot.json
@@ -74,7 +74,10 @@
                   "sha256:ca6c80d3b1ce62b1b12f1a30ca4ec018855e92b0c447bdc831a0a0644accbb6e",
                   "sha256:933071dcdeccd57028cf1c28f034bc0a091d5904a80765dae6e491c15dad4411",
                   "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8",
+                  "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35",
+                  "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc",
                   "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613",
+                  "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba",
                   "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -190,6 +193,8 @@
                   "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf",
                   "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25",
                   "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0",
+                  "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3",
+                  "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e",
                   "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc",
                   "sha256:a3dedf8c077b4656d3cd4ef641e696397a3fff83ee8b14f0e3fc69d7c10cebcf",
                   "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd",
@@ -1477,6 +1482,9 @@
           "sha256:2bad17b14cc7cdf2ef2cdf2e7efa2ed59f0324f062c7995f63c24cd20eb223d0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/iwl6050-firmware-41.28.5.1-105.el8.1.noarch.rpm"
           },
+          "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm"
+          },
           "sha256:2d3abde6a8de3e2b73933735daf067a57d627c43d90e65b7bb98cba4967bd2c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libX11-1.6.8-5.el8.x86_64.rpm"
           },
@@ -1561,6 +1569,9 @@
           "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
           },
+          "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm"
+          },
           "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libbytesize-1.4-3.el8.x86_64.rpm"
           },
@@ -1644,6 +1655,9 @@
           },
           "sha256:47d5786c78a2a50f5ce67af5a6fd73665c446ca6c66c75e80d0ad79188753d18": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libibverbs-37.2-1.el8.x86_64.rpm"
+          },
+          "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm"
           },
           "sha256:48e0e5143bf28f7220fc3c31db376c1ef0ed129fd3d2f82e3ce8531528924fd6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dnf-plugin-subscription-manager-1.28.25-1.el8.x86_64.rpm"
@@ -2185,6 +2199,9 @@
           "sha256:a707e53534ea5e52a149edeef20f1427d7644147324e7b101e34a4cc86c6bc69": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/lorax-templates-generic-28.14.65-1.el8.x86_64.rpm"
           },
+          "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
+          },
           "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
@@ -2478,6 +2495,9 @@
           },
           "sha256:d5f93aa67f44d44c7c17b73d8677d3ac2ce06214f4d123859a3e3cc9def75fe0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libldb-2.4.1-1.el8.x86_64.rpm"
+          },
+          "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm"
           },
           "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm"
@@ -4381,6 +4401,24 @@
         "checksum": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4388,6 +4426,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
       },
       {
         "name": "diffutils",
@@ -5423,6 +5470,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-qcow2-boot.json
@@ -71,7 +71,10 @@
                   "sha256:ca6c80d3b1ce62b1b12f1a30ca4ec018855e92b0c447bdc831a0a0644accbb6e",
                   "sha256:933071dcdeccd57028cf1c28f034bc0a091d5904a80765dae6e491c15dad4411",
                   "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8",
+                  "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35",
+                  "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc",
                   "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613",
+                  "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba",
                   "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -187,6 +190,8 @@
                   "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf",
                   "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25",
                   "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0",
+                  "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3",
+                  "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e",
                   "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc",
                   "sha256:a3dedf8c077b4656d3cd4ef641e696397a3fff83ee8b14f0e3fc69d7c10cebcf",
                   "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd",
@@ -1474,6 +1479,9 @@
           "sha256:2b18950e446e1bddde2f91b7d86e004d24bd43ad7f73ca3d13e5db0765d1d250": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-libdnf-0.63.0-5.el8.x86_64.rpm"
           },
+          "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm"
+          },
           "sha256:2d3abde6a8de3e2b73933735daf067a57d627c43d90e65b7bb98cba4967bd2c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libX11-1.6.8-5.el8.x86_64.rpm"
           },
@@ -1539,6 +1547,9 @@
           },
           "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
+          },
+          "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:3b1f1d599412fa0dc473e9ab4a37d295941d2493dabea4c0af2bb9ddd72844fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/rhsm-icons-1.28.25-1.el8.noarch.rpm"
@@ -1626,6 +1637,9 @@
           },
           "sha256:47d5786c78a2a50f5ce67af5a6fd73665c446ca6c66c75e80d0ad79188753d18": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libibverbs-37.2-1.el8.x86_64.rpm"
+          },
+          "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm"
           },
           "sha256:48e0e5143bf28f7220fc3c31db376c1ef0ed129fd3d2f82e3ce8531528924fd6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dnf-plugin-subscription-manager-1.28.25-1.el8.x86_64.rpm"
@@ -2137,6 +2151,9 @@
           "sha256:a707e53534ea5e52a149edeef20f1427d7644147324e7b101e34a4cc86c6bc69": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/lorax-templates-generic-28.14.65-1.el8.x86_64.rpm"
           },
+          "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
+          },
           "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
@@ -2436,6 +2453,9 @@
           },
           "sha256:d649f6c55cdb75650e55852b1812a0ff3a5d689950abf2ae17fa094501037365": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/gdk-pixbuf2-2.36.12-5.el8.x86_64.rpm"
+          },
+          "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm"
           },
           "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm"
@@ -4351,6 +4371,24 @@
         "checksum": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4358,6 +4396,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
       },
       {
         "name": "diffutils",
@@ -5393,6 +5440,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-qcow2_customize-boot.json
@@ -129,7 +129,10 @@
                   "sha256:ca6c80d3b1ce62b1b12f1a30ca4ec018855e92b0c447bdc831a0a0644accbb6e",
                   "sha256:933071dcdeccd57028cf1c28f034bc0a091d5904a80765dae6e491c15dad4411",
                   "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8",
+                  "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35",
+                  "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc",
                   "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613",
+                  "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba",
                   "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -245,6 +248,8 @@
                   "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf",
                   "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25",
                   "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0",
+                  "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3",
+                  "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e",
                   "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc",
                   "sha256:a3dedf8c077b4656d3cd4ef641e696397a3fff83ee8b14f0e3fc69d7c10cebcf",
                   "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd",
@@ -1810,6 +1815,9 @@
           "sha256:2bad17b14cc7cdf2ef2cdf2e7efa2ed59f0324f062c7995f63c24cd20eb223d0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/iwl6050-firmware-41.28.5.1-105.el8.1.noarch.rpm"
           },
+          "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm"
+          },
           "sha256:2d3abde6a8de3e2b73933735daf067a57d627c43d90e65b7bb98cba4967bd2c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libX11-1.6.8-5.el8.x86_64.rpm"
           },
@@ -1878,6 +1886,9 @@
           },
           "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
+          },
+          "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:3b1f1d599412fa0dc473e9ab4a37d295941d2493dabea4c0af2bb9ddd72844fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/rhsm-icons-1.28.25-1.el8.noarch.rpm"
@@ -1980,6 +1991,9 @@
           },
           "sha256:47d5786c78a2a50f5ce67af5a6fd73665c446ca6c66c75e80d0ad79188753d18": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libibverbs-37.2-1.el8.x86_64.rpm"
+          },
+          "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm"
           },
           "sha256:48e0e5143bf28f7220fc3c31db376c1ef0ed129fd3d2f82e3ce8531528924fd6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dnf-plugin-subscription-manager-1.28.25-1.el8.x86_64.rpm"
@@ -2533,6 +2547,9 @@
           "sha256:a707e53534ea5e52a149edeef20f1427d7644147324e7b101e34a4cc86c6bc69": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/lorax-templates-generic-28.14.65-1.el8.x86_64.rpm"
           },
+          "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
+          },
           "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
@@ -2856,6 +2873,9 @@
           },
           "sha256:d649f6c55cdb75650e55852b1812a0ff3a5d689950abf2ae17fa094501037365": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/gdk-pixbuf2-2.36.12-5.el8.x86_64.rpm"
+          },
+          "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm"
           },
           "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm"
@@ -6694,6 +6714,24 @@
         "checksum": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -6701,6 +6739,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
       },
       {
         "name": "diffutils",
@@ -7736,6 +7783,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-tar-boot.json
@@ -79,7 +79,10 @@
                   "sha256:ca6c80d3b1ce62b1b12f1a30ca4ec018855e92b0c447bdc831a0a0644accbb6e",
                   "sha256:933071dcdeccd57028cf1c28f034bc0a091d5904a80765dae6e491c15dad4411",
                   "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8",
+                  "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35",
+                  "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc",
                   "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613",
+                  "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba",
                   "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -195,6 +198,8 @@
                   "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf",
                   "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25",
                   "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0",
+                  "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3",
+                  "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e",
                   "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc",
                   "sha256:a3dedf8c077b4656d3cd4ef641e696397a3fff83ee8b14f0e3fc69d7c10cebcf",
                   "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd",
@@ -889,6 +894,9 @@
           "sha256:2b18950e446e1bddde2f91b7d86e004d24bd43ad7f73ca3d13e5db0765d1d250": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-libdnf-0.63.0-5.el8.x86_64.rpm"
           },
+          "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm"
+          },
           "sha256:2e8fd9d87a922b1441538318c401b1e4353b87a9e8000ca76b0cee681ec79c45": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libnghttp2-1.33.0-3.el8_2.1.x86_64.rpm"
           },
@@ -924,6 +932,9 @@
           },
           "sha256:3a512a2acf2cc4c77ddb3e110bdc725b0f4b81948425172ca002a65d7845d79b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/platform-python-pip-9.0.3-22.el8.noarch.rpm"
+          },
+          "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-unbound-1.7.3-17.el8.x86_64.rpm"
@@ -963,6 +974,9 @@
           },
           "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libzstd-1.4.4-1.el8.x86_64.rpm"
+          },
+          "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm"
           },
           "sha256:49f89e7b459eaa297e518c0e55d81d1b0d8181959346673babb158103422652d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/procps-ng-3.3.15-6.el8.x86_64.rpm"
@@ -1225,6 +1239,9 @@
           "sha256:a707e53534ea5e52a149edeef20f1427d7644147324e7b101e34a4cc86c6bc69": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/lorax-templates-generic-28.14.65-1.el8.x86_64.rpm"
           },
+          "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
+          },
           "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
@@ -1380,6 +1397,9 @@
           },
           "sha256:d570af0578f5b2c6225f1f2354404f65bccf91c3974e98dcbc0c7b55a61b9b46": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grep-3.1-6.el8.x86_64.rpm"
+          },
+          "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm"
           },
           "sha256:d84beeb7e2ff758872ad3b2f446ead7c0cebdb7baee49e06fac829c58e0e8ec7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/coreutils-8.30-12.el8.x86_64.rpm"
@@ -3226,6 +3246,24 @@
         "checksum": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -3233,6 +3271,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
       },
       {
         "name": "diffutils",
@@ -4268,6 +4315,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-vhd-boot.json
@@ -71,7 +71,10 @@
                   "sha256:ca6c80d3b1ce62b1b12f1a30ca4ec018855e92b0c447bdc831a0a0644accbb6e",
                   "sha256:933071dcdeccd57028cf1c28f034bc0a091d5904a80765dae6e491c15dad4411",
                   "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8",
+                  "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35",
+                  "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc",
                   "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613",
+                  "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba",
                   "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -187,6 +190,8 @@
                   "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf",
                   "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25",
                   "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0",
+                  "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3",
+                  "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e",
                   "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc",
                   "sha256:a3dedf8c077b4656d3cd4ef641e696397a3fff83ee8b14f0e3fc69d7c10cebcf",
                   "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd",
@@ -1476,6 +1481,9 @@
           "sha256:2bad17b14cc7cdf2ef2cdf2e7efa2ed59f0324f062c7995f63c24cd20eb223d0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/iwl6050-firmware-41.28.5.1-105.el8.1.noarch.rpm"
           },
+          "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm"
+          },
           "sha256:2e175740ba876aa621422ed4971794320cde1115b01ff018de7ff8186e271e48": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/authselect-1.2.2-3.el8.x86_64.rpm"
           },
@@ -1550,6 +1558,9 @@
           },
           "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
+          },
+          "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libbytesize-1.4-3.el8.x86_64.rpm"
@@ -1634,6 +1645,9 @@
           },
           "sha256:47d5786c78a2a50f5ce67af5a6fd73665c446ca6c66c75e80d0ad79188753d18": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libibverbs-37.2-1.el8.x86_64.rpm"
+          },
+          "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm"
           },
           "sha256:48e0e5143bf28f7220fc3c31db376c1ef0ed129fd3d2f82e3ce8531528924fd6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dnf-plugin-subscription-manager-1.28.25-1.el8.x86_64.rpm"
@@ -2160,6 +2174,9 @@
           "sha256:a707e53534ea5e52a149edeef20f1427d7644147324e7b101e34a4cc86c6bc69": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/lorax-templates-generic-28.14.65-1.el8.x86_64.rpm"
           },
+          "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
+          },
           "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
@@ -2459,6 +2476,9 @@
           },
           "sha256:d5f93aa67f44d44c7c17b73d8677d3ac2ce06214f4d123859a3e3cc9def75fe0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libldb-2.4.1-1.el8.x86_64.rpm"
+          },
+          "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm"
           },
           "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm"
@@ -4362,6 +4382,24 @@
         "checksum": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4369,6 +4407,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
       },
       {
         "name": "diffutils",
@@ -5404,6 +5451,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
       },
       {
         "name": "lz4-libs",

--- a/test/data/manifests/rhel_86-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-vmdk-boot.json
@@ -71,7 +71,10 @@
                   "sha256:ca6c80d3b1ce62b1b12f1a30ca4ec018855e92b0c447bdc831a0a0644accbb6e",
                   "sha256:933071dcdeccd57028cf1c28f034bc0a091d5904a80765dae6e491c15dad4411",
                   "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8",
+                  "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35",
+                  "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc",
                   "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613",
+                  "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba",
                   "sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce",
                   "sha256:801231dfc882376ddf0801e7630fb3f018591840fa285094252ac7c86951f7f2",
                   "sha256:0adfa1170d0d43b67de3ca02e7acbd46b811e4efc1aa6da58bb6c6f081d20d50",
@@ -187,6 +190,8 @@
                   "sha256:018409b1eda8be48a11a5b76b95e82ff1d9002569e0644291532d8424dc31edf",
                   "sha256:45cc50a8b02f9bbbbe2c8c056f34622d15d383f695916ac07821d688fcab1c25",
                   "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0",
+                  "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3",
+                  "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e",
                   "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc",
                   "sha256:a3dedf8c077b4656d3cd4ef641e696397a3fff83ee8b14f0e3fc69d7c10cebcf",
                   "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd",
@@ -1421,6 +1426,9 @@
           "sha256:2bad17b14cc7cdf2ef2cdf2e7efa2ed59f0324f062c7995f63c24cd20eb223d0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/iwl6050-firmware-41.28.5.1-105.el8.1.noarch.rpm"
           },
+          "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm"
+          },
           "sha256:2e175740ba876aa621422ed4971794320cde1115b01ff018de7ff8186e271e48": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/authselect-1.2.2-3.el8.x86_64.rpm"
           },
@@ -1492,6 +1500,9 @@
           },
           "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
+          },
+          "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm"
           },
           "sha256:3cc2dc1ee5132c789d05458ab1bf9e01fe78e1cc1813d8602297bdda6dd30731": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libbytesize-1.4-3.el8.x86_64.rpm"
@@ -1567,6 +1578,9 @@
           },
           "sha256:47d5786c78a2a50f5ce67af5a6fd73665c446ca6c66c75e80d0ad79188753d18": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libibverbs-37.2-1.el8.x86_64.rpm"
+          },
+          "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm"
           },
           "sha256:48e0e5143bf28f7220fc3c31db376c1ef0ed129fd3d2f82e3ce8531528924fd6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dnf-plugin-subscription-manager-1.28.25-1.el8.x86_64.rpm"
@@ -2072,6 +2086,9 @@
           "sha256:a707e53534ea5e52a149edeef20f1427d7644147324e7b101e34a4cc86c6bc69": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/lorax-templates-generic-28.14.65-1.el8.x86_64.rpm"
           },
+          "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm"
+          },
           "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
           },
@@ -2356,6 +2373,9 @@
           },
           "sha256:d5f93aa67f44d44c7c17b73d8677d3ac2ce06214f4d123859a3e3cc9def75fe0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libldb-2.4.1-1.el8.x86_64.rpm"
+          },
+          "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm"
           },
           "sha256:d759703d633257a88457c38d94b9a7836e0ec8eeb72df385df348423e668ae08": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-nftables-0.9.3-24.el8.x86_64.rpm"
@@ -4253,6 +4273,24 @@
         "checksum": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -4260,6 +4298,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
       },
       {
         "name": "diffutils",
@@ -5295,6 +5342,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
       },
       {
         "name": "lz4-libs",


### PR DESCRIPTION
Add `lvm2` to all RHEL 8.6 build roots.  This is to prepare for supporting LVM partitioning when requested by the user.