### PR TITLE
osbuild2: support firewall stage default zone setting

### DIFF
--- a/internal/osbuild2/firewall_stage.go
+++ b/internal/osbuild2/firewall_stage.go
@@ -4,6 +4,7 @@ type FirewallStageOptions struct {
 	Ports            []string `json:"ports,omitempty"`
 	EnabledServices  []string `json:"enabled_services,omitempty"`
 	DisabledServices []string `json:"disabled_services,omitempty"`
+	DefaultZone      string   `json:"default_zone,omitempty"`
 }
 
 func (FirewallStageOptions) isStageOptions() {}

--- a/test/data/manifests/centos_8-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_commit-boot.json
@@ -10028,6 +10028,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_8-aarch64-openstack-boot.json
+++ b/test/data/manifests/centos_8-aarch64-openstack-boot.json
@@ -11204,6 +11204,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_8-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-aarch64-qcow2_customize-boot.json
@@ -13297,6 +13297,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_8-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-ppc64le-qcow2_customize-boot.json
@@ -14567,6 +14567,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_8-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit-boot.json
@@ -10338,6 +10338,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_8-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit_rt-boot.json
@@ -10294,6 +10294,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_8-x86_64-openstack-boot.json
+++ b/test/data/manifests/centos_8-x86_64-openstack-boot.json
@@ -11401,6 +11401,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_8-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2_customize-boot.json
@@ -13491,6 +13491,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_8-x86_64-vhd-boot.json
+++ b/test/data/manifests/centos_8-x86_64-vhd-boot.json
@@ -11350,6 +11350,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_8-x86_64-vmdk-boot.json
+++ b/test/data/manifests/centos_8-x86_64-vmdk-boot.json
@@ -10794,6 +10794,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_9-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_commit-boot.json
@@ -9029,6 +9029,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_9-aarch64-openstack-boot.json
+++ b/test/data/manifests/centos_9-aarch64-openstack-boot.json
@@ -9805,6 +9805,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_9-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-aarch64-qcow2_customize-boot.json
@@ -12234,6 +12234,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_9-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-ppc64le-qcow2_customize-boot.json
@@ -13142,6 +13142,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_9-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-s390x-qcow2_customize-boot.json
@@ -13964,6 +13964,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_9-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit-boot.json
@@ -9402,6 +9402,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_9-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit_rt-boot.json
@@ -10655,6 +10655,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_9-x86_64-openstack-boot.json
+++ b/test/data/manifests/centos_9-x86_64-openstack-boot.json
@@ -10258,6 +10258,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_9-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-x86_64-qcow2_customize-boot.json
@@ -12706,6 +12706,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_9-x86_64-vhd-boot.json
+++ b/test/data/manifests/centos_9-x86_64-vhd-boot.json
@@ -10160,6 +10160,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/centos_9-x86_64-vmdk-boot.json
+++ b/test/data/manifests/centos_9-x86_64-vmdk-boot.json
@@ -9738,6 +9738,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/fedora_34-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-ami-boot.json
@@ -9503,6 +9503,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "mdns",

--- a/test/data/manifests/fedora_34-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_34-aarch64-openstack-boot.json
@@ -9852,6 +9852,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "mdns",

--- a/test/data/manifests/fedora_34-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-ami-boot.json
@@ -9456,6 +9456,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "mdns",

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_commit-boot.json
@@ -10976,6 +10976,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "mdns",

--- a/test/data/manifests/fedora_34-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-fedora_iot_commit_debug-boot.json
@@ -10982,6 +10982,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "mdns",

--- a/test/data/manifests/fedora_34-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-openstack-boot.json
@@ -9805,6 +9805,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "mdns",

--- a/test/data/manifests/fedora_34-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_34-x86_64-vhd-boot.json
@@ -8917,6 +8917,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "mdns",

--- a/test/data/manifests/fedora_35-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-ami-boot.json
@@ -9794,6 +9794,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "mdns",

--- a/test/data/manifests/fedora_35-aarch64-openstack-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-openstack-boot.json
@@ -10143,6 +10143,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "mdns",

--- a/test/data/manifests/fedora_35-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-ami-boot.json
@@ -9747,6 +9747,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "mdns",

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_commit-boot.json
@@ -11015,6 +11015,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "mdns",

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_commit_debug-boot.json
@@ -11021,6 +11021,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "mdns",

--- a/test/data/manifests/fedora_35-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-openstack-boot.json
@@ -10096,6 +10096,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "mdns",

--- a/test/data/manifests/fedora_35-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-vhd-boot.json
@@ -9174,6 +9174,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "mdns",

