### PR TITLE
test: Fix COMPOSE_URL issue and add set-env-variables.sh

### DIFF
--- a/test/cases/ostree-rebase.sh
+++ b/test/cases/ostree-rebase.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
+# Get OS data.
+source /usr/libexec/osbuild-composer-test/set-env-variables.sh
+
+# Get compose url if it's running on unsubscried RHEL
+if [[ ${ID} == "rhel" ]] && ! sudo subscription-manager status; then
+    source /usr/libexec/osbuild-composer-test/define-compose-url.sh
+fi
+
 # Provision the software under test.
 /usr/libexec/osbuild-composer-test/provision.sh
-
-# Get OS data.
-source /etc/os-release
-ARCH=$(uname -m)
 
 # Colorful output.
 function greenprint {


### PR DESCRIPTION
`COMPOSE_URL` is not defined in `ostree-rebase.sh`. Source `define-compose-url.sh` to define it.
 Source `set-env-variables.sh` to define environment variables.