### PR TITLE
rhel86: automatically convert to LVM on fs customizations

### DIFF
--- a/internal/disk/disk_test.go
+++ b/internal/disk/disk_test.go
@@ -124,6 +124,45 @@ var testPartitionTables = map[string]PartitionTable{
 		},
 	},
 
+	"plain-noboot": {
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
+		Partitions: []Partition{
+			{
+				Size:     1048576, // 1MB
+				Bootable: true,
+				Type:     BIOSBootPartitionGUID,
+				UUID:     BIOSBootPartitionUUID,
+			},
+			{
+				Size: 209715200, // 200 MB
+				Type: EFISystemPartitionGUID,
+				UUID: EFISystemPartitionUUID,
+				Payload: &Filesystem{
+					Type:         "vfat",
+					UUID:         EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					Label:        "EFI-SYSTEM",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Type: FilesystemDataGUID,
+				UUID: RootPartitionUUID,
+				Payload: &Filesystem{
+					Type:         "xfs",
+					Label:        "root",
+					Mountpoint:   "/",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+		},
+	},
+
 	"luks": {
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
 		Type: "gpt",
@@ -391,6 +430,11 @@ func TestCreatePartitionTableLVMify(t *testing.T) {
 		rootPath := entityPath(mpt, "/")
 		if rootPath == nil {
 			panic("no root mountpoint for PartitionTable")
+		}
+
+		bootPath := entityPath(mpt, "/boot")
+		if bootPath == nil {
+			panic("no boot mountpoint for PartitionTable")
 		}
 
 		parent := rootPath[1]

--- a/internal/distro/rhel86/distro.go
+++ b/internal/distro/rhel86/distro.go
@@ -331,6 +331,24 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint) map[string]rpmmd.Package
 		bpPackages = append(bpPackages, "chrony")
 	}
 
+	// if we have file system customization that will need to a new mount point
+	// the layout is converted to LVM so we need to corresponding packages
+	if !t.rpmOstree {
+		archName := t.arch.Name()
+		pt := t.basePartitionTables[archName]
+		haveNewMountpoint := false
+
+		if fs := bp.Customizations.GetFilesystems(); fs != nil {
+			for i := 0; !haveNewMountpoint && i < len(fs); i++ {
+				haveNewMountpoint = !pt.ContainsMountpoint(fs[i].Mountpoint)
+			}
+		}
+
+		if haveNewMountpoint {
+			bpPackages = append(bpPackages, "lvm2")
+		}
+	}
+
 	// depsolve bp packages separately
 	// bp packages aren't restricted by exclude lists
 	mergedSets[blueprintPkgsKey] = rpmmd.PackageSet{Include: bpPackages}
@@ -394,7 +412,9 @@ func (t *imageType) getPartitionTable(
 
 	imageSize := t.Size(options.Size)
 
-	return disk.NewPartitionTable(&basePartitionTable, mountpoints, imageSize, false, rng)
+	lvmify := !t.rpmOstree
+
+	return disk.NewPartitionTable(&basePartitionTable, mountpoints, imageSize, lvmify, rng)
 }
 
 func (t *imageType) getDefaultImageConfig() *distro.ImageConfig {

--- a/internal/distro/rhel86/distro_test.go
+++ b/internal/distro/rhel86/distro_test.go
@@ -704,13 +704,10 @@ func TestDistro_MountpointsWithArbitraryDepthAllowed(t *testing.T) {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			testPackageSpecSets := distro_test_common.GetTestingPackageSpecSets("kernel", arch.Name(), imgType.PayloadPackageSets())
 			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, testPackageSpecSets, 0)
-			layout := imgType.PartitionType()
-			if layout == "" || strings.HasPrefix(imgTypeName, "edge-") {
+			if strings.HasPrefix(imgTypeName, "edge-") {
 				continue
-			} else if layout == "gpt" {
-				assert.NoError(t, err)
 			} else {
-				assert.EqualError(t, err, "failed creating volume: maximum number of partitions reached (4)")
+				assert.NoError(t, err)
 			}
 		}
 	}

--- a/internal/distro/rhel86/partition_tables.go
+++ b/internal/distro/rhel86/partition_tables.go
@@ -30,6 +30,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
+				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -61,6 +62,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
+				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -84,6 +86,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				Bootable: true,
 			},
 			{
+				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
 				Payload: &disk.Filesystem{
 					Type:         "xfs",
 					Mountpoint:   "/",
@@ -99,6 +102,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		Type: "dos",
 		Partitions: []disk.Partition{
 			{
+				Size:     2 * 1024 * 1024 * 1024, // 2 GiB
 				Bootable: true,
 				Payload: &disk.Filesystem{
 					Type:         "xfs",
@@ -124,6 +128,7 @@ var ec2BasePartitionTables = distro.BasePartitionTableMap{
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
+				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -167,6 +172,7 @@ var ec2BasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
+				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -221,6 +227,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
+				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -266,6 +273,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
+				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{


### PR DESCRIPTION
Whenever we create a new mountpoint due to a user customization, ensure the layout uses LVM, i.e. convert plain layouts to it, if needed. It uses the existing lvm-ification code but enhances it so that we also create a `/boot` partition in case it does not yet exist.
Adjust the existing tests that assumed we can not create more than 4 partitions on mbr layouts, since that is now not true anymore.

