### PR TITLE
internal/distro/rhel{86,90}: drop console kargs from raw image deploy…

### DIFF
--- a/internal/distro/rhel86/pipelines.go
+++ b/internal/distro/rhel86/pipelines.go
@@ -851,11 +851,7 @@ func ostreeDeployPipeline(
 	))
 	p.AddStage(osbuild.NewOSTreeConfigStage(ostreeConfigStageOptions(repoPath, true)))
 	p.AddStage(osbuild.NewMkdirStage(efiMkdirStageOptions()))
-	kernelOpts := []string{
-		"console=tty0",
-		"console=ttyS0",
-	}
-	kernelOpts = append(kernelOpts, osbuild.GenImageKernelOptions(pt)...)
+	kernelOpts := osbuild.GenImageKernelOptions(pt)
 	p.AddStage(osbuild.NewOSTreeDeployStage(
 		&osbuild.OSTreeDeployStageOptions{
 			OsName: osname,

--- a/internal/distro/rhel90/pipelines.go
+++ b/internal/distro/rhel90/pipelines.go
@@ -846,11 +846,7 @@ func ostreeDeployPipeline(
 	))
 	p.AddStage(osbuild.NewOSTreeConfigStage(ostreeConfigStageOptions(repoPath, true)))
 	p.AddStage(osbuild.NewMkdirStage(efiMkdirStageOptions()))
-	kernelOpts := []string{
-		"console=tty0",
-		"console=ttyS0",
-	}
-	kernelOpts = append(kernelOpts, osbuild.GenImageKernelOptions(pt)...)
+	kernelOpts := osbuild.GenImageKernelOptions(pt)
 	p.AddStage(osbuild.NewOSTreeDeployStage(
 		&osbuild.OSTreeDeployStageOptions{
 			OsName: osname,

--- a/test/data/manifests/centos_8-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_simplified_installer-boot.json
@@ -438,8 +438,6 @@
                 "label": "root"
               },
               "kernel_opts": [
-                "console=tty0",
-                "console=ttyS0",
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
               ]
             }

--- a/test/data/manifests/centos_8-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_simplified_installer-boot.json
@@ -446,8 +446,6 @@
                 "label": "root"
               },
               "kernel_opts": [
-                "console=tty0",
-                "console=ttyS0",
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
               ]
             }

--- a/test/data/manifests/centos_9-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_simplified_installer-boot.json
@@ -428,8 +428,6 @@
                 "label": "root"
               },
               "kernel_opts": [
-                "console=tty0",
-                "console=ttyS0",
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
               ]
             }

--- a/test/data/manifests/centos_9-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_simplified_installer-boot.json
@@ -442,8 +442,6 @@
                 "label": "root"
               },
               "kernel_opts": [
-                "console=tty0",
-                "console=ttyS0",
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
               ]
             }

--- a/test/data/manifests/rhel_86-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_simplified_installer-boot.json
@@ -436,8 +436,6 @@
                 "label": "root"
               },
               "kernel_opts": [
-                "console=tty0",
-                "console=ttyS0",
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
               ]
             }

--- a/test/data/manifests/rhel_86-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_simplified_installer-boot.json
@@ -444,8 +444,6 @@
                 "label": "root"
               },
               "kernel_opts": [
-                "console=tty0",
-                "console=ttyS0",
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
               ]
             }

--- a/test/data/manifests/rhel_90-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_simplified_installer-boot.json
@@ -426,8 +426,6 @@
                 "label": "root"
               },
               "kernel_opts": [
-                "console=tty0",
-                "console=ttyS0",
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
               ]
             }

--- a/test/data/manifests/rhel_90-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_simplified_installer-boot.json
@@ -433,8 +433,6 @@
                 "label": "root"
               },
               "kernel_opts": [
-                "console=tty0",
-                "console=ttyS0",
                 "luks.uuid=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
               ]
             }

--- a/tools/test-case-generators/distro-arch-imagetype-map.json
+++ b/tools/test-case-generators/distro-arch-imagetype-map.json
@@ -42,6 +42,7 @@
             "edge-commit",
             "edge-container",
             "image-installer",
+            "edge-simplified-installer",
             "vhd",
             "vmdk"
         ],
@@ -52,6 +53,7 @@
             "edge-commit",
             "edge-container",
             "image-installer",
+            "edge-simplified-installer",
             "tar"
         ],
         "ppc64le": [
@@ -158,6 +160,7 @@
             "edge-commit",
             "edge-container",
             "image-installer",
+            "edge-simplified-installer",
             "vhd",
             "vmdk"
         ],
@@ -169,6 +172,7 @@
             "edge-commit",
             "edge-container",
             "image-installer",
+            "edge-simplified-installer",
             "tar"
         ],
         "ppc64le": [
@@ -222,6 +226,7 @@
             "edge-commit",
             "edge-container",
             "image-installer",
+            "edge-simplified-installer",
             "openstack",
             "qcow2",
             "tar",
@@ -234,6 +239,7 @@
             "edge-commit",
             "edge-container",
             "image-installer",
+            "edge-simplified-installer",
             "openstack",
             "qcow2",
             "tar"
@@ -256,6 +262,7 @@
             "edge-commit",
             "edge-container",
             "image-installer",
+            "edge-simplified-installer",
             "vhd",
             "vmdk"
         ],
@@ -266,6 +273,7 @@
             "edge-commit",
             "edge-container",
             "image-installer",
+            "edge-simplified-installer",
             "tar"
         ],
         "ppc64le": [


### PR DESCRIPTION
…ment

Using the simplified installer we were experiencing slow system boots.
Turns out we're incurring into https://bugzilla.redhat.com/show_bug.cgi?id=1839923
This patch just drops the console kargs - to be aligned with the
anaconda installer that doesn't experience this slow down.
The slow down doesn't happen on virtual machines as there's always a
ttyS0 there

fixes https://bugzilla.redhat.com/show_bug.cgi?id=2059429 for us

Signed-off-by: Antonio Murdaca <runcom@linux.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