--- a/test/data/manifests/rhel_8-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-openstack-boot.json
@@ -9212,6 +9212,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_8-aarch64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-rhel_edge_commit-boot.json
@@ -8263,6 +8263,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_8-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-openstack-boot.json
@@ -9226,6 +9226,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_8-x86_64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-rhel_edge_commit-boot.json
@@ -8561,6 +8561,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_8-x86_64-rhel_edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-rhel_edge_commit_rt-boot.json
@@ -8965,6 +8965,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_8-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-vhd-boot.json
@@ -9175,6 +9175,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_8-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-vmdk-boot.json
@@ -8674,6 +8674,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_84-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-openstack-boot.json
@@ -9730,6 +9730,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_84-aarch64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-rhel_edge_commit-boot.json
@@ -8637,6 +8637,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_84-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-openstack-boot.json
@@ -9909,6 +9909,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_84-x86_64-rhel_edge_commit-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-rhel_edge_commit-boot.json
@@ -8935,6 +8935,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_84-x86_64-rhel_edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-rhel_edge_commit_rt-boot.json
@@ -9292,6 +9292,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_84-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vhd-boot.json
@@ -9960,6 +9960,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
@@ -9567,6 +9567,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_85-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_commit-boot.json
@@ -9227,6 +9227,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_85-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-openstack-boot.json
@@ -10391,6 +10391,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_85-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-qcow2_customize-boot.json
@@ -12811,6 +12811,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_85-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-ppc64le-qcow2_customize-boot.json
@@ -13990,6 +13990,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_85-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-s390x-qcow2_customize-boot.json
@@ -14153,6 +14153,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_85-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-openstack-boot.json
@@ -10601,6 +10601,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_85-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-qcow2_customize-boot.json
@@ -13025,6 +13025,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_85-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-vhd-boot.json
@@ -10658,6 +10658,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_85-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-vmdk-boot.json
@@ -10198,6 +10198,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_86-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_commit-boot.json
@@ -9233,6 +9233,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_86-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-openstack-boot.json
@@ -10541,6 +10541,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_86-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-qcow2_customize-boot.json
@@ -12779,6 +12779,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_86-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-ppc64le-qcow2_customize-boot.json
@@ -13946,6 +13946,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_86-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-s390x-qcow2_customize-boot.json
@@ -14013,6 +14013,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_86-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit-boot.json
@@ -9530,6 +9530,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_86-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit_rt-boot.json
@@ -10257,6 +10257,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_86-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-openstack-boot.json
@@ -10751,6 +10751,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_86-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-qcow2_customize-boot.json
@@ -12993,6 +12993,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_86-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-vhd-boot.json
@@ -10704,6 +10704,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_86-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-vmdk-boot.json
@@ -10244,6 +10244,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_commit-boot.json
@@ -8314,6 +8314,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-openstack-boot.json
@@ -9229,6 +9229,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2_customize-boot.json
@@ -11751,6 +11751,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-qcow2_customize-boot.json
@@ -12626,6 +12626,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2_customize-boot.json
@@ -13356,6 +13356,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit-boot.json
@@ -8661,6 +8661,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit_rt-boot.json
@@ -10706,6 +10706,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-openstack-boot.json
@@ -9668,6 +9668,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-qcow2_customize-boot.json
@@ -12214,6 +12214,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-vhd-boot.json
@@ -9578,6 +9578,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-vmdk-boot.json
@@ -9239,6 +9239,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90_beta-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90_beta-aarch64-edge_commit-boot.json
@@ -8340,6 +8340,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90_beta-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_90_beta-aarch64-openstack-boot.json
@@ -9181,6 +9181,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90_beta-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90_beta-aarch64-qcow2_customize-boot.json
@@ -11721,6 +11721,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90_beta-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90_beta-ppc64le-qcow2_customize-boot.json
@@ -12578,6 +12578,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90_beta-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90_beta-s390x-qcow2_customize-boot.json
@@ -13327,6 +13327,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90_beta-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-edge_commit-boot.json
@@ -8687,6 +8687,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90_beta-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-edge_commit_rt-boot.json
@@ -10792,6 +10792,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90_beta-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-openstack-boot.json
@@ -9606,6 +9606,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90_beta-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-qcow2_customize-boot.json
@@ -12170,6 +12170,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90_beta-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-vhd-boot.json
@@ -9516,6 +9516,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/test/data/manifests/rhel_90_beta-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_90_beta-x86_64-vmdk-boot.json
@@ -9180,6 +9180,7 @@
         }
       }
     },
+    "firewall-default-zone": "public",
     "firewall-enabled": [
       "ssh",
       "dhcpv6-client",

--- a/tools/image-info
+++ b/tools/image-info
@@ -554,6 +554,24 @@ def read_default_target(tree):
     return subprocess_check_output(["systemctl", f"--root={tree}", "get-default"]).rstrip()
 
 
+def read_firewall_default_zone(tree):
+    """
+    Read the name of the default firewall zone
+
+    Returns: a string with the zone name. If the firewall configuration doesn't
+    exist, an empty string is returned.
+
+    An example return value:
+    "trusted"
+    """
+    try:
+        with open(f"{tree}/etc/firewalld/firewalld.conf") as f:
+            conf = parse_environment_vars(f.read())
+            return conf["DefaultZone"]
+    except FileNotFoundError:
+        return ""
+
+
 def read_firewall_zone(tree):
     """
     Read enabled services from the configuration of the default firewall zone.
@@ -568,11 +586,8 @@ def read_firewall_zone(tree):
         "cockpit"
     ]
     """
-    try:
-        with open(f"{tree}/etc/firewalld/firewalld.conf") as f:
-            conf = parse_environment_vars(f.read())
-            default = conf["DefaultZone"]
-    except FileNotFoundError:
+    default = read_firewall_default_zone(tree)
+    if default == "":
         default = "public"
 
     r = []
@@ -2272,6 +2287,10 @@ def append_filesystem(report, tree, *, is_ostree=False):
 
         with contextlib.suppress(FileNotFoundError):
             report["firewall-enabled"] = read_firewall_zone(tree)
+
+        firewall_default_zone = read_firewall_default_zone(tree)
+        if firewall_default_zone:
+            report["firewall-default-zone"] = firewall_default_zone
 
         fstab = read_fstab(tree)
         if fstab:


### PR DESCRIPTION
- osbuild2: support setting the default zone in firewall stage
- image-info: read the firewall default zone

Blocked on:

- [x] https://github.com/osbuild/osbuild/pull/980

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
