### PR TITLE
PartitionTable clone fix

### DIFF
--- a/internal/disk/disk_test.go
+++ b/internal/disk/disk_test.go
@@ -1,6 +1,7 @@
 package disk
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 
@@ -367,5 +368,33 @@ func TestCreatePartitionTable(t *testing.T) {
 
 		mnt := pt.FindMountable("/")
 		assert.NotNil(mnt, "Partition table '%s': failed to find root mountable", name)
+	}
+}
+
+func collectEntities(pt *PartitionTable) []Entity {
+	entities := make([]Entity, 0)
+	collector := func(ent Entity, path []Entity) error {
+		entities = append(entities, ent)
+		return nil
+	}
+	_ = pt.ForEachEntity(collector)
+	return entities
+}
+
+func TestClone(t *testing.T) {
+	for name := range testPartitionTables {
+		basePT := testPartitionTables[name]
+		baseEntities := collectEntities(&basePT)
+
+		clonePT := basePT.Clone().(*PartitionTable)
+		cloneEntities := collectEntities(clonePT)
+
+		for idx := range baseEntities {
+			for jdx := range cloneEntities {
+				if fmt.Sprintf("%p", baseEntities[idx]) == fmt.Sprintf("%p", cloneEntities[jdx]) {
+					t.Fatalf("found reference to same entity %#v in list of clones for partition table %q", baseEntities[idx], name)
+				}
+			}
+		}
 	}
 }

--- a/internal/disk/luks.go
+++ b/internal/disk/luks.go
@@ -61,7 +61,7 @@ func (lc *LUKSContainer) Clone() Entity {
 			Memory:      lc.PBKDF.Memory,
 			Parallelism: lc.PBKDF.Parallelism,
 		},
-		Payload: lc.Payload,
+		Payload: lc.Payload.Clone(),
 	}
 }
 

--- a/internal/disk/lvm.go
+++ b/internal/disk/lvm.go
@@ -93,7 +93,7 @@ func (lv *LVMLogicalVolume) Clone() Entity {
 	return &LVMLogicalVolume{
 		Name:    lv.Name,
 		Size:    lv.Size,
-		Payload: lv.Payload,
+		Payload: lv.Payload.Clone(),
 	}
 }
 


### PR DESCRIPTION
In LUKSContainer and LVMLogicalVolume we neglected to clone the Payload which means we would modify the base PartitionTable when manipulating the clone.

Added test that collects all entities before and after cloning the test partition tables and compares for duplicates between the lists.