### PR TITLE
Small cloudapi cleanups

### DIFF
--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -119,7 +119,7 @@ func (c *Composer) InitWeldr(repoPaths []string, weldrListener net.Listener,
 }
 
 func (c *Composer) InitAPI(cert, key string, enableTLS bool, enableMTLS bool, enableJWT bool, l net.Listener) error {
-	c.api = cloudapi.NewServer(c.workers, c.rpm, c.distros, c.config.Koji.AWS.Bucket)
+	c.api = cloudapi.NewServer(c.workers, c.distros, c.config.Koji.AWS.Bucket)
 	c.koji = kojiapi.NewServer(c.logger, c.workers, c.rpm, c.distros)
 
 	if !enableTLS {

--- a/internal/cloudapi/server.go
+++ b/internal/cloudapi/server.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/osbuild/osbuild-composer/internal/distroregistry"
-	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/worker"
 
 	v2 "github.com/osbuild/osbuild-composer/internal/cloudapi/v2"
@@ -14,9 +13,9 @@ type Server struct {
 	v2 *v2.Server
 }
 
-func NewServer(workers *worker.Server, rpmMetadata rpmmd.RPMMD, distros *distroregistry.Registry, awsBucket string) *Server {
+func NewServer(workers *worker.Server, distros *distroregistry.Registry, awsBucket string) *Server {
 	server := &Server{
-		v2: v2.NewServer(workers, rpmMetadata, distros, awsBucket),
+		v2: v2.NewServer(workers, distros, awsBucket),
 	}
 	return server
 }

--- a/internal/cloudapi/v2/v2.go
+++ b/internal/cloudapi/v2/v2.go
@@ -34,10 +34,9 @@ import (
 
 // Server represents the state of the cloud Server
 type Server struct {
-	workers     *worker.Server
-	rpmMetadata rpmmd.RPMMD
-	distros     *distroregistry.Registry
-	awsBucket   string
+	workers   *worker.Server
+	distros   *distroregistry.Registry
+	awsBucket string
 }
 
 type apiHandlers struct {
@@ -46,12 +45,11 @@ type apiHandlers struct {
 
 type binder struct{}
 
-func NewServer(workers *worker.Server, rpmMetadata rpmmd.RPMMD, distros *distroregistry.Registry, bucket string) *Server {
+func NewServer(workers *worker.Server, distros *distroregistry.Registry, bucket string) *Server {
 	server := &Server{
-		workers:     workers,
-		rpmMetadata: rpmMetadata,
-		distros:     distros,
-		awsBucket:   bucket,
+		workers:   workers,
+		distros:   distros,
+		awsBucket: bucket,
 	}
 	return server
 }

--- a/internal/cloudapi/v2/v2_test.go
+++ b/internal/cloudapi/v2/v2_test.go
@@ -31,7 +31,7 @@ func newV2Server(t *testing.T, dir string) (*v2.Server, *worker.Server, context.
 	require.NoError(t, err)
 	require.NotNil(t, distros)
 
-	v2Server := v2.NewServer(rpmFixture.Workers, rpm, distros, "image-builder.service")
+	v2Server := v2.NewServer(rpmFixture.Workers, distros, "image-builder.service")
 	require.NotNil(t, v2Server)
 
 	// start a routine which just completes depsolve jobs


### PR DESCRIPTION
- remove rpmmd from cloudapi code
- drop rpmmd_mock dependency from cloudapi tests

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
