### PR TITLE
Support for fedora-iot-commit with Fedora aarch64

### DIFF
--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/distro"
-	fedora "github.com/osbuild/osbuild-composer/internal/distro/fedora33"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedora"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/test"
 )

--- a/cmd/osbuild-store-dump/main.go
+++ b/cmd/osbuild-store-dump/main.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/distro"
-	fedora "github.com/osbuild/osbuild-composer/internal/distro/fedora33"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedora"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/store"
 	"github.com/osbuild/osbuild-composer/internal/target"

--- a/internal/blueprint/customizations_test.go
+++ b/internal/blueprint/customizations_test.go
@@ -19,7 +19,7 @@ func TestCheckAllowed(t *testing.T) {
 	GID := 321
 
 	expectedUsers := []UserCustomization{
-		UserCustomization{
+		{
 			Name:        "John",
 			Description: &Desc,
 			Password:    &Pass,
@@ -80,7 +80,7 @@ func TestGetKernel(t *testing.T) {
 func TestSSHKey(t *testing.T) {
 
 	expectedSSHKeys := []SSHKeyCustomization{
-		SSHKeyCustomization{
+		{
 			User: "test-user",
 			Key:  "test-key",
 		},
@@ -111,7 +111,7 @@ func TestGetUsers(t *testing.T) {
 	GID := 321
 
 	expectedUsers := []UserCustomization{
-		UserCustomization{
+		{
 			Name:        "John",
 			Description: &Desc,
 			Password:    &Pass,
@@ -137,7 +137,7 @@ func TestGetGroups(t *testing.T) {
 
 	GID := 1234
 	expectedGroups := []GroupCustomization{
-		GroupCustomization{
+		{
 			Name: "TestGroup",
 			GID:  &GID,
 		},

--- a/internal/distro/distro_test_common/distro_test_common.go
+++ b/internal/distro/distro_test_common/distro_test_common.go
@@ -170,10 +170,13 @@ func kernelCount(imgType distro.ImageType) int {
 	sets := imgType.PackageSets(blueprint.Blueprint{})
 	pkgs := sets["packages"].Append(sets["blueprint"]).Include
 	n := 0
+	// ignore duplicated kernel packages
+	found := map[string]struct{}{}
 	for _, pkg := range pkgs {
 		for _, kernel := range knownKernels {
-			if kernel == pkg {
+			if _, ok := found[pkg]; !ok && kernel == pkg {
 				n++
+				found[pkg] = struct{}{}
 			}
 		}
 	}

--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -1,4 +1,4 @@
-package fedora33
+package fedora
 
 import (
 	"encoding/json"

--- a/internal/distro/fedora/distro_test.go
+++ b/internal/distro/fedora/distro_test.go
@@ -1,4 +1,4 @@
-package fedora33_test
+package fedora_test
 
 import (
 	"fmt"
@@ -10,7 +10,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/distro/distro_test_common"
-	fedora "github.com/osbuild/osbuild-composer/internal/distro/fedora33"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedora"
 )
 
 const (

--- a/internal/distro/fedora/package_sets.go
+++ b/internal/distro/fedora/package_sets.go
@@ -1,4 +1,4 @@
-package fedora33
+package fedora
 
 // This file defines package sets that are used by more than one image type.
 

--- a/internal/distro/fedora33/package_sets.go
+++ b/internal/distro/fedora33/package_sets.go
@@ -1,0 +1,258 @@
+package fedora33
+
+// This file defines package sets that are used by more than one image type.
+
+import (
+	"github.com/osbuild/osbuild-composer/internal/distro"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+)
+
+// BUILD PACKAGE SETS
+
+// distro-wide build package set
+func distroBuildPackageSet(t *imageType) rpmmd.PackageSet {
+	ps := rpmmd.PackageSet{
+		Include: []string{
+			"dnf",
+			"dosfstools",
+			"e2fsprogs",
+			"policycoreutils",
+			"qemu-img",
+			"selinux-policy-targeted",
+			"systemd",
+			"tar",
+			"xz",
+		},
+	}
+
+	if t.arch.Name() == distro.X86_64ArchName {
+		ps = ps.Append(x8664BuildPackageSet(t))
+	}
+	return ps
+}
+
+// x86_64 build package set
+func x8664BuildPackageSet(t *imageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{"grub2-pc"},
+	}
+}
+
+// AMI type
+func ec2CorePackageSet(t *imageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"@Core",
+			"chrony",
+			"selinux-policy-targeted",
+			"langpacks-en",
+			"libxcrypt-compat",
+			"xfsprogs",
+			"cloud-init",
+			"checkpolicy",
+			"net-tools",
+		},
+		Exclude: []string{
+			"dracut-config-rescue",
+			"geolite2-city",
+			"geolite2-country",
+			"zram-generator-defaults",
+		},
+	}
+}
+
+// QCOW2 type
+func qcow2PackageSet(t *imageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"@Fedora Cloud Server",
+			"chrony",
+			"systemd-udev",
+			"selinux-policy-targeted",
+			"langpacks-en",
+		},
+		Exclude: []string{
+			"dracut-config-rescue",
+			"etables",
+			"firewalld",
+			"geolite2-city",
+			"geolite2-country",
+			"gobject-introspection",
+			"plymouth",
+			"zram-generator-defaults",
+		},
+	}
+}
+
+// OpenStack package set
+func openStackPackageSet(t *imageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"@Core",
+			"chrony",
+			"selinux-policy-targeted",
+			"spice-vdagent",
+			"qemu-guest-agent",
+			"xen-libs",
+			"langpacks-en",
+			"cloud-init",
+			"libdrm",
+		},
+		Exclude: []string{
+			"dracut-config-rescue",
+			"geolite2-city",
+			"geolite2-country",
+			"zram-generator-defaults",
+		},
+	}
+}
+
+// VHD package set
+func vhdPackageSet(t *imageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"@Core",
+			"chrony",
+			"selinux-policy-targeted",
+			"langpacks-en",
+			"net-tools",
+			"ntfsprogs",
+			"WALinuxAgent",
+			"libxcrypt-compat",
+			"initscripts",
+			"glibc-all-langpacks",
+		},
+		Exclude: []string{
+			"dracut-config-rescue",
+			"geolite2-city",
+			"geolite2-country",
+			"zram-generator-defaults",
+		},
+	}
+}
+
+// VMDK package set
+func vmdkPackageSet(t *imageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"@Fedora Cloud Server",
+			"chrony",
+			"systemd-udev",
+			"selinux-policy-targeted",
+			"langpacks-en",
+		},
+		Exclude: []string{
+			"dracut-config-rescue",
+			"etables",
+			"firewalld",
+			"geolite2-city",
+			"geolite2-country",
+			"gobject-introspection",
+			"plymouth",
+			"zram-generator-defaults",
+		},
+	}
+}
+
+// OCI Image package set
+func ociImagePackageSet(t *imageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"@Fedora Cloud Server",
+			"chrony",
+			"systemd-udev",
+			"selinux-policy-targeted",
+			"langpacks-en",
+		},
+		Exclude: []string{
+			"dracut-config-rescue",
+			"etables",
+			"firewalld",
+			"geolite2-city",
+			"geolite2-country",
+			"gobject-introspection",
+			"plymouth",
+			"zram-generator-defaults",
+		},
+	}
+}
+
+// iot commit OS package set
+
+// common iot image build package set
+func iotBuildPackageSet(t *imageType) rpmmd.PackageSet {
+	return distroBuildPackageSet(t).Append(rpmmd.PackageSet{Include: []string{"rpm-ostree"}})
+}
+
+func iotCommitPackageSet(t *imageType) rpmmd.PackageSet {
+	ps := rpmmd.PackageSet{
+		Include: []string{
+			"fedora-release-iot",
+			"glibc", "glibc-minimal-langpack", "nss-altfiles",
+			"sssd-client", "libsss_sudo", "shadow-utils",
+			"dracut-config-generic", "dracut-network", "polkit", "lvm2",
+			"cryptsetup", "pinentry",
+			"keyutils", "cracklib-dicts",
+			"e2fsprogs", "xfsprogs", "dosfstools",
+			"gnupg2",
+			"basesystem", "python3", "bash",
+			"xz", "gzip",
+			"coreutils", "which", "curl",
+			"firewalld", "iptables",
+			"NetworkManager", "NetworkManager-wifi", "NetworkManager-wwan",
+			"wpa_supplicant", "iwd", "tpm2-pkcs11",
+			"dnsmasq", "traceroute",
+			"hostname", "iproute", "iputils",
+			"openssh-clients", "openssh-server", "passwd",
+			"policycoreutils", "procps-ng", "rootfiles", "rpm",
+			"selinux-policy-targeted", "setup", "shadow-utils",
+			"sudo", "systemd", "util-linux", "vim-minimal",
+			"less", "tar",
+			"fwupd", "usbguard",
+			"greenboot", "greenboot-grub2", "greenboot-rpm-ostree-grub2", "greenboot-reboot", "greenboot-status",
+			"ignition", "zezere-ignition",
+			"rsync", "attr",
+			"ima-evm-utils",
+			"bash-completion",
+			"tmux", "screen",
+			"policycoreutils-python-utils",
+			"setools-console",
+			"audit", "rng-tools", "chrony",
+			"bluez", "bluez-libs", "bluez-mesh",
+			"kernel-tools", "libgpiod-utils",
+			"podman", "container-selinux", "skopeo", "criu",
+			"slirp4netns", "fuse-overlayfs",
+			"clevis", "clevis-dracut", "clevis-luks", "clevis-pin-tpm2",
+			"parsec", "dbus-parsec",
+			"iwl7260-firmware", "iwlax2xx-firmware",
+		},
+	}
+	switch t.arch.Name() {
+	case distro.X86_64ArchName:
+		ps = ps.Append(x8664IOTCommitPackageSet())
+
+	case distro.Aarch64ArchName:
+		ps = ps.Append(aarch64IOTCommitPackageSet())
+	}
+
+	return ps
+
+}
+
+func x8664IOTCommitPackageSet() rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"grub2", "grub2-efi-x64", "efibootmgr", "shim-x64", "microcode_ctl",
+			"iwl1000-firmware", "iwl100-firmware", "iwl105-firmware", "iwl135-firmware",
+			"iwl2000-firmware", "iwl2030-firmware", "iwl3160-firmware", "iwl5000-firmware",
+			"iwl5150-firmware", "iwl6000-firmware", "iwl6050-firmware",
+		},
+	}
+}
+
+func aarch64IOTCommitPackageSet() rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{"grub2", "grub2-efi-aa64", "efibootmgr", "shim-aa64", "uboot-images-armv8",
+			"bcm283x-firmware", "arm-image-installer"},
+	}
+}

--- a/internal/distroregistry/distroregistry.go
+++ b/internal/distroregistry/distroregistry.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/osbuild/osbuild-composer/internal/distro"
-	fedora "github.com/osbuild/osbuild-composer/internal/distro/fedora33"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedora"
 	"github.com/osbuild/osbuild-composer/internal/distro/rhel8"
 	"github.com/osbuild/osbuild-composer/internal/distro/rhel84"
 	"github.com/osbuild/osbuild-composer/internal/distro/rhel85"

--- a/internal/osbuild1/assembler_test.go
+++ b/internal/osbuild1/assembler_test.go
@@ -55,7 +55,7 @@ func TestAssembler_UnmarshalJSON(t *testing.T) {
 					Size:     2147483648,
 					PTUUID:   "0x14fc63d2",
 					PTType:   "mbr",
-					Partitions: []QEMUPartition{QEMUPartition{
+					Partitions: []QEMUPartition{{
 						Start:    2048,
 						Bootable: true,
 						Filesystem: &QEMUFilesystem{

--- a/internal/osbuild1/source_test.go
+++ b/internal/osbuild1/source_test.go
@@ -64,8 +64,8 @@ func TestSource_UnmarshalJSON(t *testing.T) {
 			fields: fields{
 				Name: "org.osbuild.files",
 				Source: &FilesSource{URLs: map[string]FileSource{
-					"checksum1": FileSource{URL: "url1"},
-					"checksum2": FileSource{URL: "url2"},
+					"checksum1": {URL: "url1"},
+					"checksum2": {URL: "url2"},
 				}},
 			},
 			args: args{

--- a/internal/store/json_test.go
+++ b/internal/store/json_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/distro"
-	fedora "github.com/osbuild/osbuild-composer/internal/distro/fedora33"
+	"github.com/osbuild/osbuild-composer/internal/distro/fedora"
 	"github.com/osbuild/osbuild-composer/internal/distro/test_distro"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/target"

--- a/internal/store/json_test.go
+++ b/internal/store/json_test.go
@@ -425,11 +425,11 @@ func Test_newBlueprintsFromV0(t *testing.T) {
 				},
 			},
 			want: map[string]blueprint.Blueprint{
-				"blueprint-1": blueprint.Blueprint{
+				"blueprint-1": {
 					Name:        "blueprint-1",
 					Description: "First Blueprint in Test",
 					Version:     "0.0.1"},
-				"blueprint-2": blueprint.Blueprint{
+				"blueprint-2": {
 					Name:        "blueprint-2",
 					Description: "Second Blueprint in Test",
 					Version:     "0.0.1"},
@@ -459,11 +459,11 @@ func Test_newBlueprintsV0(t *testing.T) {
 		{
 			name: "Two Blueprints",
 			blueprints: map[string]blueprint.Blueprint{
-				"blueprint-1": blueprint.Blueprint{
+				"blueprint-1": {
 					Name:        "blueprint-1",
 					Description: "First Blueprint in Test",
 					Version:     "0.0.1"},
-				"blueprint-2": blueprint.Blueprint{
+				"blueprint-2": {
 					Name:        "blueprint-2",
 					Description: "Second Blueprint in Test",
 					Version:     "0.0.1"},
@@ -517,11 +517,11 @@ func Test_newWorkspaceFromV0(t *testing.T) {
 				},
 			},
 			want: map[string]blueprint.Blueprint{
-				"blueprint-1": blueprint.Blueprint{
+				"blueprint-1": {
 					Name:        "blueprint-1",
 					Description: "First Blueprint in Test",
 					Version:     "0.0.1"},
-				"blueprint-2": blueprint.Blueprint{
+				"blueprint-2": {
 					Name:        "blueprint-2",
 					Description: "Second Blueprint in Test",
 					Version:     "0.0.1"},
@@ -551,11 +551,11 @@ func Test_newWorkspaceV0(t *testing.T) {
 		{
 			name: "Two Blueprints",
 			blueprints: map[string]blueprint.Blueprint{
-				"blueprint-1": blueprint.Blueprint{
+				"blueprint-1": {
 					Name:        "blueprint-1",
 					Description: "First Blueprint in Test",
 					Version:     "0.0.1"},
-				"blueprint-2": blueprint.Blueprint{
+				"blueprint-2": {
 					Name:        "blueprint-2",
 					Description: "Second Blueprint in Test",
 					Version:     "0.0.1"},
@@ -1264,7 +1264,7 @@ func Test_newComposesV0(t *testing.T) {
 				uuid.MustParse("f53b49c0-d321-447e-8ab8-6e827891e3f0"): {
 					Blueprint: &bp,
 					ImageBuilds: []imageBuildV0{
-						imageBuildV0{
+						{
 							ID:        0,
 							ImageType: test_distro.TestImageTypeName,
 							Manifest:  []byte("JSON MANIFEST GOES HERE"),
@@ -1295,7 +1295,7 @@ func Test_newComposesV0(t *testing.T) {
 				uuid.MustParse("14c454d0-26f3-4a56-8ceb-a5673aaba686"): {
 					Blueprint: &bp,
 					ImageBuilds: []imageBuildV0{
-						imageBuildV0{
+						{
 							ID:        0,
 							ImageType: test_distro.TestImageTypeName,
 							Manifest:  []byte("JSON MANIFEST GOES HERE"),

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -44,11 +44,11 @@ type storeTest struct {
 
 //func to initialize some default values before the suite is ran
 func (suite *storeTest) SetupSuite() {
-	suite.myRepoConfig = []rpmmd.RepoConfig{rpmmd.RepoConfig{
+	suite.myRepoConfig = []rpmmd.RepoConfig{{
 		Name:       "testRepo",
 		MirrorList: "testURL",
 	}}
-	suite.myPackageSpec = []rpmmd.PackageSpec{rpmmd.PackageSpec{}}
+	suite.myPackageSpec = []rpmmd.PackageSpec{{}}
 	suite.myDistro = test_distro.New()
 	suite.myArch, _ = suite.myDistro.GetArch(test_distro.TestArchName)
 	suite.myImageType, _ = suite.myArch.GetImageType(test_distro.TestImageTypeName)
@@ -327,7 +327,7 @@ func (suite *storeTest) TestDeleteSourceByID() {
 }
 
 func (suite *storeTest) TestPushSource() {
-	expectedSource := map[string]SourceConfig{"testKey": SourceConfig{Name: "testSourceConfig", Type: "", URL: "", CheckGPG: false, CheckSSL: false, System: false}}
+	expectedSource := map[string]SourceConfig{"testKey": {Name: "testSourceConfig", Type: "", URL: "", CheckGPG: false, CheckSSL: false, System: false}}
 	suite.myStore.PushSource("testKey", suite.mySourceConfig)
 	suite.Equal(expectedSource, suite.myStore.sources)
 }
@@ -359,7 +359,7 @@ func (suite *storeTest) TestGetSource() {
 func (suite *storeTest) TestGetAllSourcesByName() {
 	suite.myStore.sources = make(map[string]SourceConfig)
 	suite.myStore.sources["testSource"] = suite.mySourceConfig
-	expectedSource := map[string]SourceConfig{"testSourceConfig": SourceConfig{Name: "testSourceConfig", Type: "", URL: "", CheckGPG: false, CheckSSL: false, System: false}}
+	expectedSource := map[string]SourceConfig{"testSourceConfig": {Name: "testSourceConfig", Type: "", URL: "", CheckGPG: false, CheckSSL: false, System: false}}
 	actualSource := suite.myStore.GetAllSourcesByName()
 	suite.Equal(expectedSource, actualSource)
 }
@@ -367,7 +367,7 @@ func (suite *storeTest) TestGetAllSourcesByName() {
 func (suite *storeTest) TestGetAllSourcesByID() {
 	suite.myStore.sources = make(map[string]SourceConfig)
 	suite.myStore.sources["testSource"] = suite.mySourceConfig
-	expectedSource := map[string]SourceConfig{"testSource": SourceConfig{Name: "testSourceConfig", Type: "", URL: "", CheckGPG: false, CheckSSL: false, System: false}}
+	expectedSource := map[string]SourceConfig{"testSource": {Name: "testSourceConfig", Type: "", URL: "", CheckGPG: false, CheckSSL: false, System: false}}
 	actualSource := suite.myStore.GetAllSourcesByID()
 	suite.Equal(expectedSource, actualSource)
 }

--- a/test/data/manifests/fedora_35-aarch64-ami-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-ami-boot.json
@@ -3683,6 +3683,1708 @@
     }
   },
   "rpmmd": {
+    "blueprint": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm",
+        "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm",
+        "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm",
+        "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
+        "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm",
+        "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm",
+        "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm",
+        "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm",
+        "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
+        "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm",
+        "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm",
+        "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm",
+        "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm",
+        "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm",
+        "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
+        "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm",
+        "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm",
+        "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm",
+        "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm",
+        "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm",
+        "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm",
+        "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm",
+        "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
     "build-packages": [
       {
         "name": "acl",

--- a/test/data/manifests/fedora_35-aarch64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-fedora_iot_commit-boot.json
@@ -1,11 +1,8 @@
 {
-  "boot": {
-    "type": "openstack"
-  },
   "compose-request": {
     "distro": "fedora-35",
     "arch": "aarch64",
-    "image-type": "openstack",
+    "image-type": "fedora-iot-commit",
     "repositories": [
       {
         "name": "fedora",
@@ -34,22 +31,8 @@
         "check_gpg": true
       }
     ],
-    "filename": "disk.qcow2",
-    "blueprint": {
-      "name": "openstack-boot-test",
-      "description": "Image for boot test",
-      "packages": [],
-      "modules": [],
-      "groups": [],
-      "customizations": {
-        "user": [
-          {
-            "name": "redhat",
-            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
-          }
-        ]
-      }
-    }
+    "filename": "commit.tar",
+    "blueprint": {}
   },
   "manifest": {
     "sources": {
@@ -64,14 +47,14 @@
           "sha256:01c4eedbedec34f5413a98f2dae6a84466270a71aceb647206e84e64b452ed96": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-python3-0.8.2-8.fc35.aarch64.rpm"
           },
+          "sha256:028ac461745f7189b35ebb09178d4c69206d0fc6fc0f0e82d465e245d3173d1d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmbim-utils-1.26.0-1.fc35.aarch64.rpm"
+          },
           "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm"
           },
           "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm"
-          },
-          "sha256:02f5457be9eac8a6ae4b19950895850da94f62a9c5e5f390a68a590092096c96": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/a/alsa-lib-1.2.6.1-3.fc35.aarch64.rpm"
           },
           "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm"
@@ -91,11 +74,11 @@
           "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm"
           },
-          "sha256:07fd0548f64b358ffd9ce32e885b7b91dc7e6208171d7efb9874923aead0fa5c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm"
+          "sha256:080dca65723955e080557603c34ac7f4961f438ec90f2a1183bad3d321ffd2c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-tools-libs-5.15.4-200.fc35.aarch64.rpm"
           },
-          "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-jsonpatch-1.21-18.fc35.noarch.rpm"
+          "sha256:08809b3fc9e1a59314bba40beeccd2981f31f24b62baf276217b6e9eae193ad7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/a/arm-image-installer-3.5-1.fc35.noarch.rpm"
           },
           "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.aarch64.rpm"
@@ -103,8 +86,11 @@
           "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm"
           },
-          "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm"
+          "sha256:0cb072b3ab5755d4ee272fb3fe9b632ab53c14a6037e42cec7dc0de5b7341b19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/greenboot-reboot-0.12.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:0d2e94bebd4f3ca297c347171e548e9a9ec917dfaee87d73e62a753177d4fd8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-parsec-0.3.1-4.fc35.aarch64.rpm"
           },
           "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm"
@@ -118,11 +104,11 @@
           "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm"
           },
-          "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm"
+          "sha256:10202d4ab23cec2514530c824c118f566829b14c1784ade9db35079aacc7dabf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/usbguard-1.0.0-6.fc35.aarch64.rpm"
           },
-          "sha256:10190a125e7f12c0fb5c138b041c1c3625c43be574b1a42a845217cf2737cd88": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/spice-vdagent-0.21.0-5.fc35.aarch64.rpm"
+          "sha256:109eec660842523b39da8f0647db99c05f21bd54f7eac626789be55acce59e81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lvm2-libs-2.03.11-6.fc35.aarch64.rpm"
           },
           "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm"
@@ -142,14 +128,23 @@
           "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm"
           },
-          "sha256:137e82364adba68a95cf5af5369af68318afe9fea740c5deb6cd40f71727db34": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-guest-agent-6.1.0-10.fc35.aarch64.rpm"
+          "sha256:13fb3e19cb7a637e64b94a049d756401c637c3871b99f51b0531db8602bf135f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-wwan-1.32.12-2.fc35.aarch64.rpm"
           },
           "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm"
           },
-          "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-font-en-3.0-15.fc35.noarch.rpm"
+          "sha256:1606617e17243ca6d9cfab6553f6930ff859634a04d3ffec3cb6c1a7277d6709": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/jose-11-3.fc35.aarch64.rpm"
+          },
+          "sha256:1679081e390beefe9b77ca83d0e9d5ce3731762b271582116b1b8f222bc3f84c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/crun-1.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:183226966749e33e2fdc008797fb5f7782da589be4a10ef3692bbe684892e88f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnet-1.2-4.fc35.aarch64.rpm"
+          },
+          "sha256:190a2c0a742e9e3080107b4ea209bfa0adfd13f9892cbe99f4e203153724b93f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zezere-ignition-0.5-9.fc35.noarch.rpm"
           },
           "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.aarch64.rpm"
@@ -157,11 +152,14 @@
           "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm"
           },
-          "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.aarch64.rpm"
+          "sha256:1b7d568ae321ad117b5b48eb61dda25b02ba7762b8097f0abc87b461b4979998": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/v/volume_key-libs-0.3.12-14.fc35.aarch64.rpm"
           },
-          "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fonts-filesystem-2.0.5-6.fc35.noarch.rpm"
+          "sha256:1bed49c7153d4b2ea49a46af3360e4bee3a7f435ff0e4b58b96370813f738b41": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libftdi-1.5-2.fc35.aarch64.rpm"
+          },
+          "sha256:1d0db47703af808b523a192acbcbde38d01b327f27d8bb9b28d17c12fab56e2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblockdev-2.26-1.fc35.aarch64.rpm"
           },
           "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm"
@@ -181,14 +179,23 @@
           "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm"
           },
+          "sha256:215c466fbf21d59ab899258513f6ce120a9a01ce09b544e6daa6fa23711a6434": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dnsmasq-2.86-3.fc35.aarch64.rpm"
+          },
           "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm"
           },
           "sha256:22a906074aaab00a9c1bac318f9d10323566670fc7772c61e196574dfc63ee9b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-policycoreutils-3.3-1.fc35.noarch.rpm"
           },
+          "sha256:2367e7436b2a8635504c9ad4a0a30043cd782e4d3bb61bc2f8f3ae54fc235a01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblockdev-swap-2.26-1.fc35.aarch64.rpm"
+          },
           "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:23d8e74f6ee55974f07a08ef7f881956029d52a03a6c3c4d93d2ba77d2b12739": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/clevis-luks-18-4.fc35.aarch64.rpm"
           },
           "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm"
@@ -199,11 +206,11 @@
           "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.aarch64.rpm"
           },
+          "sha256:2533e03bea40216e6ada92db8d91f0a63742267c5cb853f0ca1733a4afe2a532": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libatasmart-0.19-21.fc35.aarch64.rpm"
+          },
           "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm"
-          },
-          "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-attrs-21.2.0-4.fc35.noarch.rpm"
           },
           "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm"
@@ -214,11 +221,20 @@
           "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efibootmgr-16-11.fc35.aarch64.rpm"
           },
+          "sha256:26db7baa5f56c18294dd53b31b6d59ef38fffe05d46608594653a457789c13a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/attr-2.5.1-3.fc35.aarch64.rpm"
+          },
           "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.aarch64.rpm"
           },
+          "sha256:2746f2c19fa38e489d55f0e0ee0c07bd6edbaf259dd84aee17381f3709cb58e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/i/iwd-1.21-1.fc35.aarch64.rpm"
+          },
           "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:28024f873b855efd75f0a1cbd9149409a4fc553276c95811d136ff844aaaedd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-subid-4.9-8.fc35.aarch64.rpm"
           },
           "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm"
@@ -229,32 +245,41 @@
           "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm"
           },
+          "sha256:2b04a72168d77e8a916b1bf7e70cc1977064e19339132562e85d899e3a29b603": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/flashrom-1.2-7.fc35.aarch64.rpm"
+          },
           "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm"
           },
           "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm"
           },
-          "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.26.7-2.fc35.noarch.rpm"
-          },
-          "sha256:2db66e2d4cb69b7433e334870a06b167dfbe38ba8c8be5d6eb6d3fe69ac0f769": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXext-1.3.4-7.fc35.aarch64.rpm"
+          "sha256:2dd8af06b106716d1e2d7c058518efc4be513e3bab8d4637ae6d5202c2acfcf3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bcm2835-firmware-20210930-1.b5257da.fc35.aarch64.rpm"
           },
           "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efi-filesystem-5-4.fc35.noarch.rpm"
           },
+          "sha256:2f36a4315506b13e0c8b01a08511c484b29028ebb9dace8d6d1aa94db2716219": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/greenboot-rpm-ostree-grub2-0.12.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:3030255b1885347b03057ca9e9ce9c9ad29d186727ab4d26cabd14eedaf84c05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgudev-237-1.fc35.aarch64.rpm"
+          },
           "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm"
+          },
+          "sha256:308fcc73237de6563a5343fd3b45fd29abb41338fc7517ca7818f74bf2e315b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/nspr-4.32.0-4.fc35.aarch64.rpm"
           },
           "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm"
           },
+          "sha256:30bd2714391cd78d2072d2ad5fc0d94adb1875b39159be8dfcf602ac36f31040": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-2.4.2-1.fc35.aarch64.rpm"
+          },
           "sha256:30c4143715cbe6d44c23039777276fe7b900130ea6193d75512f5d4651e52e13": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gobject-introspection-1.70.0-1.fc35.aarch64.rpm"
-          },
-          "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-requests-2.27.0-1.fc35.noarch.rpm"
           },
           "sha256:31e3038cdc752f890970d60653b510eb815e56be7854ba627ef7843b4c760ec9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-nftables-1.0.0-1.fc35.aarch64.rpm"
@@ -262,11 +287,8 @@
           "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm"
           },
-          "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-ply-3.11-13.fc35.noarch.rpm"
-          },
-          "sha256:375b89f3a452a62f3a02ada8971b14e854fa95b0d4cb9efb0449e5f85d6959c6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-markupsafe-2.0.0-2.fc35.aarch64.rpm"
+          "sha256:35eafd70242202d8a16226e1d792e940546d8c6f42d9211e0d286e7fe4d4abae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/skopeo-1.5.2-1.fc35.aarch64.rpm"
           },
           "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm"
@@ -277,26 +299,26 @@
           "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/firewalld-1.0.1-2.fc35.noarch.rpm"
           },
-          "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.aarch64.rpm"
+          "sha256:38f2d755858d9d6e9ff7e30717a0974e4f731173943665cf1aba12213dd79732": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/criu-3.16.1-2.fc35.aarch64.rpm"
           },
           "sha256:39fd9eb8e77b430637602dc7cfce448e1792ace9cc9041c33f957b70d7b205c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/inih-49-4.fc35.aarch64.rpm"
           },
-          "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.aarch64.rpm"
-          },
           "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm"
+          },
+          "sha256:3b1c4c7a8c136815e78051ebe384d5497f89b3e004cc6ded86cea5971b20cb63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libqmi-utils-1.30.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:3b2989088d5a142d61120e445db12fe0eea145dbd21d6ffdae1483aa2c62a385": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rtl-sdr-0.6.0-10.fc35.aarch64.rpm"
           },
           "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm"
           },
           "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm"
-          },
-          "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.aarch64.rpm"
           },
           "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm"
@@ -307,11 +329,11 @@
           "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm"
           },
+          "sha256:3d8acf78b1daa3e2b6528471f7ab3799a24ba1ffa66751f134c74db56b91ee7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/containernetworking-plugins-1.0.1-1.fc35.aarch64.rpm"
+          },
           "sha256:3eecb51a03f9eed59710f6c6cbc5d66aea9bc521940d0b8d73fca835f1402897": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chrony-4.1-3.fc35.aarch64.rpm"
-          },
-          "sha256:3f7252d59a6cafd37c6ce4851ba6ab13a0594e0a435bce4d8c392485888278a5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libdrm-2.4.109-1.fc35.aarch64.rpm"
           },
           "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm"
@@ -328,9 +350,6 @@
           "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm"
           },
-          "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.aarch64.rpm"
-          },
           "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm"
           },
@@ -340,29 +359,47 @@
           "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.aarch64.rpm"
           },
+          "sha256:43adc18fc7e50377ea155a9679c7a7985ded3dfe4692019ca54ef1d65c702e43": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/u/uboot-images-armv8-2021.10-3.fc35.noarch.rpm"
+          },
           "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:445c078bffe6ec618ac462378b67632a2d0732d0767f9d008ee163320d2e7a3d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bcm283x-overlays-20210930-1.b5257da.fc35.aarch64.rpm"
+          },
+          "sha256:46266d1762bf3ae1711b1cbfb37cabc8e3c884cdbecbdaa6d9fff1259fa0f55b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-2.9.9-13.fc35.aarch64.rpm"
           },
           "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm"
           },
-          "sha256:469ec3ace1ffa4e3153c772d5ec5a65f8cb6e98d07405134c6b06545796e31c2": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyyaml-5.4.1-4.fc35.aarch64.rpm"
+          "sha256:4728c8dcf044d801a3c03d786598d23c5f6c7df8d8b363796f5ba3fdbd566d65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fwupd-efi-1.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:475a1da757738ac1c46ed406c782726ad75b9171254c9aecb282353bec8ccf0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblockdev-part-2.26-1.fc35.aarch64.rpm"
+          },
+          "sha256:4801858945fbf03ccf0605293a3749826e09b39658597106c89bb61fb3940366": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/jq-1.6-10.fc35.aarch64.rpm"
+          },
+          "sha256:4991a3c50f9f52859148b48cd2a251a4c14d7b9b510f6c2f27e7d849201dbfca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fwupd-plugin-uefi-capsule-data-1.7.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:4a3381116ae3fc1b08a6459eef839ee8e0e75d5bd83d00a24f132b34f7580d46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-tools-5.15.4-200.fc35.aarch64.rpm"
           },
           "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/parted-3.4-6.fc35.aarch64.rpm"
           },
-          "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-charset-normalizer-2.0.4-1.fc35.noarch.rpm"
+          "sha256:4b29b2e2e3e15473e94ef1f37225806f1af94ab990bf2c9022e34d9bb28089a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblockdev-mdraid-2.26-1.fc35.aarch64.rpm"
+          },
+          "sha256:4b3dfb13a1aa92f00e3bf0ab38fc41c7fe98a519e3a1b5b32aae1ec3d8bec520": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/criu-libs-3.16.1-2.fc35.aarch64.rpm"
           },
           "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm"
-          },
-          "sha256:4c728458d61305c022946aa7199e2b462ac4449f04303def895923581b05d8c2": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libX11-common-1.7.3.1-1.fc35.noarch.rpm"
-          },
-          "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt-2.1.0-2.fc35.noarch.rpm"
           },
           "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/firewalld-filesystem-1.0.1-2.fc35.noarch.rpm"
@@ -376,23 +413,29 @@
           "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.aarch64.rpm"
           },
+          "sha256:4e3887518cd02b033fc31d445ed18cb70cb0ab7568a2eb7e39eec43c5dcbe951": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/clevis-dracut-18-4.fc35.aarch64.rpm"
+          },
           "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.aarch64.rpm"
           },
-          "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-en-3.0-15.fc35.noarch.rpm"
+          "sha256:4f0d774fdab0e9e3052ebed054f484f7e2e20bb1ff4694b1bb612ef4c57a2a51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/conmon-2.0.30-2.fc35.aarch64.rpm"
           },
           "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.aarch64.rpm"
           },
-          "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.aarch64.rpm"
+          "sha256:4f539ddd922dfc864123f8fd35ba364e19f9ccd9bbf6c9d480c65fef3f254782": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/clevis-pin-tpm2-0.5.0-1.fc35.aarch64.rpm"
           },
           "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm"
           },
           "sha256:501d1c9a812d927bc37ec65f11d818fef9f0647d711f132c91c1718124c32dc4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-gobject-base-3.42.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:50763d3f0eda21834dd020c4c3f4cf1ae982da02c841ed95aee507290be4b058": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-event-1.02.175-6.fc35.aarch64.rpm"
           },
           "sha256:50d0b3571e271cce3c9f314f3fab80485b706c347cb6e9c710c28cf552c07ec5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/checkpolicy-3.3-1.fc35.aarch64.rpm"
@@ -409,11 +452,11 @@
           "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm"
           },
+          "sha256:53beb80220710bbd61de26573ca7d8fee1ec4cf914f5d9f84ad9e7f231f22bfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/nss-softokn-freebl-3.73.0-1.fc35.aarch64.rpm"
+          },
           "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.aarch64.rpm"
-          },
-          "sha256:5437317aa8a5d94a9de9cd15d58399146783b4b96ee52a0a134c09b79933a8b0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.34-11.fc35.aarch64.rpm"
           },
           "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm"
@@ -424,6 +467,9 @@
           "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm"
           },
+          "sha256:5622830594978a3c99a778d66011211a058f95c80e421910bdd90118662d81e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libudisks2-2.9.4-1.fc35.aarch64.rpm"
+          },
           "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm"
           },
@@ -433,17 +479,8 @@
           "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm"
           },
-          "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-configobj-5.0.6-25.fc35.noarch.rpm"
-          },
-          "sha256:58b6c3272af7450868f9b6ee3e15f05e45104751cacaa4a22345983caaea14da": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-filesystem-1.7.0-11.fc35.aarch64.rpm"
-          },
-          "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.aarch64.rpm"
-          },
-          "sha256:5969e69eb5d24f65384e616513a940894f570a0423469dbcdead3d3b3d6c0b7f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/h/hwdata-0.355-1.fc35.noarch.rpm"
+          "sha256:586c904f0e704585041c3d71a83c891a124922e5348a02ec4834b8f1a17f3929": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxmlb-0.3.6-1.fc35.aarch64.rpm"
           },
           "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.aarch64.rpm"
@@ -454,17 +491,14 @@
           "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm"
           },
+          "sha256:5b6c7f2e43c1260c206d65dccd8cb947cb0f3348eaadf0afa6809fea9c9f914d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/ModemManager-1.18.2-1.fc35.aarch64.rpm"
+          },
           "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm"
           },
           "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm"
-          },
-          "sha256:5d3d700fc60b7ec85915692030f7fa121ca83ea74acca62b6dfdbc9f8cd5ae7e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdt-1.6.1-2.fc35.aarch64.rpm"
-          },
-          "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
           },
           "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm"
@@ -472,29 +506,44 @@
           "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.aarch64.rpm"
           },
-          "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm"
-          },
           "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm"
           },
-          "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pycparser-2.20-5.fc35.noarch.rpm"
+          "sha256:6309f36857ff99d328e83a052186b819b92139c37da35160c91d1d5624a7ae1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/j/jitterentropy-3.3.1-1.fc35.aarch64.rpm"
           },
-          "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.aarch64.rpm"
+          "sha256:6318c5e457a2fa88c518f518866d9d8c3e6337fd0016debd04a58f72d9da6e6e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/catatonit-0.1.7-1.fc35.aarch64.rpm"
+          },
+          "sha256:641c5b454f3cefa3c9da1b9970486bb931852945398efd977e744684d1da781c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-iot-35-36.noarch.rpm"
+          },
+          "sha256:649b1aeda89e3838e2063ec6a01ba516a199880f7333e7cc2331e0041638a050": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lzo-2.10-5.fc35.aarch64.rpm"
           },
           "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm"
           },
+          "sha256:66105bec59eecac3dc1b3a08f8530271014df12c5b69cc1a699fb1959bd63058": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/nss-util-3.73.0-1.fc35.aarch64.rpm"
+          },
           "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm"
           },
-          "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm"
+          "sha256:66ffa480698ff5d048b1ffcfd5a78ecaaeb831831591c0457148b69b8d120d5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/wireless-regdb-2021.07.14-2.fc35.noarch.rpm"
+          },
+          "sha256:678a86552377e7ca081270778b0434fb8cfef3ecb0ecf4fca52f53afe0c66d9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/b/bluez-mesh-5.63-1.fc35.aarch64.rpm"
+          },
+          "sha256:67aac59b48fb8b8ce219306fff459a09a1b7e5dcb3ae24cf7ce48a6d9ef13ff8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tpm2-tools-5.2-1.fc35.aarch64.rpm"
           },
           "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm"
+          },
+          "sha256:69048b9660fd703a15817beb7248fbd14ee00c0b5e2e3d1c65a4ad9a994a5183": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tpm2-pkcs11-1.7.0-1.fc35.aarch64.rpm"
           },
           "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm"
@@ -505,14 +554,20 @@
           "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm"
           },
-          "sha256:69e19b20bc15ca446f218e1106357f6ee2fbe78fccfe4eb7100a9eafd91cce23": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpciaccess-0.16-5.fc35.aarch64.rpm"
+          "sha256:69e489e334c05ce06c984e189d73849853583c59aaf7c60a690bf3d02c137ea7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-overlayfs-1.7.1-2.fc35.aarch64.rpm"
           },
-          "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm"
+          "sha256:6adb150683f3c6ab63c568be09b92fe990ecd32f8ed049273f1d46aae3f50129": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bubblewrap-0.5.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:6aed0d8e3025df0de1fbbbae857f8e7fa0e42561e294f923224779617d4ac35f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcab1-1.4-5.fc35.aarch64.rpm"
           },
           "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:6b70550aaff6f0a18cacec9d697d6e2697f1d12058f129e55dee3457a99bec30": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gdisk-1.0.8-2.fc35.aarch64.rpm"
           },
           "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm"
@@ -520,14 +575,11 @@
           "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm"
           },
-          "sha256:6c5f9498b18f3634aff99c8c07148876906a35357a86d473ff62f1073059a7aa": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-core-libs-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm"
+          "sha256:6c36aa3211de438afc66ef7e164629ed6c78d142be1c7b06bf8a9244260d2cbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/luksmeta-9-12.fc35.aarch64.rpm"
           },
-          "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-en-3.0-15.fc35.noarch.rpm"
-          },
-          "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-GB-0.20140811.1-20.fc35.noarch.rpm"
+          "sha256:6cc8527a433894beef6f7d13d340d346dc282f5d4ca9ae23c4899dc5926bf982": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblockdev-crypto-2.26-1.fc35.aarch64.rpm"
           },
           "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm"
@@ -544,17 +596,23 @@
           "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm"
           },
+          "sha256:6e764f772148419feb7602ed81a6aa9ced35997931bd62d6699118957c5db86a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/ostree-2022.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:6ec44e1fd7a4de66115ffed1790e7723e2e0a2aa489efe0369e9ed127bd8edb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mdadm-4.2-rc2.fc35.aarch64.rpm"
+          },
           "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm"
           },
           "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setuptools-57.4.0-1.fc35.noarch.rpm"
           },
+          "sha256:6f7f54b120526821e215487d860b04800d723fb259d0d19f4e412645d2abea6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmbim-1.26.0-1.fc35.aarch64.rpm"
+          },
           "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm"
-          },
-          "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.aarch64.rpm"
           },
           "sha256:717d52dab884a42e0c346dd8d2b6f5bcb80b85703c7a208df04ff96ec4114f6f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nftables-1.0.0-1.fc35.aarch64.rpm"
@@ -577,6 +635,9 @@
           "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm"
           },
+          "sha256:75ea1c8a9d97996e6c9a4d915a9ef9c5432c912f716b206c868b5d1e3c997d1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-common-3.10.5-1.fc35.aarch64.rpm"
+          },
           "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm"
           },
@@ -586,17 +647,32 @@
           "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm"
           },
-          "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.aarch64.rpm"
+          "sha256:780b5eb1c3aaf26ff92cc7092a4d0a454f96bb621ee0463b66f762386f5544a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-3.10.5-1.fc35.aarch64.rpm"
+          },
+          "sha256:78387c08ffff62399ccc1ae280f414d2f7521699481faac70faa23b5abdb18f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libjose-11-3.fc35.aarch64.rpm"
           },
           "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:78ef00e846f607c84444984b48eef2cb02964bcc085566d24d7c87d6ac2d704c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblockdev-utils-2.26-1.fc35.aarch64.rpm"
+          },
+          "sha256:796b15e590c5d726d63a3ca5bd7076b77a7d00bf844a6ed4b34d4de01cb0b089": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/r/rpm-ostree-2022.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:7a78f9c1f9646ab9a4d3b76dbee078df943d520970445a4c0c075c29dc0aa99f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/slirp4netns-1.1.12-2.fc35.aarch64.rpm"
           },
           "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm"
           },
           "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:7b74b239d9149d37b1b55234810ab2ae9b3a9f949b2bd4ebd04839abb5c332b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/greenboot-0.12.0-1.fc35.aarch64.rpm"
           },
           "sha256:7bc35d9fda6ebfe33a63cf1093a2c64b03da111461fce2b213f4fc5e91519eaa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnftnl-1.2.0-2.fc35.aarch64.rpm"
@@ -619,35 +695,26 @@
           "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm"
           },
-          "sha256:81b1b84501851960326a165de6e938696a6a69f69bfac3478b26c5e2a24a6c73": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXrandr-1.5.2-7.fc35.aarch64.rpm"
-          },
-          "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-idna-3.2-1.fc35.noarch.rpm"
-          },
-          "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.aarch64.rpm"
+          "sha256:80a1e30e73044d23ab6e5d4531b5f52c4bd563a5232cba54e8d40380e79f0d3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-completion-2.11-3.fc35.noarch.rpm"
           },
           "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm"
           },
-          "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonschema-3.2.0-12.fc35.noarch.rpm"
-          },
-          "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jinja2-3.0.1-2.fc35.noarch.rpm"
-          },
           "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm"
           },
-          "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib-3.0.2-11.fc35.noarch.rpm"
+          "sha256:8504180f7a9f66fe58c27bccca983655207037255c4471d797fa65c0b36912f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/b/bluez-5.63-1.fc35.aarch64.rpm"
+          },
+          "sha256:85591f702b9d91e1c816d584ae8de4b6e69da0d6941bd9fedcdd0de65bd4840c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nss-altfiles-2.18.1-19.fc35.aarch64.rpm"
           },
           "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm"
           },
-          "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dejavu-sans-fonts-2.37-17.fc35.noarch.rpm"
+          "sha256:87434169fd88f118042741c2a73188dbfbb4ed4f36d8cd4d78f7f1a580787447": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/podman-gvproxy-3.4.4-1.fc35.aarch64.rpm"
           },
           "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm"
@@ -658,14 +725,14 @@
           "sha256:8a93cb5f7a78270157d8bc5272478d64104a7d89dccfea2dd227d8692fc510c3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-nft-1.8.7-13.fc35.aarch64.rpm"
           },
-          "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyserial-3.4-12.fc35.noarch.rpm"
+          "sha256:8b2def9e5cfecdddbd865b0b59b9532e525af274877b3ddde95b4a9fbbcb530e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-1.6.1-3.fc35.aarch64.rpm"
           },
-          "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.aarch64.rpm"
+          "sha256:8b5e4fd8efef5bfea6f8df721d56001e8139810222d7db6e16a94e05fb2fe67b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/nss-softokn-3.73.0-1.fc35.aarch64.rpm"
           },
-          "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.aarch64.rpm"
+          "sha256:8ceaa90de879f507b79e2b5319df475455b1df2db0652333f65551a61d72a193": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/containers-common-1-32.fc35.noarch.rpm"
           },
           "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm"
@@ -679,20 +746,20 @@
           "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm"
           },
+          "sha256:8ff63ca096faa6ce047d3392e2ffc8cddec346ef03fbd0a395687f843a774e29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/i/iwlax2xx-firmware-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:90c7b019374c9431f7b5419098362a6449dc8e6e4c6e0d87308bee6ec0aa4032": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setools-console-4.4.0-3.fc35.aarch64.rpm"
+          },
           "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm"
           },
           "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm"
           },
-          "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.aarch64.rpm"
-          },
           "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm"
-          },
-          "sha256:92165f8506bcde6d8b121033f17441f51c57b163b2d24e591c6d7d667d967f07": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXau-1.0.9-7.fc35.aarch64.rpm"
           },
           "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm"
@@ -706,29 +773,32 @@
           "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.aarch64.rpm"
           },
+          "sha256:93ed0b24b9f4cf580780c0ee6e89737cc42f800164d84f1b84fe8cc5d2b708c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bcm283x-firmware-20210930-1.b5257da.fc35.aarch64.rpm"
+          },
           "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm"
-          },
-          "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.aarch64.rpm"
           },
           "sha256:9593a8e47f980af2a61700947cf6da75b409621598029854c05f1a4f5749d1cb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libsemanage-3.3-1.fc35.aarch64.rpm"
           },
+          "sha256:95d047e12ecfe478b7f2a53803a528c3876c81cfdc36dc13f4f9345249e158fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/r/rpm-ostree-libs-2022.1-2.fc35.aarch64.rpm"
+          },
           "sha256:95f62c37836b177bbaff44da7e94c70bd9badddbd873cc0b470f14c56257eee5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipset-libs-7.15-1.fc35.aarch64.rpm"
-          },
-          "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.aarch64.rpm"
           },
           "sha256:9605b7a0fbfb73c13a99ae45476c02cf3a0cde1b7edf137e90f8006863519a83": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setools-4.4.0-3.fc35.aarch64.rpm"
           },
+          "sha256:9619cce941f30750a8cea4c6d9fe1384c053cc1c645aec111d93b4f790da4744": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgpiod-1.6.3-3.fc35.aarch64.rpm"
+          },
           "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm"
           },
-          "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-babel-2.9.1-4.fc35.noarch.rpm"
+          "sha256:9692c1d6a2c57049d1d050bff3e422164ec59b53aa09513172cfc975ac10cedb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/parsec-0.7.0-3.fc35.aarch64.rpm"
           },
           "sha256:972e63fdf149b8fa4cc48d07c77a5b2a8d630b2a71deee28d78c8eb260df65b0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/jansson-2.13.1-3.fc35.aarch64.rpm"
@@ -736,8 +806,8 @@
           "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm"
           },
-          "sha256:97c959173adc41a960200043e95347cb2ef9035dd7eec79d5489b11e3332a23d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-scripts-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm"
+          "sha256:97cba75d786761ac4a8dc22811c18403372671e4dc35ac326c83b91c10142296": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/traceroute-2.1.0-14.fc35.aarch64.rpm"
           },
           "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm"
@@ -745,23 +815,38 @@
           "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.aarch64.rpm"
           },
+          "sha256:995c4dedc7a0c58a2cc5d780e6bab6f3adcb64f935924cfa6af7df603bffa842": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-glib-1.6.6-1.fc35.aarch64.rpm"
+          },
+          "sha256:9a5e4f31d85972d815ac080b9e39f741d1f4aeaf7e998fde7cef282a5527fffd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/usbguard-selinux-1.0.0-6.fc35.noarch.rpm"
+          },
+          "sha256:9a9d2db751a6524d3c641fdcb6eb8c5da81686aed260187fbc842c5ce542895e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-3.14.0-6.fc35.aarch64.rpm"
+          },
           "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm"
+          },
+          "sha256:9b5b0486a1d86998a6a446b951afb6246933644094cda1003e9cc620459d076f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libell-0.47-1.fc35.aarch64.rpm"
           },
           "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm"
           },
+          "sha256:9d0886ba7fcc25ff9748d7d5a9a4580470bef38d6ddd982acba3fd17ec82400e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ntfs-3g-libs-2021.8.22-2.fc35.aarch64.rpm"
+          },
           "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-10.fc35.aarch64.rpm"
-          },
-          "sha256:9da9f25dfdfb817d5ed99288c9bec5a6547dfe388c156e9dd83f10c0a04204ae": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxcb-1.13.1-8.fc35.aarch64.rpm"
           },
           "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm"
           },
           "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm"
+          },
+          "sha256:9f701673ee9035ca9c2391ab7ae8fccee803fa979b326c523cddfdc097f8c657": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-event-libs-1.02.175-6.fc35.aarch64.rpm"
           },
           "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm"
@@ -772,8 +857,8 @@
           "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm"
           },
-          "sha256:a0bcda38ffb40a7e6d28c88dbbbf9b6f2d77e2614aafb53d69bd24bf111ba46a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXrender-0.9.10-15.fc35.aarch64.rpm"
+          "sha256:a09da17a664bae9f998c5fc3224ef4983dca376d7861313c79e13eba59d7b221": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lvm2-2.03.11-6.fc35.aarch64.rpm"
           },
           "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm"
@@ -790,17 +875,11 @@
           "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm"
           },
-          "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.aarch64.rpm"
-          },
           "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm"
           },
           "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.aarch64.rpm"
-          },
-          "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc35.noarch.rpm"
           },
           "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.aarch64.rpm"
@@ -811,17 +890,35 @@
           "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm"
           },
+          "sha256:a784c4c3ccbae43e8693079ee023f0302837c7e79ef506053e6ab4c244547974": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libjcat-0.1.9-1.fc35.aarch64.rpm"
+          },
+          "sha256:a788fcf4b4145f95c9e1ef9d9119b5952eadd4596fcae90763319b079847af48": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-iot-35-36.noarch.rpm"
+          },
           "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm"
           },
           "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm"
           },
+          "sha256:a8d1b6966d03bd23286c5a6f4192b921d89af5e9bb770756cf0442f22cc954b6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-network-055-6.fc35.aarch64.rpm"
+          },
           "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.aarch64.rpm"
           },
+          "sha256:a9847dcfcf017e55abce19fbbb3f9d7480ff433fc687d9a8a075d5be37da0fd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/container-selinux-2.170.0-2.fc35.noarch.rpm"
+          },
+          "sha256:aa30a972a41bbfb84243dbcdf221d8d8d6b0fa28e67d71d48845befcc6b871df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgpiod-utils-1.6.3-3.fc35.aarch64.rpm"
+          },
           "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm"
+          },
+          "sha256:ab81bdcc43062cf8d2780350e98ba76b6e37f71a89e52c947c982fdca59966bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpkgconf-1.8.0-1.fc35.aarch64.rpm"
           },
           "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm"
@@ -829,11 +926,14 @@
           "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm"
           },
+          "sha256:ac087df3c8ed872cd579f257ec347a51923535add93ebc6190de7f9c482f3e00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/b/bluez-libs-5.63-1.fc35.aarch64.rpm"
+          },
+          "sha256:ac16154e7ad3440e137a65b0d9bc96942f257651aaf1f41298f15329a216c2c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rsync-3.2.3-8.fc35.aarch64.rpm"
+          },
           "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm"
-          },
-          "sha256:aca22d55edba0d7f60f4d6f8f5c064ce64df4561af9c44e592fa842d1b83110c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libX11-1.7.3.1-1.fc35.aarch64.rpm"
           },
           "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
@@ -850,11 +950,14 @@
           "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm"
           },
-          "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.aarch64.rpm"
+          "sha256:b005c546d9966003ae0c66faf1cea9b6acd2b6e9f7dee2d2e578a5b30f11686a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pkgconf-m4-1.8.0-1.fc35.noarch.rpm"
           },
           "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:b0c4da2957a85cd15d93fb0b4aa074c8a6d978e443f66b0482b9b4ef3bbe1a23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pciutils-libs-3.7.0-4.fc35.aarch64.rpm"
           },
           "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm"
@@ -862,14 +965,14 @@
           "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm"
           },
-          "sha256:b30f029f856c7ff5a9ef7c71b4f8d0858b96962c5523ee7c7bcc6313b13a3b0c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cryptography-3.4.7-5.fc35.aarch64.rpm"
-          },
           "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm"
           },
-          "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.aarch64.rpm"
+          "sha256:b4c8b4e130ddfec411a27fe72c8b55c8a9c4630b68dd10daa7e3729be3e545f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/shared-mime-info-2.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:b4f37d46a28bebaf35b8f76f7680ff5530d09af6bd00cdd4d19db8181cc4cc23": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-wifi-1.32.12-2.fc35.aarch64.rpm"
           },
           "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm"
@@ -877,8 +980,17 @@
           "sha256:b5c3b6992403e43f615f21646d88a88dfcfb15e6a0c8a0e097f99879df3386ac": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-img-6.1.0-10.fc35.aarch64.rpm"
           },
+          "sha256:b5e0b095706279778e1f20e6e0448ac20e7f37e9acfb962700ce7fd52d9a43e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pkgconf-pkg-config-1.8.0-1.fc35.aarch64.rpm"
+          },
           "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm"
+          },
+          "sha256:b6440724382944ff5721c0c352ca59c714b1d0a1f76bbf2b810172c5923f39d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libqb-2.0.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:b653df1724c6a811905cd8d28eaac3dfaa088e84334e9e8306355bb6f1bfb1f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/nss-sysinit-3.73.0-1.fc35.aarch64.rpm"
           },
           "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.aarch64.rpm"
@@ -889,6 +1001,15 @@
           "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm"
           },
+          "sha256:b8d733d55d2988b05b167b1b9d2542d35663c1529c00380ff1d940264fdd15ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fwupd-plugin-flashrom-1.7.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:b90acd201d652a6b6a9b3d1333ae5160af3c4e24edd26786967b577062bada6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblockdev-fs-2.26-1.fc35.aarch64.rpm"
+          },
+          "sha256:b93cee77f8662f35ab2ed9e047b50020a8be9eac8aa9bea59eefcd02ed844f43": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libluksmeta-9-12.fc35.aarch64.rpm"
+          },
           "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm"
           },
@@ -898,11 +1019,14 @@
           "sha256:b98735362bb79e3def6794fa863fe09a1c3690c8c7880e83f572c20860ba25ba": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libselinux-3.3-1.fc35.aarch64.rpm"
           },
+          "sha256:ba48d9343b3223739a6744c723c68823307928b423375a18fe7c7c1cd2e5af82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgusb-0.3.9-1.fc35.aarch64.rpm"
+          },
+          "sha256:ba67c8942f30df3be1eda8006390741a3825dd4e5eadee6e3e0b6c22fbf95930": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblockdev-loop-2.26-1.fc35.aarch64.rpm"
+          },
           "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm"
-          },
-          "sha256:baf6082e248e7e84f3cb5ec2695f0dc9afeca615b3f39c60283902ab06d3f564": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cffi-1.14.6-2.fc35.aarch64.rpm"
           },
           "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm"
@@ -919,6 +1043,12 @@
           "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm"
           },
+          "sha256:be29b25a2f937e4442da2511c27ea07403b8476c01619d6a50b182e3c3f7f7aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dmidecode-3.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:be32c0e88209b3e4c727c73bd7495523e2cb76f5d0b63f68a7e830bcb6b479d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/screen-4.8.0-6.fc35.aarch64.rpm"
+          },
           "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm"
           },
@@ -931,12 +1061,6 @@
           "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm"
           },
-          "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pysocks-1.7.1-11.fc35.noarch.rpm"
-          },
-          "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cloud-init-20.4-7.fc35.noarch.rpm"
-          },
           "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.aarch64.rpm"
           },
@@ -946,14 +1070,23 @@
           "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm"
           },
-          "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.aarch64.rpm"
+          "sha256:c23a8cdd67d918268714ace5939872365ff62039b4da08a8c6b57883052dac9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/podman-3.4.4-1.fc35.aarch64.rpm"
           },
           "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm"
           },
           "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/mokutil-0.5.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:c473b4f4a820f535de9b6d10734c55eb6741de76f2671f893289b668751f16a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libqmi-1.30.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:c5027788836c69df20f78d0389ed9079e629453e18d69eff2e9efb826d0f937f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/clevis-18-4.fc35.aarch64.rpm"
+          },
+          "sha256:c537a18bde094f4a4202260cb2ecfb0893fab60adb06387462f6c8b36dc96d4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/nss-3.73.0-1.fc35.aarch64.rpm"
           },
           "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm"
@@ -964,14 +1097,14 @@
           "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.aarch64.rpm"
           },
-          "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch.rpm"
-          },
           "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm"
           },
           "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm"
+          },
+          "sha256:c7e3fddc8895550d1096c908c9c9c71aa5b4d150d504f939bd45aaf87579c03d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbytesize-2.6-2.fc35.aarch64.rpm"
           },
           "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm"
@@ -979,32 +1112,32 @@
           "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm"
           },
-          "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.aarch64.rpm"
-          },
           "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:cc1fc05e1e26e7f0e2fad7e91457139add3f444d4982613bdb3271235702705a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pkgconf-1.8.0-1.fc35.aarch64.rpm"
           },
           "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm"
           },
-          "sha256:cd38bc0d85c3664d68bc57e006a9b0d31abec2a71a56e0a5a11a81a673f90a2a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/x/xen-licenses-4.15.1-4.fc35.aarch64.rpm"
+          "sha256:cd39f952196a0241d1c3e9bea61cd86f4a6c3a8b9ba25b6b384860e22bd5a0f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-python-utils-3.3-1.fc35.noarch.rpm"
           },
-          "sha256:cd892e1d1657846057a26c5abe7cc78d190742b81933a099bbe2c75e766b37d3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXinerama-1.1.4-9.fc35.aarch64.rpm"
+          "sha256:cd908e1b818441a631035416579c08315b3fae510151174fd40a02901be0586e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/ModemManager-glib-1.18.2-1.fc35.aarch64.rpm"
           },
           "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-firewall-1.0.1-2.fc35.noarch.rpm"
-          },
-          "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm"
           },
           "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.aarch64.rpm"
           },
           "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm"
+          },
+          "sha256:d02201323b888e80d8559f8205d4e30eb068df4ac3bdf0699e52a543f687ef57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/clevis-systemd-18-4.fc35.aarch64.rpm"
           },
           "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.aarch64.rpm"
@@ -1015,23 +1148,14 @@
           "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm"
           },
+          "sha256:d1c5895bbbcbc78e11eb9164c07fd62562c84b8b3b6129b4ffff83173c71562c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libqrtr-glib-1.0.0-2.fc35.aarch64.rpm"
+          },
           "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm"
           },
-          "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm"
-          },
-          "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.aarch64.rpm"
-          },
           "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm"
-          },
-          "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-0.20140811.1-20.fc35.noarch.rpm"
-          },
-          "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.aarch64.rpm"
           },
           "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm"
@@ -1039,11 +1163,17 @@
           "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm"
           },
-          "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt+crypto-2.1.0-2.fc35.noarch.rpm"
+          "sha256:d59194acb6a6fb541c9c0156b8ea67d60bf6ff5e8597c9efcd1e2b60b2e17342": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbsd-0.10.0-8.fc35.aarch64.rpm"
           },
           "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm"
+          },
+          "sha256:d600334211805f9f0bcf64a6bc1a2ab4824fd7976e186f79fec9b92392d394f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/ostree-libs-2022.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:d7fe083650f0a0e0005ed0841a6a4c665b53104950388c87fedbae810d86df6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/i/iwl7260-firmware-25.30.13.0-127.fc35.noarch.rpm"
           },
           "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm"
@@ -1057,6 +1187,12 @@
           "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm"
           },
+          "sha256:d97452702c3b5f4832b589f03f3869334f08767c298a0adc6d85d51129f7cfeb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-persistent-data-0.9.0-6.fc35.aarch64.rpm"
+          },
+          "sha256:d991d713a73c4e3fddfaaffc51e66fc30e3261f3705babba50fd2ac2e9ebc7a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ntfsprogs-2021.8.22-2.fc35.aarch64.rpm"
+          },
           "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm"
           },
@@ -1066,14 +1202,23 @@
           "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm"
           },
+          "sha256:db78601913c72afca547d7cc8308c618c948d050a9e3b9b62fa4528d951024ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/podman-plugins-3.4.4-1.fc35.aarch64.rpm"
+          },
           "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:dbc885283d2a69517ffd1a601eda98a8e8d34bf4ea6e75d6f3dd28d574222e09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/i/ignition-2.13.0-1.fc35.aarch64.rpm"
           },
           "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm"
           },
           "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm"
+          },
+          "sha256:de15a0ecfb5316b527f2b599a5f536eb1f755ab0157cf1082c73db93a1059781": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fwupd-plugin-modem-manager-1.7.3-1.fc35.aarch64.rpm"
           },
           "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm"
@@ -1090,23 +1235,26 @@
           "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm"
           },
-          "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.aarch64.rpm"
+          "sha256:e1a7c69b36c1824633898435c16fb10d733424e029da26f5050b0555bf85b66d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/oniguruma-6.9.7.1-1.fc35.1.aarch64.rpm"
+          },
+          "sha256:e1d84083341116709a56a3aad727030a691d4e12b4d348eb75f7dc809d08ffe1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/wpa_supplicant-2.9-13.fc35.aarch64.rpm"
+          },
+          "sha256:e376e649c2be4f52e94b1d9e287668c78fa41eebba6d0cbc8f41ba4ea3a15e2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fwupd-1.7.3-1.fc35.aarch64.rpm"
           },
           "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm"
-          },
-          "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-US-0.20140811.1-20.fc35.noarch.rpm"
-          },
-          "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonpointer-2.0-4.fc35.noarch.rpm"
           },
           "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.aarch64.rpm"
           },
           "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm"
+          },
+          "sha256:e64f54c1e4bc0cb5881ca76f9eddb0caf3500b8ecb3e5ac634f5ca1457b46414": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iw-5.9-3.fc35.aarch64.rpm"
           },
           "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm"
@@ -1120,6 +1268,12 @@
           "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm"
           },
+          "sha256:ea062d3815a8b93462b1cf13d6e517d7d0ec69dfce33f55d66695504d0baf678": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/b/btrfs-progs-5.15.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:ea89c837ae0f083755d3499adc8a4bf34e16c7f9f7ee776bf7623fb765997f57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bcm2711-firmware-20210930-1.b5257da.fc35.aarch64.rpm"
+          },
           "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm"
           },
@@ -1129,20 +1283,14 @@
           "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm"
           },
-          "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.aarch64.rpm"
-          },
-          "sha256:ee9c63222e5d761bf50ada5b6c5068e7555c08f159489b5da9d4944684426308": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXfixes-6.0.0-2.fc35.aarch64.rpm"
-          },
           "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm"
           },
           "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm"
           },
-          "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          "sha256:f05c62d78957eb1ecabf42d5f95303b9381453e9754f01edf094674626260765": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/u/udisks2-2.9.4-1.fc35.aarch64.rpm"
           },
           "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm"
@@ -1150,8 +1298,17 @@
           "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm"
           },
+          "sha256:f255fca77a9d1f936e1c0ea9d01141c1ee7e23cf4be68aed3e7567bf1cc5ac64": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/greenboot-grub2-0.12.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:f2bdf2e6ffceec804128ea284dad46caac869232d9997ba51b8d4bc7f2558b16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tmux-3.2a-2.fc35.aarch64.rpm"
+          },
           "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:f367f9afbcc3c7e8652d1d525d20c0cf19fdcf1a8c837cc5fd3de4e518ca1207": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libslirp-4.6.1-2.fc35.aarch64.rpm"
           },
           "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm"
@@ -1161,9 +1318,6 @@
           },
           "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm"
-          },
-          "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-prettytable-0.7.2-27.fc35.noarch.rpm"
           },
           "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm"
@@ -1176,9 +1330,6 @@
           },
           "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm"
-          },
-          "sha256:f878dd687438db0e07f2eb571246103ae0e136647242f0bf7f806ddd77e04a91": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-1.7.0-11.fc35.aarch64.rpm"
           },
           "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.aarch64.rpm"
@@ -1204,17 +1355,14 @@
           "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.aarch64.rpm"
           },
-          "sha256:fc05e6abb02bcb99462711686ddfc47783c0a5575bdb451a7fce641a3b809e8e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.18.0-8.fc35.aarch64.rpm"
+          "sha256:fc4197a7f551c4d9580524cd5dc294bbd6fe52d45f479d1e92bab8f28ea3564b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/r/rng-tools-6.14-2.git.b2b7934e.fc35.aarch64.rpm"
           },
-          "sha256:fccda302546302309788e451ccaa2fb2abba72fa7b4184e82e1ff89830d8e306": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/net-tools-2.0-0.60.20160912git.fc35.aarch64.rpm"
+          "sha256:fc5e0f9bb760d12519e8e2183ab51d3196e4416a3e7572156edf6bd042af5776": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/greenboot-status-0.12.0-1.fc35.aarch64.rpm"
           },
           "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm"
-          },
-          "sha256:fdb23c2568785740578c8c2aef40f717f37cac51f71a8e2fc27c0ffd83bc7884": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/x/xen-libs-4.15.1-4.fc35.aarch64.rpm"
           },
           "sha256:fe1323e767bb5941d49d5b6565750614a2f649d5d34453e5ace10b3012b7a413": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xfsprogs-5.12.0-2.fc35.aarch64.rpm"
@@ -1266,6 +1414,10 @@
                   },
                   {
                     "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:6adb150683f3c6ab63c568be09b92fe990ecd32f8ed049273f1d46aae3f50129",
                     "check_gpg": true
                   },
                   {
@@ -1381,6 +1533,14 @@
                     "check_gpg": true
                   },
                   {
+                    "checksum": "sha256:46266d1762bf3ae1711b1cbfb37cabc8e3c884cdbecbdaa6d9fff1259fa0f55b",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:75ea1c8a9d97996e6c9a4d915a9ef9c5432c912f716b206c868b5d1e3c997d1f",
+                    "check_gpg": true
+                  },
+                  {
                     "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
                     "check_gpg": true
                   },
@@ -1434,6 +1594,10 @@
                   },
                   {
                     "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:995c4dedc7a0c58a2cc5d780e6bab6f3adcb64f935924cfa6af7df603bffa842",
                     "check_gpg": true
                   },
                   {
@@ -2053,6 +2217,14 @@
                     "check_gpg": true
                   },
                   {
+                    "checksum": "sha256:6e764f772148419feb7602ed81a6aa9ced35997931bd62d6699118957c5db86a",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:d600334211805f9f0bcf64a6bc1a2ab4824fd7976e186f79fec9b92392d394f4",
+                    "check_gpg": true
+                  },
+                  {
                     "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
                     "check_gpg": true
                   },
@@ -2102,6 +2274,14 @@
                   },
                   {
                     "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:796b15e590c5d726d63a3ca5bd7076b77a7d00bf844a6ed4b34d4de01cb0b089",
+                    "check_gpg": true
+                  },
+                  {
+                    "checksum": "sha256:95d047e12ecfe478b7f2a53803a528c3876c81cfdc36dc13f4f9345249e158fb",
                     "check_gpg": true
                   },
                   {
@@ -2179,11 +2359,23 @@
             ],
             "packages": [
               {
+                "checksum": "sha256:5b6c7f2e43c1260c206d65dccd8cb947cb0f3348eaadf0afa6809fea9c9f914d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cd908e1b818441a631035416579c08315b3fae510151174fd40a02901be0586e",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
                 "check_gpg": true
               },
               {
                 "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:26db7baa5f56c18294dd53b31b6d59ef38fffe05d46608594653a457789c13a8",
                 "check_gpg": true
               },
               {
@@ -2203,11 +2395,31 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+                "checksum": "sha256:80a1e30e73044d23ab6e5d4531b5f52c4bd563a5232cba54e8d40380e79f0d3c",
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65",
+                "checksum": "sha256:ea89c837ae0f083755d3499adc8a4bf34e16c7f9f7ee776bf7623fb765997f57",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2dd8af06b106716d1e2d7c058518efc4be513e3bab8d4637ae6d5202c2acfcf3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:93ed0b24b9f4cf580780c0ee6e89737cc42f800164d84f1b84fe8cc5d2b708c3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:445c078bffe6ec618ac462378b67632a2d0732d0767f9d008ee163320d2e7a3d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6adb150683f3c6ab63c568be09b92fe990ecd32f8ed049273f1d46aae3f50129",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
                 "check_gpg": true
               },
               {
@@ -2219,7 +2431,11 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a",
+                "checksum": "sha256:4f0d774fdab0e9e3052ebed054f484f7e2e20bb1ff4694b1bb612ef4c57a2a51",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3d8acf78b1daa3e2b6528471f7ab3799a24ba1ffa66751f134c74db56b91ee7d",
                 "check_gpg": true
               },
               {
@@ -2271,11 +2487,7 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+                "checksum": "sha256:0d2e94bebd4f3ca297c347171e548e9a9ec917dfaee87d73e62a753177d4fd8a",
                 "check_gpg": true
               },
               {
@@ -2283,15 +2495,19 @@
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:50763d3f0eda21834dd020c4c3f4cf1ae982da02c841ed95aee507290be4b058",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9f701673ee9035ca9c2391ab7ae8fccee803fa979b326c523cddfdc097f8c657",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+                "checksum": "sha256:d97452702c3b5f4832b589f03f3869334f08767c298a0adc6d85d51129f7cfeb",
                 "check_gpg": true
               },
               {
@@ -2299,11 +2515,11 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+                "checksum": "sha256:be29b25a2f937e4442da2511c27ea07403b8476c01619d6a50b182e3c3f7f7aa",
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+                "checksum": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
                 "check_gpg": true
               },
               {
@@ -2339,10 +2555,6 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
                 "check_gpg": true
               },
@@ -2367,11 +2579,35 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee",
+                "checksum": "sha256:2b04a72168d77e8a916b1bf7e70cc1977064e19339132562e85d899e3a29b603",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:46266d1762bf3ae1711b1cbfb37cabc8e3c884cdbecbdaa6d9fff1259fa0f55b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:75ea1c8a9d97996e6c9a4d915a9ef9c5432c912f716b206c868b5d1e3c997d1f",
                 "check_gpg": true
               },
               {
                 "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:69e489e334c05ce06c984e189d73849853583c59aaf7c60a690bf3d02c137ea7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:780b5eb1c3aaf26ff92cc7092a4d0a454f96bb621ee0463b66f762386f5544a9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4728c8dcf044d801a3c03d786598d23c5f6c7df8d8b363796f5ba3fdbd566d65",
                 "check_gpg": true
               },
               {
@@ -2380,6 +2616,10 @@
               },
               {
                 "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6b70550aaff6f0a18cacec9d697d6e2697f1d12058f129e55dee3457a99bec30",
                 "check_gpg": true
               },
               {
@@ -2403,11 +2643,27 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+                "checksum": "sha256:7b74b239d9149d37b1b55234810ab2ae9b3a9f949b2bd4ebd04839abb5c332b9",
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21",
+                "checksum": "sha256:f255fca77a9d1f936e1c0ea9d01141c1ee7e23cf4be68aed3e7567bf1cc5ac64",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:0cb072b3ab5755d4ee272fb3fe9b632ab53c14a6037e42cec7dc0de5b7341b19",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2f36a4315506b13e0c8b01a08511c484b29028ebb9dace8d6d1aa94db2716219",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fc5e0f9bb760d12519e8e2183ab51d3196e4416a3e7572156edf6bd042af5776",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
                 "check_gpg": true
               },
               {
@@ -2420,26 +2676,6 @@
               },
               {
                 "checksum": "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:f878dd687438db0e07f2eb571246103ae0e136647242f0bf7f806ddd77e04a91",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:58b6c3272af7450868f9b6ee3e15f05e45104751cacaa4a22345983caaea14da",
                 "check_gpg": true
               },
               {
@@ -2456,10 +2692,6 @@
               },
               {
                 "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce",
                 "check_gpg": true
               },
               {
@@ -2495,11 +2727,27 @@
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:e64f54c1e4bc0cb5881ca76f9eddb0caf3500b8ecb3e5ac634f5ca1457b46414",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:972e63fdf149b8fa4cc48d07c77a5b2a8d630b2a71deee28d78c8eb260df65b0",
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:1606617e17243ca6d9cfab6553f6930ff859634a04d3ffec3cb6c1a7277d6709",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4801858945fbf03ccf0605293a3749826e09b39658597106c89bb61fb3940366",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:995c4dedc7a0c58a2cc5d780e6bab6f3adcb64f935924cfa6af7df603bffa842",
                 "check_gpg": true
               },
               {
@@ -2508,6 +2756,10 @@
               },
               {
                 "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8b2def9e5cfecdddbd865b0b59b9532e525af274877b3ddde95b4a9fbbcb530e",
                 "check_gpg": true
               },
               {
@@ -2531,43 +2783,11 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:92165f8506bcde6d8b121033f17441f51c57b163b2d24e591c6d7d667d967f07",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:2db66e2d4cb69b7433e334870a06b167dfbe38ba8c8be5d6eb6d3fe69ac0f769",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:ee9c63222e5d761bf50ada5b6c5068e7555c08f159489b5da9d4944684426308",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:cd892e1d1657846057a26c5abe7cc78d190742b81933a099bbe2c75e766b37d3",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:81b1b84501851960326a165de6e938696a6a69f69bfac3478b26c5e2a24a6c73",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:a0bcda38ffb40a7e6d28c88dbbbf9b6f2d77e2614aafb53d69bd24bf111ba46a",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
                 "check_gpg": true
               },
               {
@@ -2583,11 +2803,11 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+                "checksum": "sha256:2533e03bea40216e6ada92db8d91f0a63742267c5cb853f0ca1733a4afe2a532",
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094",
+                "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
                 "check_gpg": true
               },
               {
@@ -2595,7 +2815,47 @@
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:1d0db47703af808b523a192acbcbde38d01b327f27d8bb9b28d17c12fab56e2e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6cc8527a433894beef6f7d13d340d346dc282f5d4ca9ae23c4899dc5926bf982",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b90acd201d652a6b6a9b3d1333ae5160af3c4e24edd26786967b577062bada6c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ba67c8942f30df3be1eda8006390741a3825dd4e5eadee6e3e0b6c22fbf95930",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4b29b2e2e3e15473e94ef1f37225806f1af94ab990bf2c9022e34d9bb28089a8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:475a1da757738ac1c46ed406c782726ad75b9171254c9aecb282353bec8ccf0a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2367e7436b2a8635504c9ad4a0a30043cd782e4d3bb61bc2f8f3ae54fc235a01",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:78ef00e846f607c84444984b48eef2cb02964bcc085566d24d7c87d6ac2d704c",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d59194acb6a6fb541c9c0156b8ea67d60bf6ff5e8597c9efcd1e2b60b2e17342",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c7e3fddc8895550d1096c908c9c9c71aa5b4d150d504f939bd45aaf87579c03d",
                 "check_gpg": true
               },
               {
@@ -2607,27 +2867,11 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
                 "check_gpg": true
               },
               {
@@ -2647,10 +2891,6 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:5d3d700fc60b7ec85915692030f7fa121ca83ea74acca62b6dfdbc9f8cd5ae7e",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
                 "check_gpg": true
               },
@@ -2659,7 +2899,27 @@
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:1bed49c7153d4b2ea49a46af3360e4bee3a7f435ff0e4b58b96370813f738b41",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6aed0d8e3025df0de1fbbbae857f8e7fa0e42561e294f923224779617d4ac35f",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9619cce941f30750a8cea4c6d9fe1384c053cc1c645aec111d93b4f790da4744",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:aa30a972a41bbfb84243dbcdf221d8d8d6b0fa28e67d71d48845befcc6b871df",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3030255b1885347b03057ca9e9ce9c9ad29d186727ab4d26cabd14eedaf84c05",
                 "check_gpg": true
               },
               {
@@ -2667,7 +2927,7 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a",
+                "checksum": "sha256:78387c08ffff62399ccc1ae280f414d2f7521699481faac70faa23b5abdb18f4",
                 "check_gpg": true
               },
               {
@@ -2680,6 +2940,18 @@
               },
               {
                 "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b93cee77f8662f35ab2ed9e047b50020a8be9eac8aa9bea59eefcd02ed844f43",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6f7f54b120526821e215487d860b04800d723fb259d0d19f4e412645d2abea6d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:028ac461745f7189b35ebb09178d4c69206d0fc6fc0f0e82d465e245d3173d1d",
                 "check_gpg": true
               },
               {
@@ -2699,15 +2971,15 @@
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:183226966749e33e2fdc008797fb5f7782da589be4a10ef3692bbe684892e88f",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63",
                 "check_gpg": true
               },
               {
                 "checksum": "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831",
                 "check_gpg": true
               },
               {
@@ -2727,19 +2999,11 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:69e19b20bc15ca446f218e1106357f6ee2fbe78fccfe4eb7100a9eafd91cce23",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad",
+                "checksum": "sha256:ab81bdcc43062cf8d2780350e98ba76b6e37f71a89e52c947c982fdca59966bd",
                 "check_gpg": true
               },
               {
@@ -2751,7 +3015,15 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1",
+                "checksum": "sha256:c473b4f4a820f535de9b6d10734c55eb6741de76f2671f893289b668751f16a2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:3b1c4c7a8c136815e78051ebe384d5497f89b3e004cc6ded86cea5971b20cb63",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d1c5895bbbcbc78e11eb9164c07fd62562c84b8b3b6129b4ffff83173c71562c",
                 "check_gpg": true
               },
               {
@@ -2768,6 +3040,10 @@
               },
               {
                 "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f367f9afbcc3c7e8652d1d525d20c0cf19fdcf1a8c837cc5fd3de4e518ca1207",
                 "check_gpg": true
               },
               {
@@ -2791,19 +3067,7 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a",
                 "check_gpg": true
               },
               {
@@ -2812,10 +3076,6 @@
               },
               {
                 "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
                 "check_gpg": true
               },
               {
@@ -2839,10 +3099,6 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:9da9f25dfdfb817d5ed99288c9bec5a6547dfe388c156e9dd83f10c0a04204ae",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
                 "check_gpg": true
               },
@@ -2855,11 +3111,19 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7",
+                "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+                "checksum": "sha256:6c36aa3211de438afc66ef7e164629ed6c78d142be1c7b06bf8a9244260d2cbe",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a09da17a664bae9f998c5fc3224ef4983dca376d7861313c79e13eba59d7b221",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:109eec660842523b39da8f0647db99c05f21bd54f7eac626789be55acce59e81",
                 "check_gpg": true
               },
               {
@@ -2867,7 +3131,11 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9",
+                "checksum": "sha256:649b1aeda89e3838e2063ec6a01ba516a199880f7333e7cc2331e0041638a050",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6ec44e1fd7a4de66115ffed1790e7723e2e0a2aa489efe0369e9ed127bd8edb5",
                 "check_gpg": true
               },
               {
@@ -2887,19 +3155,11 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
                 "check_gpg": true
               },
               {
                 "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:fccda302546302309788e451ccaa2fb2abba72fa7b4184e82e1ff89830d8e306",
                 "check_gpg": true
               },
               {
@@ -2912,6 +3172,22 @@
               },
               {
                 "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:85591f702b9d91e1c816d584ae8de4b6e69da0d6941bd9fedcdd0de65bd4840c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9d0886ba7fcc25ff9748d7d5a9a4580470bef38d6ddd982acba3fd17ec82400e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d991d713a73c4e3fddfaaffc51e66fc30e3261f3705babba50fd2ac2e9ebc7a1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e1a7c69b36c1824633898435c16fb10d733424e029da26f5050b0555bf85b66d",
                 "check_gpg": true
               },
               {
@@ -2943,11 +3219,19 @@
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:9692c1d6a2c57049d1d050bff3e422164ec59b53aa09513172cfc975ac10cedb",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd",
                 "check_gpg": true
               },
               {
                 "checksum": "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b0c4da2957a85cd15d93fb0b4aa074c8a6d978e443f66b0482b9b4ef3bbe1a23",
                 "check_gpg": true
               },
               {
@@ -2971,15 +3255,15 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:07fd0548f64b358ffd9ce32e885b7b91dc7e6208171d7efb9874923aead0fa5c",
+                "checksum": "sha256:cc1fc05e1e26e7f0e2fad7e91457139add3f444d4982613bdb3271235702705a",
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:6c5f9498b18f3634aff99c8c07148876906a35357a86d473ff62f1073059a7aa",
+                "checksum": "sha256:b005c546d9966003ae0c66faf1cea9b6acd2b6e9f7dee2d2e578a5b30f11686a",
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:97c959173adc41a960200043e95347cb2ef9035dd7eec79d5489b11e3332a23d",
+                "checksum": "sha256:b5e0b095706279778e1f20e6e0448ac20e7f37e9acfb962700ce7fd52d9a43e6",
                 "check_gpg": true
               },
               {
@@ -2992,6 +3276,10 @@
               },
               {
                 "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9a9d2db751a6524d3c641fdcb6eb8c5da81686aed260187fbc842c5ce542895e",
                 "check_gpg": true
               },
               {
@@ -3011,47 +3299,11 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:5702b6d62b7efb235cf49b6174288053d345236107a43de33d6c80d9784d7140",
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:baf6082e248e7e84f3cb5ec2695f0dc9afeca615b3f39c60283902ab06d3f564",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:b30f029f856c7ff5a9ef7c71b4f8d0858b96962c5523ee7c7bcc6313b13a3b0c",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
                 "check_gpg": true
               },
               {
@@ -3063,83 +3315,7 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:375b89f3a452a62f3a02ada8971b14e854fa95b0d4cb9efb0449e5f85d6959c6",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:31e3038cdc752f890970d60653b510eb815e56be7854ba627ef7843b4c760ec9",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:469ec3ace1ffa4e3153c772d5ec5a65f8cb6e98d07405134c6b06545796e31c2",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
                 "check_gpg": true
               },
               {
@@ -3148,14 +3324,6 @@
               },
               {
                 "checksum": "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
                 "check_gpg": true
               },
               {
@@ -3171,10 +3339,6 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
                 "check_gpg": true
               },
@@ -3183,11 +3347,15 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+                "checksum": "sha256:ac16154e7ad3440e137a65b0d9bc96942f257651aaf1f41298f15329a216c2c6",
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+                "checksum": "sha256:3b2989088d5a142d61120e445db12fe0eea145dbd21d6ffdae1483aa2c62a385",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:be32c0e88209b3e4c727c73bd7495523e2cb76f5d0b63f68a7e830bcb6b479d3",
                 "check_gpg": true
               },
               {
@@ -3195,7 +3363,15 @@
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:90c7b019374c9431f7b5419098362a6449dc8e6e4c6e0d87308bee6ec0aa4032",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b4c8b4e130ddfec411a27fe72c8b55c8a9c4630b68dd10daa7e3729be3e545f4",
                 "check_gpg": true
               },
               {
@@ -3203,7 +3379,7 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:10190a125e7f12c0fb5c138b041c1c3625c43be574b1a42a845217cf2737cd88",
+                "checksum": "sha256:7a78f9c1f9646ab9a4d3b76dbee078df943d520970445a4c0c075c29dc0aa99f",
                 "check_gpg": true
               },
               {
@@ -3219,7 +3395,19 @@
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f2bdf2e6ffceec804128ea284dad46caac869232d9997ba51b8d4bc7f2558b16",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:97cba75d786761ac4a8dc22811c18403372671e4dc35ac326c83b91c10142296",
                 "check_gpg": true
               },
               {
@@ -3231,7 +3419,11 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+                "checksum": "sha256:10202d4ab23cec2514530c824c118f566829b14c1784ade9db35079aacc7dabf",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:9a5e4f31d85972d815ac080b9e39f741d1f4aeaf7e998fde7cef282a5527fffd",
                 "check_gpg": true
               },
               {
@@ -3243,11 +3435,23 @@
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:1b7d568ae321ad117b5b48eb61dda25b02ba7762b8097f0abc87b461b4979998",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
                 "check_gpg": true
               },
               {
                 "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:66ffa480698ff5d048b1ffcfd5a78ecaaeb831831591c0457148b69b8d120d5d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e1d84083341116709a56a3aad727030a691d4e12b4d348eb75f7dc809d08ffe1",
                 "check_gpg": true
               },
               {
@@ -3271,11 +3475,11 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+                "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+                "checksum": "sha256:190a2c0a742e9e3080107b4ea209bfa0adfd13f9892cbe99f4e203153724b93f",
                 "check_gpg": true
               },
               {
@@ -3291,7 +3495,31 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:02f5457be9eac8a6ae4b19950895850da94f62a9c5e5f390a68a590092096c96",
+                "checksum": "sha256:b4f37d46a28bebaf35b8f76f7680ff5530d09af6bd00cdd4d19db8181cc4cc23",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:13fb3e19cb7a637e64b94a049d756401c637c3871b99f51b0531db8602bf135f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:08809b3fc9e1a59314bba40beeccd2981f31f24b62baf276217b6e9eae193ad7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8504180f7a9f66fe58c27bccca983655207037255c4471d797fa65c0b36912f7",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ac087df3c8ed872cd579f257ec347a51923535add93ebc6190de7f9c482f3e00",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:678a86552377e7ca081270778b0434fb8cfef3ecb0ecf4fca52f53afe0c66d9a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:ea062d3815a8b93462b1cf13d6e517d7d0ec69dfce33f55d66695504d0baf678",
                 "check_gpg": true
               },
               {
@@ -3299,7 +3527,55 @@
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:6318c5e457a2fa88c518f518866d9d8c3e6337fd0016debd04a58f72d9da6e6e",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:50d0b3571e271cce3c9f314f3fab80485b706c347cb6e9c710c28cf552c07ec5",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c5027788836c69df20f78d0389ed9079e629453e18d69eff2e9efb826d0f937f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4e3887518cd02b033fc31d445ed18cb70cb0ab7568a2eb7e39eec43c5dcbe951",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:23d8e74f6ee55974f07a08ef7f881956029d52a03a6c3c4d93d2ba77d2b12739",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4f539ddd922dfc864123f8fd35ba364e19f9ccd9bbf6c9d480c65fef3f254782",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d02201323b888e80d8559f8205d4e30eb068df4ac3bdf0699e52a543f687ef57",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a9847dcfcf017e55abce19fbbb3f9d7480ff433fc687d9a8a075d5be37da0fd6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8ceaa90de879f507b79e2b5319df475455b1df2db0652333f65551a61d72a193",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:38f2d755858d9d6e9ff7e30717a0974e4f731173943665cf1aba12213dd79732",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4b3dfb13a1aa92f00e3bf0ab38fc41c7fe98a519e3a1b5b32aae1ec3d8bec520",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:1679081e390beefe9b77ca83d0e9d5ce3731762b271582116b1b8f222bc3f84c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:30bd2714391cd78d2072d2ad5fc0d94adb1875b39159be8dfcf602ac36f31040",
                 "check_gpg": true
               },
               {
@@ -3311,7 +3587,7 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+                "checksum": "sha256:215c466fbf21d59ab899258513f6ce120a9a01ce09b544e6daa6fa23711a6434",
                 "check_gpg": true
               },
               {
@@ -3320,6 +3596,10 @@
               },
               {
                 "checksum": "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a8d1b6966d03bd23286c5a6f4192b921d89af5e9bb770756cf0442f22cc954b6",
                 "check_gpg": true
               },
               {
@@ -3339,15 +3619,31 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+                "checksum": "sha256:641c5b454f3cefa3c9da1b9970486bb931852945398efd977e744684d1da781c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:a788fcf4b4145f95c9e1ef9d9119b5952eadd4596fcae90763319b079847af48",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:e376e649c2be4f52e94b1d9e287668c78fa41eebba6d0cbc8f41ba4ea3a15e2e",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b8d733d55d2988b05b167b1b9d2542d35663c1529c00380ff1d940264fdd15ff",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:de15a0ecfb5316b527f2b599a5f536eb1f755ab0157cf1082c73db93a1059781",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:4991a3c50f9f52859148b48cd2a251a4c14d7b9b510f6c2f27e7d849201dbfca",
                 "check_gpg": true
               },
               {
@@ -3371,7 +3667,7 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:5437317aa8a5d94a9de9cd15d58399146783b4b96ee52a0a134c09b79933a8b0",
+                "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
                 "check_gpg": true
               },
               {
@@ -3403,7 +3699,23 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:5969e69eb5d24f65384e616513a940894f570a0423469dbcdead3d3b3d6c0b7f",
+                "checksum": "sha256:dbc885283d2a69517ffd1a601eda98a8e8d34bf4ea6e75d6f3dd28d574222e09",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:2746f2c19fa38e489d55f0e0ee0c07bd6edbaf259dd84aee17381f3709cb58e2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d7fe083650f0a0e0005ed0841a6a4c665b53104950388c87fedbae810d86df6f",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8ff63ca096faa6ce047d3392e2ffc8cddec346ef03fbd0a395687f843a774e29",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6309f36857ff99d328e83a052186b819b92139c37da35160c91d1d5624a7ae1b",
                 "check_gpg": true
               },
               {
@@ -3419,15 +3731,15 @@
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:4a3381116ae3fc1b08a6459eef839ee8e0e75d5bd83d00a24f132b34f7580d46",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:080dca65723955e080557603c34ac7f4961f438ec90f2a1183bad3d321ffd2c4",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:aca22d55edba0d7f60f4d6f8f5c064ce64df4561af9c44e592fa842d1b83110c",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:4c728458d61305c022946aa7199e2b462ac4449f04303def895923581b05d8c2",
                 "check_gpg": true
               },
               {
@@ -3443,11 +3755,7 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:3f7252d59a6cafd37c6ce4851ba6ab13a0594e0a435bce4d8c392485888278a5",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+                "checksum": "sha256:9b5b0486a1d86998a6a446b951afb6246933644094cda1003e9cc620459d076f",
                 "check_gpg": true
               },
               {
@@ -3463,15 +3771,19 @@
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:ba48d9343b3223739a6744c723c68823307928b423375a18fe7c7c1cd2e5af82",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70",
+                "checksum": "sha256:a784c4c3ccbae43e8693079ee023f0302837c7e79ef506053e6ab4c244547974",
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c",
+                "checksum": "sha256:b6440724382944ff5721c0c352ca59c714b1d0a1f76bbf2b810172c5923f39d3",
                 "check_gpg": true
               },
               {
@@ -3495,14 +3807,6 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207",
                 "check_gpg": true
               },
@@ -3519,7 +3823,15 @@
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:5622830594978a3c99a778d66011211a058f95c80e421910bdd90118662d81e6",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:586c904f0e704585041c3d71a83c891a124922e5348a02ec4834b8f1a17f3929",
                 "check_gpg": true
               },
               {
@@ -3547,6 +3859,30 @@
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:308fcc73237de6563a5343fd3b45fd29abb41338fc7517ca7818f74bf2e315b8",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:c537a18bde094f4a4202260cb2ecfb0893fab60adb06387462f6c8b36dc96d4c",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:8b5e4fd8efef5bfea6f8df721d56001e8139810222d7db6e16a94e05fb2fe67b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:53beb80220710bbd61de26573ca7d8fee1ec4cf914f5d9f84ad9e7f231f22bfc",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:b653df1724c6a811905cd8d28eaac3dfaa088e84334e9e8306355bb6f1bfb1f6",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:66105bec59eecac3dc1b3a08f8530271014df12c5b69cc1a699fb1959bd63058",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14",
                 "check_gpg": true
               },
@@ -3556,6 +3892,14 @@
               },
               {
                 "checksum": "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:6e764f772148419feb7602ed81a6aa9ced35997931bd62d6699118957c5db86a",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:d600334211805f9f0bcf64a6bc1a2ab4824fd7976e186f79fec9b92392d394f4",
                 "check_gpg": true
               },
               {
@@ -3571,7 +3915,23 @@
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:c23a8cdd67d918268714ace5939872365ff62039b4da08a8c6b57883052dac9d",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:87434169fd88f118042741c2a73188dbfbb4ed4f36d8cd4d78f7f1a580787447",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:db78601913c72afca547d7cc8308c618c948d050a9e3b9b62fa4528d951024ce",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:cd39f952196a0241d1c3e9bea61cd86f4a6c3a8b9ba25b6b384860e22bd5a0f6",
                 "check_gpg": true
               },
               {
@@ -3595,18 +3955,6 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
                 "check_gpg": true
               },
@@ -3623,27 +3971,19 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:fc05e6abb02bcb99462711686ddfc47783c0a5575bdb451a7fce641a3b809e8e",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:137e82364adba68a95cf5af5369af68318afe9fea740c5deb6cd40f71727db34",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:fc4197a7f551c4d9580524cd5dc294bbd6fe52d45f479d1e92bab8f28ea3564b",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:796b15e590c5d726d63a3ca5bd7076b77a7d00bf844a6ed4b34d4de01cb0b089",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:95d047e12ecfe478b7f2a53803a528c3876c81cfdc36dc13f4f9345249e158fb",
                 "check_gpg": true
               },
               {
@@ -3659,19 +3999,15 @@
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:28024f873b855efd75f0a1cbd9149409a4fc553276c95811d136ff844aaaedd3",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:35eafd70242202d8a16226e1d792e940546d8c6f42d9211e0d286e7fe4d4abae",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad",
                 "check_gpg": true
               },
               {
@@ -3687,10 +4023,6 @@
                 "check_gpg": true
               },
               {
-                "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
-                "check_gpg": true
-              },
-              {
                 "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
                 "check_gpg": true
               },
@@ -3703,7 +4035,23 @@
                 "check_gpg": true
               },
               {
+                "checksum": "sha256:69048b9660fd703a15817beb7248fbd14ee00c0b5e2e3d1c65a4ad9a994a5183",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:67aac59b48fb8b8ce219306fff459a09a1b7e5dcb3ae24cf7ce48a6d9ef13ff8",
+                "check_gpg": true
+              },
+              {
                 "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:43adc18fc7e50377ea155a9679c7a7985ded3dfe4692019ca54ef1d65c702e43",
+                "check_gpg": true
+              },
+              {
+                "checksum": "sha256:f05c62d78957eb1ecabf42d5f95303b9381453e9754f01edf094674626260765",
                 "check_gpg": true
               },
               {
@@ -3712,14 +4060,6 @@
               },
               {
                 "checksum": "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:fdb23c2568785740578c8c2aef40f717f37cac51f71a8e2fc27c0ffd83bc7884",
-                "check_gpg": true
-              },
-              {
-                "checksum": "sha256:cd38bc0d85c3664d68bc57e006a9b0d31abec2a71a56e0a5a11a81a673f90a2a",
                 "check_gpg": true
               }
             ]
@@ -3744,47 +4084,6 @@
           }
         },
         {
-          "name": "org.osbuild.users",
-          "options": {
-            "users": {
-              "redhat": {
-                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
-              }
-            }
-          }
-        },
-        {
-          "name": "org.osbuild.fstab",
-          "options": {
-            "filesystems": [
-              {
-                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-                "vfs_type": "ext4",
-                "path": "/",
-                "options": "defaults",
-                "freq": 1,
-                "passno": 1
-              },
-              {
-                "uuid": "46BB-8120",
-                "vfs_type": "vfat",
-                "path": "/boot/efi",
-                "options": "umask=0077,shortname=winnt",
-                "passno": 2
-              }
-            ]
-          }
-        },
-        {
-          "name": "org.osbuild.grub2",
-          "options": {
-            "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-            "uefi": {
-              "vendor": "fedora"
-            }
-          }
-        },
-        {
           "name": "org.osbuild.fix-bls",
           "options": {}
         },
@@ -3792,10 +4091,22 @@
           "name": "org.osbuild.systemd",
           "options": {
             "enabled_services": [
-              "cloud-init.service",
-              "cloud-config.service",
-              "cloud-final.service",
-              "cloud-init-local.service"
+              "NetworkManager.service",
+              "firewalld.service",
+              "rngd.service",
+              "sshd.service",
+              "zezere_ignition.timer",
+              "zezere_ignition_banner.service",
+              "greenboot-grub2-set-counter",
+              "greenboot-grub2-set-success",
+              "greenboot-healthcheck",
+              "greenboot-rpm-ostree-grub2-check-fallback",
+              "greenboot-status",
+              "greenboot-task-runner",
+              "redboot-auto-reboot",
+              "redboot-task-runner",
+              "parsec",
+              "dbus-parsec"
             ]
           }
         },
@@ -3804,39 +4115,24 @@
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
           }
+        },
+        {
+          "name": "org.osbuild.rpm-ostree",
+          "options": {
+            "etc_group_members": [
+              "wheel",
+              "docker"
+            ]
+          }
         }
       ],
       "assembler": {
-        "name": "org.osbuild.qemu",
+        "name": "org.osbuild.ostree.commit",
         "options": {
-          "format": "qcow2",
-          "filename": "disk.qcow2",
-          "size": 2147483648,
-          "ptuuid": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
-          "pttype": "gpt",
-          "partitions": [
-            {
-              "start": 2048,
-              "size": 972800,
-              "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-              "uuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
-              "filesystem": {
-                "type": "vfat",
-                "uuid": "46BB-8120",
-                "label": "EFI-SYSTEM",
-                "mountpoint": "/boot/efi"
-              }
-            },
-            {
-              "start": 976896,
-              "uuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
-              "filesystem": {
-                "type": "ext4",
-                "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-                "mountpoint": "/"
-              }
-            }
-          ]
+          "ref": "fedora/35/aarch64/iot",
+          "tar": {
+            "filename": "commit.tar"
+          }
         }
       }
     }
@@ -5596,6 +5892,16 @@
         "check_gpg": true
       },
       {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bubblewrap-0.5.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6adb150683f3c6ab63c568be09b92fe990ecd32f8ed049273f1d46aae3f50129",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -5876,6 +6182,26 @@
         "check_gpg": true
       },
       {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:46266d1762bf3ae1711b1cbfb37cabc8e3c884cdbecbdaa6d9fff1259fa0f55b",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-common-3.10.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:75ea1c8a9d97996e6c9a4d915a9ef9c5432c912f716b206c868b5d1e3c997d1f",
+        "check_gpg": true
+      },
+      {
         "name": "fuse-libs",
         "epoch": 0,
         "version": "2.9.9",
@@ -6013,6 +6339,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
         "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-glib-1.6.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:995c4dedc7a0c58a2cc5d780e6bab6f3adcb64f935924cfa6af7df603bffa842",
         "check_gpg": true
       },
       {
@@ -7556,6 +7892,26 @@
         "check_gpg": true
       },
       {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2022.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/ostree-2022.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e764f772148419feb7602ed81a6aa9ced35997931bd62d6699118957c5db86a",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2022.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/ostree-libs-2022.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d600334211805f9f0bcf64a6bc1a2ab4824fd7976e186f79fec9b92392d394f4",
+        "check_gpg": true
+      },
+      {
         "name": "pcsc-lite",
         "epoch": 0,
         "version": "1.9.5",
@@ -7686,6 +8042,26 @@
         "check_gpg": true
       },
       {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2022.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/r/rpm-ostree-2022.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:796b15e590c5d726d63a3ca5bd7076b77a7d00bf844a6ed4b34d4de01cb0b089",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2022.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/r/rpm-ostree-libs-2022.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:95d047e12ecfe478b7f2a53803a528c3876c81cfdc36dc13f4f9345249e158fb",
+        "check_gpg": true
+      },
+      {
         "name": "selinux-policy",
         "epoch": 0,
         "version": "35.8",
@@ -7788,6 +8164,26 @@
     ],
     "packages": [
       {
+        "name": "ModemManager",
+        "epoch": 0,
+        "version": "1.18.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/ModemManager-1.18.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5b6c7f2e43c1260c206d65dccd8cb947cb0f3348eaadf0afa6809fea9c9f914d",
+        "check_gpg": true
+      },
+      {
+        "name": "ModemManager-glib",
+        "epoch": 0,
+        "version": "1.18.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/ModemManager-glib-1.18.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:cd908e1b818441a631035416579c08315b3fae510151174fd40a02901be0586e",
+        "check_gpg": true
+      },
+      {
         "name": "acl",
         "epoch": 0,
         "version": "2.3.1",
@@ -7805,6 +8201,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm",
         "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+        "check_gpg": true
+      },
+      {
+        "name": "attr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/attr-2.5.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:26db7baa5f56c18294dd53b31b6d59ef38fffe05d46608594653a457789c13a8",
         "check_gpg": true
       },
       {
@@ -7848,6 +8254,66 @@
         "check_gpg": true
       },
       {
+        "name": "bash-completion",
+        "epoch": 1,
+        "version": "2.11",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-completion-2.11-3.fc35.noarch.rpm",
+        "checksum": "sha256:80a1e30e73044d23ab6e5d4531b5f52c4bd563a5232cba54e8d40380e79f0d3c",
+        "check_gpg": true
+      },
+      {
+        "name": "bcm2711-firmware",
+        "epoch": 0,
+        "version": "20210930",
+        "release": "1.b5257da.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bcm2711-firmware-20210930-1.b5257da.fc35.aarch64.rpm",
+        "checksum": "sha256:ea89c837ae0f083755d3499adc8a4bf34e16c7f9f7ee776bf7623fb765997f57",
+        "check_gpg": true
+      },
+      {
+        "name": "bcm2835-firmware",
+        "epoch": 0,
+        "version": "20210930",
+        "release": "1.b5257da.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bcm2835-firmware-20210930-1.b5257da.fc35.aarch64.rpm",
+        "checksum": "sha256:2dd8af06b106716d1e2d7c058518efc4be513e3bab8d4637ae6d5202c2acfcf3",
+        "check_gpg": true
+      },
+      {
+        "name": "bcm283x-firmware",
+        "epoch": 0,
+        "version": "20210930",
+        "release": "1.b5257da.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bcm283x-firmware-20210930-1.b5257da.fc35.aarch64.rpm",
+        "checksum": "sha256:93ed0b24b9f4cf580780c0ee6e89737cc42f800164d84f1b84fe8cc5d2b708c3",
+        "check_gpg": true
+      },
+      {
+        "name": "bcm283x-overlays",
+        "epoch": 0,
+        "version": "20210930",
+        "release": "1.b5257da.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bcm283x-overlays-20210930-1.b5257da.fc35.aarch64.rpm",
+        "checksum": "sha256:445c078bffe6ec618ac462378b67632a2d0732d0767f9d008ee163320d2e7a3d",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bubblewrap-0.5.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6adb150683f3c6ab63c568be09b92fe990ecd32f8ed049273f1d46aae3f50129",
+        "check_gpg": true
+      },
+      {
         "name": "bzip2-libs",
         "epoch": 0,
         "version": "1.0.8",
@@ -7855,16 +8321,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm",
         "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
-        "check_gpg": true
-      },
-      {
-        "name": "c-ares",
-        "epoch": 0,
-        "version": "1.17.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65",
         "check_gpg": true
       },
       {
@@ -7888,13 +8344,23 @@
         "check_gpg": true
       },
       {
-        "name": "cloud-init",
+        "name": "conmon",
+        "epoch": 2,
+        "version": "2.0.30",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/conmon-2.0.30-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4f0d774fdab0e9e3052ebed054f484f7e2e20bb1ff4694b1bb612ef4c57a2a51",
+        "check_gpg": true
+      },
+      {
+        "name": "containernetworking-plugins",
         "epoch": 0,
-        "version": "20.4",
-        "release": "7.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cloud-init-20.4-7.fc35.noarch.rpm",
-        "checksum": "sha256:c0be8fbd6171dac53aa40efd4dfc3f0185843f7506d042d5821cf1cb4217a78a",
+        "version": "1.0.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/containernetworking-plugins-1.0.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:3d8acf78b1daa3e2b6528471f7ab3799a24ba1ffa66751f134c74db56b91ee7d",
         "check_gpg": true
       },
       {
@@ -8018,23 +8484,13 @@
         "check_gpg": true
       },
       {
-        "name": "dejavu-sans-fonts",
+        "name": "dbus-parsec",
         "epoch": 0,
-        "version": "2.37",
-        "release": "17.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dejavu-sans-fonts-2.37-17.fc35.noarch.rpm",
-        "checksum": "sha256:880f90cba8baea53cf9c487c8e97d4160c6e98257909bb69559f5c129c2441c8",
-        "check_gpg": true
-      },
-      {
-        "name": "deltarpm",
-        "epoch": 0,
-        "version": "3.6.2",
-        "release": "10.fc35",
+        "version": "0.3.1",
+        "release": "4.fc35",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
-        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-parsec-0.3.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:0d2e94bebd4f3ca297c347171e548e9a9ec917dfaee87d73e62a753177d4fd8a",
         "check_gpg": true
       },
       {
@@ -8048,6 +8504,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-event-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:50763d3f0eda21834dd020c4c3f4cf1ae982da02c841ed95aee507290be4b058",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-event-libs-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9f701673ee9035ca9c2391ab7ae8fccee803fa979b326c523cddfdc097f8c657",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 0,
         "version": "1.02.175",
@@ -8058,23 +8534,13 @@
         "check_gpg": true
       },
       {
-        "name": "dhcp-client",
-        "epoch": 12,
-        "version": "4.4.2",
-        "release": "16.b1.fc35",
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.fc35",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.aarch64.rpm",
-        "checksum": "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070",
-        "check_gpg": true
-      },
-      {
-        "name": "dhcp-common",
-        "epoch": 12,
-        "version": "4.4.2",
-        "release": "16.b1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm",
-        "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-persistent-data-0.9.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:d97452702c3b5f4832b589f03f3869334f08767c298a0adc6d85d51129f7cfeb",
         "check_gpg": true
       },
       {
@@ -8088,23 +8554,23 @@
         "check_gpg": true
       },
       {
-        "name": "dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dmidecode-3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:be29b25a2f937e4442da2511c27ea07403b8476c01619d6a50b182e3c3f7f7aa",
         "check_gpg": true
       },
       {
-        "name": "dnf-data",
+        "name": "dosfstools",
         "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+        "version": "4.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
         "check_gpg": true
       },
       {
@@ -8188,16 +8654,6 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-repos-modular",
-        "epoch": 0,
-        "version": "35",
-        "release": "1",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm",
-        "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
-        "check_gpg": true
-      },
-      {
         "name": "file",
         "epoch": 0,
         "version": "5.40",
@@ -8258,13 +8714,33 @@
         "check_gpg": true
       },
       {
-        "name": "fonts-filesystem",
-        "epoch": 1,
-        "version": "2.0.5",
-        "release": "6.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fonts-filesystem-2.0.5-6.fc35.noarch.rpm",
-        "checksum": "sha256:1d44d5177b7f373d8a08ebf6a6fc3f990e9d542485ed9cc49c3e90045556d7ee",
+        "name": "flashrom",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/flashrom-1.2-7.fc35.aarch64.rpm",
+        "checksum": "sha256:2b04a72168d77e8a916b1bf7e70cc1977064e19339132562e85d899e3a29b603",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:46266d1762bf3ae1711b1cbfb37cabc8e3c884cdbecbdaa6d9fff1259fa0f55b",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-common-3.10.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:75ea1c8a9d97996e6c9a4d915a9ef9c5432c912f716b206c868b5d1e3c997d1f",
         "check_gpg": true
       },
       {
@@ -8275,6 +8751,46 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
         "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-overlayfs",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-overlayfs-1.7.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:69e489e334c05ce06c984e189d73849853583c59aaf7c60a690bf3d02c137ea7",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-3.10.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:780b5eb1c3aaf26ff92cc7092a4d0a454f96bb621ee0463b66f762386f5544a9",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse3-libs-3.10.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e3ff3d6307373af1bad2fcfa82307c0b3ccd9bf7cff66a8935981ebfcc94d4b",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-efi",
+        "epoch": 0,
+        "version": "1.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fwupd-efi-1.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4728c8dcf044d801a3c03d786598d23c5f6c7df8d8b363796f5ba3fdbd566d65",
         "check_gpg": true
       },
       {
@@ -8295,6 +8811,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm",
         "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+        "check_gpg": true
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gdisk-1.0.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:6b70550aaff6f0a18cacec9d697d6e2697f1d12058f129e55dee3457a99bec30",
         "check_gpg": true
       },
       {
@@ -8348,6 +8874,56 @@
         "check_gpg": true
       },
       {
+        "name": "greenboot",
+        "epoch": 0,
+        "version": "0.12.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/greenboot-0.12.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:7b74b239d9149d37b1b55234810ab2ae9b3a9f949b2bd4ebd04839abb5c332b9",
+        "check_gpg": true
+      },
+      {
+        "name": "greenboot-grub2",
+        "epoch": 0,
+        "version": "0.12.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/greenboot-grub2-0.12.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f255fca77a9d1f936e1c0ea9d01141c1ee7e23cf4be68aed3e7567bf1cc5ac64",
+        "check_gpg": true
+      },
+      {
+        "name": "greenboot-reboot",
+        "epoch": 0,
+        "version": "0.12.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/greenboot-reboot-0.12.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0cb072b3ab5755d4ee272fb3fe9b632ab53c14a6037e42cec7dc0de5b7341b19",
+        "check_gpg": true
+      },
+      {
+        "name": "greenboot-rpm-ostree-grub2",
+        "epoch": 0,
+        "version": "0.12.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/greenboot-rpm-ostree-grub2-0.12.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2f36a4315506b13e0c8b01a08511c484b29028ebb9dace8d6d1aa94db2716219",
+        "check_gpg": true
+      },
+      {
+        "name": "greenboot-status",
+        "epoch": 0,
+        "version": "0.12.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/greenboot-status-0.12.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fc5e0f9bb760d12519e8e2183ab51d3196e4416a3e7572156edf6bd042af5776",
+        "check_gpg": true
+      },
+      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -8355,16 +8931,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm",
         "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
-        "check_gpg": true
-      },
-      {
-        "name": "groff-base",
-        "epoch": 0,
-        "version": "1.22.4",
-        "release": "8.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.aarch64.rpm",
-        "checksum": "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21",
         "check_gpg": true
       },
       {
@@ -8395,56 +8961,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.aarch64.rpm",
         "checksum": "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be",
-        "check_gpg": true
-      },
-      {
-        "name": "hunspell",
-        "epoch": 0,
-        "version": "1.7.0",
-        "release": "11.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-1.7.0-11.fc35.aarch64.rpm",
-        "checksum": "sha256:f878dd687438db0e07f2eb571246103ae0e136647242f0bf7f806ddd77e04a91",
-        "check_gpg": true
-      },
-      {
-        "name": "hunspell-en",
-        "epoch": 0,
-        "version": "0.20140811.1",
-        "release": "20.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-0.20140811.1-20.fc35.noarch.rpm",
-        "checksum": "sha256:d410e22cbb51f6c23ff3cb2dd597ec35a1d86ddf657f0046856136311e61f16f",
-        "check_gpg": true
-      },
-      {
-        "name": "hunspell-en-GB",
-        "epoch": 0,
-        "version": "0.20140811.1",
-        "release": "20.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-GB-0.20140811.1-20.fc35.noarch.rpm",
-        "checksum": "sha256:6cb78ab7c60560a9c98804875dad59e43c9128fa4571de7d9ff94e3e14966e4f",
-        "check_gpg": true
-      },
-      {
-        "name": "hunspell-en-US",
-        "epoch": 0,
-        "version": "0.20140811.1",
-        "release": "20.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-en-US-0.20140811.1-20.fc35.noarch.rpm",
-        "checksum": "sha256:e46d93f6334b10b8cc69b6fa42ae442882d47aa31f159dd5f9a3844911e09b2e",
-        "check_gpg": true
-      },
-      {
-        "name": "hunspell-filesystem",
-        "epoch": 0,
-        "version": "1.7.0",
-        "release": "11.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hunspell-filesystem-1.7.0-11.fc35.aarch64.rpm",
-        "checksum": "sha256:58b6c3272af7450868f9b6ee3e15f05e45104751cacaa4a22345983caaea14da",
         "check_gpg": true
       },
       {
@@ -8485,16 +9001,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm",
         "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
-        "check_gpg": true
-      },
-      {
-        "name": "ipcalc",
-        "epoch": 0,
-        "version": "1.0.1",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.aarch64.rpm",
-        "checksum": "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce",
         "check_gpg": true
       },
       {
@@ -8578,6 +9084,16 @@
         "check_gpg": true
       },
       {
+        "name": "iw",
+        "epoch": 0,
+        "version": "5.9",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iw-5.9-3.fc35.aarch64.rpm",
+        "checksum": "sha256:e64f54c1e4bc0cb5881ca76f9eddb0caf3500b8ecb3e5ac634f5ca1457b46414",
+        "check_gpg": true
+      },
+      {
         "name": "jansson",
         "epoch": 0,
         "version": "2.13.1",
@@ -8588,6 +9104,26 @@
         "check_gpg": true
       },
       {
+        "name": "jose",
+        "epoch": 0,
+        "version": "11",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/jose-11-3.fc35.aarch64.rpm",
+        "checksum": "sha256:1606617e17243ca6d9cfab6553f6930ff859634a04d3ffec3cb6c1a7277d6709",
+        "check_gpg": true
+      },
+      {
+        "name": "jq",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/jq-1.6-10.fc35.aarch64.rpm",
+        "checksum": "sha256:4801858945fbf03ccf0605293a3749826e09b39658597106c89bb61fb3940366",
+        "check_gpg": true
+      },
+      {
         "name": "json-c",
         "epoch": 0,
         "version": "0.15",
@@ -8595,6 +9131,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
         "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-glib-1.6.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:995c4dedc7a0c58a2cc5d780e6bab6f3adcb64f935924cfa6af7df603bffa842",
         "check_gpg": true
       },
       {
@@ -8615,6 +9161,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
         "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-1.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:8b2def9e5cfecdddbd865b0b59b9532e525af274877b3ddde95b4a9fbbcb530e",
         "check_gpg": true
       },
       {
@@ -8668,96 +9224,6 @@
         "check_gpg": true
       },
       {
-        "name": "langpacks-core-en",
-        "epoch": 0,
-        "version": "3.0",
-        "release": "15.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-en-3.0-15.fc35.noarch.rpm",
-        "checksum": "sha256:4efde5212b5b250e2d1fda64f35b56a2cf2a55afb84280f8c826b7fa9bb12f07",
-        "check_gpg": true
-      },
-      {
-        "name": "langpacks-core-font-en",
-        "epoch": 0,
-        "version": "3.0",
-        "release": "15.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-core-font-en-3.0-15.fc35.noarch.rpm",
-        "checksum": "sha256:144dca5b5fb11bbadea0f8e92a66cb31e7d1a1cfb5078b5b053b52d667c1a75f",
-        "check_gpg": true
-      },
-      {
-        "name": "langpacks-en",
-        "epoch": 0,
-        "version": "3.0",
-        "release": "15.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/langpacks-en-3.0-15.fc35.noarch.rpm",
-        "checksum": "sha256:6c72244bea772a8a29c07c66f76289013adcd8bb11d60bdc8375c78b6e9aec2a",
-        "check_gpg": true
-      },
-      {
-        "name": "libXau",
-        "epoch": 0,
-        "version": "1.0.9",
-        "release": "7.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXau-1.0.9-7.fc35.aarch64.rpm",
-        "checksum": "sha256:92165f8506bcde6d8b121033f17441f51c57b163b2d24e591c6d7d667d967f07",
-        "check_gpg": true
-      },
-      {
-        "name": "libXext",
-        "epoch": 0,
-        "version": "1.3.4",
-        "release": "7.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXext-1.3.4-7.fc35.aarch64.rpm",
-        "checksum": "sha256:2db66e2d4cb69b7433e334870a06b167dfbe38ba8c8be5d6eb6d3fe69ac0f769",
-        "check_gpg": true
-      },
-      {
-        "name": "libXfixes",
-        "epoch": 0,
-        "version": "6.0.0",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXfixes-6.0.0-2.fc35.aarch64.rpm",
-        "checksum": "sha256:ee9c63222e5d761bf50ada5b6c5068e7555c08f159489b5da9d4944684426308",
-        "check_gpg": true
-      },
-      {
-        "name": "libXinerama",
-        "epoch": 0,
-        "version": "1.1.4",
-        "release": "9.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXinerama-1.1.4-9.fc35.aarch64.rpm",
-        "checksum": "sha256:cd892e1d1657846057a26c5abe7cc78d190742b81933a099bbe2c75e766b37d3",
-        "check_gpg": true
-      },
-      {
-        "name": "libXrandr",
-        "epoch": 0,
-        "version": "1.5.2",
-        "release": "7.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXrandr-1.5.2-7.fc35.aarch64.rpm",
-        "checksum": "sha256:81b1b84501851960326a165de6e938696a6a69f69bfac3478b26c5e2a24a6c73",
-        "check_gpg": true
-      },
-      {
-        "name": "libXrender",
-        "epoch": 0,
-        "version": "0.9.10",
-        "release": "15.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libXrender-0.9.10-15.fc35.aarch64.rpm",
-        "checksum": "sha256:a0bcda38ffb40a7e6d28c88dbbbf9b6f2d77e2614aafb53d69bd24bf111ba46a",
-        "check_gpg": true
-      },
-      {
         "name": "libacl",
         "epoch": 0,
         "version": "2.3.1",
@@ -8765,6 +9231,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
         "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "12.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libaio-0.3.111-12.fc35.aarch64.rpm",
+        "checksum": "sha256:7ffee621301e8918ebe90d82a936d9aba21fb05460b9f133b739fad56109ec7a",
         "check_gpg": true
       },
       {
@@ -8798,6 +9274,16 @@
         "check_gpg": true
       },
       {
+        "name": "libatasmart",
+        "epoch": 0,
+        "version": "0.19",
+        "release": "21.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libatasmart-0.19-21.fc35.aarch64.rpm",
+        "checksum": "sha256:2533e03bea40216e6ada92db8d91f0a63742267c5cb853f0ca1733a4afe2a532",
+        "check_gpg": true
+      },
+      {
         "name": "libattr",
         "epoch": 0,
         "version": "2.5.1",
@@ -8805,16 +9291,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm",
         "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
-        "check_gpg": true
-      },
-      {
-        "name": "libbasicobjects",
-        "epoch": 0,
-        "version": "0.1.1",
-        "release": "48.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.aarch64.rpm",
-        "checksum": "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094",
         "check_gpg": true
       },
       {
@@ -8828,6 +9304,86 @@
         "check_gpg": true
       },
       {
+        "name": "libblockdev",
+        "epoch": 0,
+        "version": "2.26",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblockdev-2.26-1.fc35.aarch64.rpm",
+        "checksum": "sha256:1d0db47703af808b523a192acbcbde38d01b327f27d8bb9b28d17c12fab56e2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-crypto",
+        "epoch": 0,
+        "version": "2.26",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblockdev-crypto-2.26-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6cc8527a433894beef6f7d13d340d346dc282f5d4ca9ae23c4899dc5926bf982",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-fs",
+        "epoch": 0,
+        "version": "2.26",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblockdev-fs-2.26-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b90acd201d652a6b6a9b3d1333ae5160af3c4e24edd26786967b577062bada6c",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-loop",
+        "epoch": 0,
+        "version": "2.26",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblockdev-loop-2.26-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ba67c8942f30df3be1eda8006390741a3825dd4e5eadee6e3e0b6c22fbf95930",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-mdraid",
+        "epoch": 0,
+        "version": "2.26",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblockdev-mdraid-2.26-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4b29b2e2e3e15473e94ef1f37225806f1af94ab990bf2c9022e34d9bb28089a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-part",
+        "epoch": 0,
+        "version": "2.26",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblockdev-part-2.26-1.fc35.aarch64.rpm",
+        "checksum": "sha256:475a1da757738ac1c46ed406c782726ad75b9171254c9aecb282353bec8ccf0a",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-swap",
+        "epoch": 0,
+        "version": "2.26",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblockdev-swap-2.26-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2367e7436b2a8635504c9ad4a0a30043cd782e4d3bb61bc2f8f3ae54fc235a01",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-utils",
+        "epoch": 0,
+        "version": "2.26",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblockdev-utils-2.26-1.fc35.aarch64.rpm",
+        "checksum": "sha256:78ef00e846f607c84444984b48eef2cb02964bcc085566d24d7c87d6ac2d704c",
+        "check_gpg": true
+      },
+      {
         "name": "libbrotli",
         "epoch": 0,
         "version": "1.0.9",
@@ -8835,6 +9391,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm",
         "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+        "check_gpg": true
+      },
+      {
+        "name": "libbsd",
+        "epoch": 0,
+        "version": "0.10.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbsd-0.10.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:d59194acb6a6fb541c9c0156b8ea67d60bf6ff5e8597c9efcd1e2b60b2e17342",
+        "check_gpg": true
+      },
+      {
+        "name": "libbytesize",
+        "epoch": 0,
+        "version": "2.6",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbytesize-2.6-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c7e3fddc8895550d1096c908c9c9c71aa5b4d150d504f939bd45aaf87579c03d",
         "check_gpg": true
       },
       {
@@ -8858,16 +9434,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcollection",
-        "epoch": 0,
-        "version": "0.7.0",
-        "release": "48.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.aarch64.rpm",
-        "checksum": "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36",
-        "check_gpg": true
-      },
-      {
         "name": "libcom_err",
         "epoch": 0,
         "version": "1.46.3",
@@ -8878,16 +9444,6 @@
         "check_gpg": true
       },
       {
-        "name": "libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
-        "check_gpg": true
-      },
-      {
         "name": "libdb",
         "epoch": 0,
         "version": "5.3.28",
@@ -8895,26 +9451,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm",
         "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
-        "check_gpg": true
-      },
-      {
-        "name": "libdhash",
-        "epoch": 0,
-        "version": "0.5.0",
-        "release": "48.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.aarch64.rpm",
-        "checksum": "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1",
-        "check_gpg": true
-      },
-      {
-        "name": "libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
         "check_gpg": true
       },
       {
@@ -8958,16 +9494,6 @@
         "check_gpg": true
       },
       {
-        "name": "libfdt",
-        "epoch": 0,
-        "version": "1.6.1",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdt-1.6.1-2.fc35.aarch64.rpm",
-        "checksum": "sha256:5d3d700fc60b7ec85915692030f7fa121ca83ea74acca62b6dfdbc9f8cd5ae7e",
-        "check_gpg": true
-      },
-      {
         "name": "libffi",
         "epoch": 0,
         "version": "3.1",
@@ -8988,6 +9514,26 @@
         "check_gpg": true
       },
       {
+        "name": "libftdi",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libftdi-1.5-2.fc35.aarch64.rpm",
+        "checksum": "sha256:1bed49c7153d4b2ea49a46af3360e4bee3a7f435ff0e4b58b96370813f738b41",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcab1",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcab1-1.4-5.fc35.aarch64.rpm",
+        "checksum": "sha256:6aed0d8e3025df0de1fbbbae857f8e7fa0e42561e294f923224779617d4ac35f",
+        "check_gpg": true
+      },
+      {
         "name": "libgcrypt",
         "epoch": 0,
         "version": "1.9.4",
@@ -8995,6 +9541,36 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm",
         "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpiod",
+        "epoch": 0,
+        "version": "1.6.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgpiod-1.6.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9619cce941f30750a8cea4c6d9fe1384c053cc1c645aec111d93b4f790da4744",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpiod-utils",
+        "epoch": 0,
+        "version": "1.6.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgpiod-utils-1.6.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:aa30a972a41bbfb84243dbcdf221d8d8d6b0fa28e67d71d48845befcc6b871df",
+        "check_gpg": true
+      },
+      {
+        "name": "libgudev",
+        "epoch": 0,
+        "version": "237",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgudev-237-1.fc35.aarch64.rpm",
+        "checksum": "sha256:3030255b1885347b03057ca9e9ce9c9ad29d186727ab4d26cabd14eedaf84c05",
         "check_gpg": true
       },
       {
@@ -9008,13 +9584,13 @@
         "check_gpg": true
       },
       {
-        "name": "libini_config",
+        "name": "libjose",
         "epoch": 0,
-        "version": "1.3.1",
-        "release": "48.fc35",
+        "version": "11",
+        "release": "3.fc35",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.aarch64.rpm",
-        "checksum": "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libjose-11-3.fc35.aarch64.rpm",
+        "checksum": "sha256:78387c08ffff62399ccc1ae280f414d2f7521699481faac70faa23b5abdb18f4",
         "check_gpg": true
       },
       {
@@ -9045,6 +9621,36 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
         "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "libluksmeta",
+        "epoch": 0,
+        "version": "9",
+        "release": "12.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libluksmeta-9-12.fc35.aarch64.rpm",
+        "checksum": "sha256:b93cee77f8662f35ab2ed9e047b50020a8be9eac8aa9bea59eefcd02ed844f43",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim",
+        "epoch": 0,
+        "version": "1.26.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmbim-1.26.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6f7f54b120526821e215487d860b04800d723fb259d0d19f4e412645d2abea6d",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim-utils",
+        "epoch": 0,
+        "version": "1.26.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmbim-utils-1.26.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:028ac461745f7189b35ebb09178d4c69206d0fc6fc0f0e82d465e245d3173d1d",
         "check_gpg": true
       },
       {
@@ -9088,6 +9694,16 @@
         "check_gpg": true
       },
       {
+        "name": "libnet",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnet-1.2-4.fc35.aarch64.rpm",
+        "checksum": "sha256:183226966749e33e2fdc008797fb5f7782da589be4a10ef3692bbe684892e88f",
+        "check_gpg": true
+      },
+      {
         "name": "libnetfilter_conntrack",
         "epoch": 0,
         "version": "1.0.8",
@@ -9105,16 +9721,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.aarch64.rpm",
         "checksum": "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3",
-        "check_gpg": true
-      },
-      {
-        "name": "libnfsidmap",
-        "epoch": 1,
-        "version": "2.5.4",
-        "release": "2.rc3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.aarch64.rpm",
-        "checksum": "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831",
         "check_gpg": true
       },
       {
@@ -9158,16 +9764,6 @@
         "check_gpg": true
       },
       {
-        "name": "libpath_utils",
-        "epoch": 0,
-        "version": "0.2.1",
-        "release": "48.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.aarch64.rpm",
-        "checksum": "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032",
-        "check_gpg": true
-      },
-      {
         "name": "libpcap",
         "epoch": 14,
         "version": "1.10.1",
@@ -9178,23 +9774,13 @@
         "check_gpg": true
       },
       {
-        "name": "libpciaccess",
+        "name": "libpkgconf",
         "epoch": 0,
-        "version": "0.16",
-        "release": "5.fc35",
+        "version": "1.8.0",
+        "release": "1.fc35",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpciaccess-0.16-5.fc35.aarch64.rpm",
-        "checksum": "sha256:69e19b20bc15ca446f218e1106357f6ee2fbe78fccfe4eb7100a9eafd91cce23",
-        "check_gpg": true
-      },
-      {
-        "name": "libpipeline",
-        "epoch": 0,
-        "version": "1.5.3",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.aarch64.rpm",
-        "checksum": "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpkgconf-1.8.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ab81bdcc43062cf8d2780350e98ba76b6e37f71a89e52c947c982fdca59966bd",
         "check_gpg": true
       },
       {
@@ -9218,13 +9804,33 @@
         "check_gpg": true
       },
       {
-        "name": "libref_array",
+        "name": "libqmi",
         "epoch": 0,
-        "version": "0.1.5",
-        "release": "48.fc35",
+        "version": "1.30.2",
+        "release": "1.fc35",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.aarch64.rpm",
-        "checksum": "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libqmi-1.30.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c473b4f4a820f535de9b6d10734c55eb6741de76f2671f893289b668751f16a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libqmi-utils",
+        "epoch": 0,
+        "version": "1.30.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libqmi-utils-1.30.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:3b1c4c7a8c136815e78051ebe384d5497f89b3e004cc6ded86cea5971b20cb63",
+        "check_gpg": true
+      },
+      {
+        "name": "libqrtr-glib",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libqrtr-glib-1.0.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d1c5895bbbcbc78e11eb9164c07fd62562c84b8b3b6129b4ffff83173c71562c",
         "check_gpg": true
       },
       {
@@ -9265,6 +9871,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm",
         "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+        "check_gpg": true
+      },
+      {
+        "name": "libslirp",
+        "epoch": 0,
+        "version": "4.6.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libslirp-4.6.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f367f9afbcc3c7e8652d1d525d20c0cf19fdcf1a8c837cc5fd3de4e518ca1207",
         "check_gpg": true
       },
       {
@@ -9318,16 +9934,6 @@
         "check_gpg": true
       },
       {
-        "name": "libtalloc",
-        "epoch": 0,
-        "version": "2.3.3",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.aarch64.rpm",
-        "checksum": "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180",
-        "check_gpg": true
-      },
-      {
         "name": "libtasn1",
         "epoch": 0,
         "version": "4.16.0",
@@ -9335,26 +9941,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm",
         "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
-        "check_gpg": true
-      },
-      {
-        "name": "libtdb",
-        "epoch": 0,
-        "version": "1.4.4",
-        "release": "3.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.aarch64.rpm",
-        "checksum": "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6",
-        "check_gpg": true
-      },
-      {
-        "name": "libtevent",
-        "epoch": 0,
-        "version": "0.11.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a",
         "check_gpg": true
       },
       {
@@ -9375,16 +9961,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
         "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
-        "check_gpg": true
-      },
-      {
-        "name": "liburing",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/liburing-2.0-2.fc35.aarch64.rpm",
-        "checksum": "sha256:f21ea3f290003e150b6af58f9eb995fe68446b204ae5b22369f820af56a38011",
         "check_gpg": true
       },
       {
@@ -9438,16 +10014,6 @@
         "check_gpg": true
       },
       {
-        "name": "libxcb",
-        "epoch": 0,
-        "version": "1.13.1",
-        "release": "8.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxcb-1.13.1-8.fc35.aarch64.rpm",
-        "checksum": "sha256:9da9f25dfdfb817d5ed99288c9bec5a6547dfe388c156e9dd83f10c0a04204ae",
-        "check_gpg": true
-      },
-      {
         "name": "libxkbcommon",
         "epoch": 0,
         "version": "1.3.1",
@@ -9478,16 +10044,6 @@
         "check_gpg": true
       },
       {
-        "name": "lmdb-libs",
-        "epoch": 0,
-        "version": "0.9.29",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.aarch64.rpm",
-        "checksum": "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7",
-        "check_gpg": true
-      },
-      {
         "name": "lua-libs",
         "epoch": 0,
         "version": "5.4.3",
@@ -9495,6 +10051,36 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm",
         "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+        "check_gpg": true
+      },
+      {
+        "name": "luksmeta",
+        "epoch": 0,
+        "version": "9",
+        "release": "12.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/luksmeta-9-12.fc35.aarch64.rpm",
+        "checksum": "sha256:6c36aa3211de438afc66ef7e164629ed6c78d142be1c7b06bf8a9244260d2cbe",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 0,
+        "version": "2.03.11",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lvm2-2.03.11-6.fc35.aarch64.rpm",
+        "checksum": "sha256:a09da17a664bae9f998c5fc3224ef4983dca376d7861313c79e13eba59d7b221",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 0,
+        "version": "2.03.11",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lvm2-libs-2.03.11-6.fc35.aarch64.rpm",
+        "checksum": "sha256:109eec660842523b39da8f0647db99c05f21bd54f7eac626789be55acce59e81",
         "check_gpg": true
       },
       {
@@ -9508,13 +10094,23 @@
         "check_gpg": true
       },
       {
-        "name": "man-db",
+        "name": "lzo",
         "epoch": 0,
-        "version": "2.9.4",
-        "release": "2.fc35",
+        "version": "2.10",
+        "release": "5.fc35",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.aarch64.rpm",
-        "checksum": "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lzo-2.10-5.fc35.aarch64.rpm",
+        "checksum": "sha256:649b1aeda89e3838e2063ec6a01ba516a199880f7333e7cc2331e0041638a050",
+        "check_gpg": true
+      },
+      {
+        "name": "mdadm",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "rc2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mdadm-4.2-rc2.fc35.aarch64.rpm",
+        "checksum": "sha256:6ec44e1fd7a4de66115ffed1790e7723e2e0a2aa489efe0369e9ed127bd8edb5",
         "check_gpg": true
       },
       {
@@ -9558,16 +10154,6 @@
         "check_gpg": true
       },
       {
-        "name": "ncurses",
-        "epoch": 0,
-        "version": "6.2",
-        "release": "8.20210508.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.aarch64.rpm",
-        "checksum": "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7",
-        "check_gpg": true
-      },
-      {
         "name": "ncurses-base",
         "epoch": 0,
         "version": "6.2",
@@ -9585,16 +10171,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm",
         "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
-        "check_gpg": true
-      },
-      {
-        "name": "net-tools",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "0.60.20160912git.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/net-tools-2.0-0.60.20160912git.fc35.aarch64.rpm",
-        "checksum": "sha256:fccda302546302309788e451ccaa2fb2abba72fa7b4184e82e1ff89830d8e306",
         "check_gpg": true
       },
       {
@@ -9625,6 +10201,46 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
         "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-altfiles",
+        "epoch": 0,
+        "version": "2.18.1",
+        "release": "19.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nss-altfiles-2.18.1-19.fc35.aarch64.rpm",
+        "checksum": "sha256:85591f702b9d91e1c816d584ae8de4b6e69da0d6941bd9fedcdd0de65bd4840c",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-libs",
+        "epoch": 2,
+        "version": "2021.8.22",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ntfs-3g-libs-2021.8.22-2.fc35.aarch64.rpm",
+        "checksum": "sha256:9d0886ba7fcc25ff9748d7d5a9a4580470bef38d6ddd982acba3fd17ec82400e",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfsprogs",
+        "epoch": 2,
+        "version": "2021.8.22",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ntfsprogs-2021.8.22-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d991d713a73c4e3fddfaaffc51e66fc30e3261f3705babba50fd2ac2e9ebc7a1",
+        "check_gpg": true
+      },
+      {
+        "name": "oniguruma",
+        "epoch": 0,
+        "version": "6.9.7.1",
+        "release": "1.fc35.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/oniguruma-6.9.7.1-1.fc35.1.aarch64.rpm",
+        "checksum": "sha256:e1a7c69b36c1824633898435c16fb10d733424e029da26f5050b0555bf85b66d",
         "check_gpg": true
       },
       {
@@ -9698,6 +10314,16 @@
         "check_gpg": true
       },
       {
+        "name": "parsec",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/parsec-0.7.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9692c1d6a2c57049d1d050bff3e422164ec59b53aa09513172cfc975ac10cedb",
+        "check_gpg": true
+      },
+      {
         "name": "parted",
         "epoch": 0,
         "version": "3.4",
@@ -9715,6 +10341,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.aarch64.rpm",
         "checksum": "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a",
+        "check_gpg": true
+      },
+      {
+        "name": "pciutils-libs",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pciutils-libs-3.7.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b0c4da2957a85cd15d93fb0b4aa074c8a6d978e443f66b0482b9b4ef3bbe1a23",
         "check_gpg": true
       },
       {
@@ -9768,33 +10404,33 @@
         "check_gpg": true
       },
       {
-        "name": "plymouth",
+        "name": "pkgconf",
         "epoch": 0,
-        "version": "0.9.5",
-        "release": "3.20210331git1ea1020.fc35",
+        "version": "1.8.0",
+        "release": "1.fc35",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm",
-        "checksum": "sha256:07fd0548f64b358ffd9ce32e885b7b91dc7e6208171d7efb9874923aead0fa5c",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pkgconf-1.8.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:cc1fc05e1e26e7f0e2fad7e91457139add3f444d4982613bdb3271235702705a",
         "check_gpg": true
       },
       {
-        "name": "plymouth-core-libs",
+        "name": "pkgconf-m4",
         "epoch": 0,
-        "version": "0.9.5",
-        "release": "3.20210331git1ea1020.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-core-libs-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm",
-        "checksum": "sha256:6c5f9498b18f3634aff99c8c07148876906a35357a86d473ff62f1073059a7aa",
+        "version": "1.8.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pkgconf-m4-1.8.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:b005c546d9966003ae0c66faf1cea9b6acd2b6e9f7dee2d2e578a5b30f11686a",
         "check_gpg": true
       },
       {
-        "name": "plymouth-scripts",
+        "name": "pkgconf-pkg-config",
         "epoch": 0,
-        "version": "0.9.5",
-        "release": "3.20210331git1ea1020.fc35",
+        "version": "1.8.0",
+        "release": "1.fc35",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-scripts-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm",
-        "checksum": "sha256:97c959173adc41a960200043e95347cb2ef9035dd7eec79d5489b11e3332a23d",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pkgconf-pkg-config-1.8.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b5e0b095706279778e1f20e6e0448ac20e7f37e9acfb962700ce7fd52d9a43e6",
         "check_gpg": true
       },
       {
@@ -9825,6 +10461,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
         "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf",
+        "epoch": 0,
+        "version": "3.14.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-3.14.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9a9d2db751a6524d3c641fdcb6eb8c5da81686aed260187fbc842c5ce542895e",
         "check_gpg": true
       },
       {
@@ -9868,16 +10514,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-attrs",
-        "epoch": 0,
-        "version": "21.2.0",
-        "release": "4.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-attrs-21.2.0-4.fc35.noarch.rpm",
-        "checksum": "sha256:259d0bc18d3e3992c66990df46cb61a06615447efe4b01d455303fa7bccc7135",
-        "check_gpg": true
-      },
-      {
         "name": "python3-audit",
         "epoch": 0,
         "version": "3.0.6",
@@ -9888,66 +10524,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-babel",
-        "epoch": 0,
-        "version": "2.9.1",
-        "release": "4.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-babel-2.9.1-4.fc35.noarch.rpm",
-        "checksum": "sha256:967d7172d0f3417e1f33d127b1226f7d89d0e0914202166e5e56dbd24b88173f",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-cffi",
-        "epoch": 0,
-        "version": "1.14.6",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cffi-1.14.6-2.fc35.aarch64.rpm",
-        "checksum": "sha256:baf6082e248e7e84f3cb5ec2695f0dc9afeca615b3f39c60283902ab06d3f564",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-charset-normalizer",
-        "epoch": 0,
-        "version": "2.0.4",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-charset-normalizer-2.0.4-1.fc35.noarch.rpm",
-        "checksum": "sha256:4b772ca1a729e5afa32722a2eeee3ddfbcf713d1d038a969d1c48bea4fbff45e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-configobj",
-        "epoch": 0,
-        "version": "5.0.6",
-        "release": "25.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-configobj-5.0.6-25.fc35.noarch.rpm",
-        "checksum": "sha256:581b0ecc341c11577b75e1bfbf2fbf9da1cd321ef9ad5bb1819ad5e3f4de578a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-cryptography",
-        "epoch": 0,
-        "version": "3.4.7",
-        "release": "5.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-cryptography-3.4.7-5.fc35.aarch64.rpm",
-        "checksum": "sha256:b30f029f856c7ff5a9ef7c71b4f8d0858b96962c5523ee7c7bcc6313b13a3b0c",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-dateutil",
-        "epoch": 1,
-        "version": "2.8.1",
-        "release": "7.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm",
-        "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
-        "check_gpg": true
-      },
-      {
         "name": "python3-dbus",
         "epoch": 0,
         "version": "1.2.18",
@@ -9955,26 +10531,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.aarch64.rpm",
         "checksum": "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-distro",
-        "epoch": 0,
-        "version": "1.6.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-dnf",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
         "check_gpg": true
       },
       {
@@ -9998,106 +10554,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-hawkey",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-idna",
-        "epoch": 0,
-        "version": "3.2",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-idna-3.2-1.fc35.noarch.rpm",
-        "checksum": "sha256:81d68e2bbc28476860615076ba84983af8f44247b78fcd732450200a366f3dcd",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-jinja2",
-        "epoch": 0,
-        "version": "3.0.1",
-        "release": "2.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jinja2-3.0.1-2.fc35.noarch.rpm",
-        "checksum": "sha256:83d17507f635f05e898c3c1c1d73c5ce0a85aff99de357deeec2eab5d488a339",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-jsonpointer",
-        "epoch": 0,
-        "version": "2.0",
-        "release": "4.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonpointer-2.0-4.fc35.noarch.rpm",
-        "checksum": "sha256:e5161075aabd3e7500a57f97a0579c9ed8e406c496cb0c0a55574a96d409b684",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-jsonschema",
-        "epoch": 0,
-        "version": "3.2.0",
-        "release": "12.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jsonschema-3.2.0-12.fc35.noarch.rpm",
-        "checksum": "sha256:831c806f8b28426fdc7a184e2b75fdc61ec6613b47d4e9e7a76248e65dac13ab",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-jwt+crypto",
-        "epoch": 0,
-        "version": "2.1.0",
-        "release": "2.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt+crypto-2.1.0-2.fc35.noarch.rpm",
-        "checksum": "sha256:d57809e72dcc9f92d36836f031a0499fde02b0aab2b4682a5d8fe56a4afd9fd6",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-jwt",
-        "epoch": 0,
-        "version": "2.1.0",
-        "release": "2.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-jwt-2.1.0-2.fc35.noarch.rpm",
-        "checksum": "sha256:4cfe2d608935563ba36a58710fca600dced8293d14a16eb8a2f935df3ffcfa62",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libcomps",
-        "epoch": 0,
-        "version": "0.1.18",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
-        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-libdnf",
-        "epoch": 0,
-        "version": "0.64.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-markupsafe",
-        "epoch": 0,
-        "version": "2.0.0",
-        "release": "2.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-markupsafe-2.0.0-2.fc35.aarch64.rpm",
-        "checksum": "sha256:375b89f3a452a62f3a02ada8971b14e854fa95b0d4cb9efb0449e5f85d6959c6",
-        "check_gpg": true
-      },
-      {
         "name": "python3-nftables",
         "epoch": 1,
         "version": "1.0.0",
@@ -10105,96 +10561,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-nftables-1.0.0-1.fc35.aarch64.rpm",
         "checksum": "sha256:31e3038cdc752f890970d60653b510eb815e56be7854ba627ef7843b4c760ec9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-oauthlib+signedtoken",
-        "epoch": 0,
-        "version": "3.0.2",
-        "release": "11.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch.rpm",
-        "checksum": "sha256:c74cbc93bb6c53d2a8379a796f448e9d2221479086ea0f8c87b90bd74b3d9d3d",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-oauthlib",
-        "epoch": 0,
-        "version": "3.0.2",
-        "release": "11.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-oauthlib-3.0.2-11.fc35.noarch.rpm",
-        "checksum": "sha256:85e61f4e95f1add6f77ba7a9c736ed481366cb9e8c9680da684246c05f173ec9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-ply",
-        "epoch": 0,
-        "version": "3.11",
-        "release": "13.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-ply-3.11-13.fc35.noarch.rpm",
-        "checksum": "sha256:338184ed6f1cc41a7ffc32f5c79bac3436472aba89bb8c2d22967145074b61af",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-prettytable",
-        "epoch": 0,
-        "version": "0.7.2",
-        "release": "27.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-prettytable-0.7.2-27.fc35.noarch.rpm",
-        "checksum": "sha256:f4d3a5ce87f5b0ce77a4df998828b845a8a7956f89964e1880df4eb01c973e71",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-pycparser",
-        "epoch": 0,
-        "version": "2.20",
-        "release": "5.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pycparser-2.20-5.fc35.noarch.rpm",
-        "checksum": "sha256:60d8a9d62157a6066a0a333116d168bae092d86d8db8938ea5b2eaed0f46dce3",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-pyserial",
-        "epoch": 0,
-        "version": "3.4",
-        "release": "12.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyserial-3.4-12.fc35.noarch.rpm",
-        "checksum": "sha256:8a98a57503f777f2c01cd1e7fc114a83d4ab4a8746ff0b991ad36a2f02349fa7",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-pysocks",
-        "epoch": 0,
-        "version": "1.7.1",
-        "release": "11.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pysocks-1.7.1-11.fc35.noarch.rpm",
-        "checksum": "sha256:c0ae7285887e937e60395874088dd56054295b81a186ebb838f6d4b81467bed6",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-pyyaml",
-        "epoch": 0,
-        "version": "5.4.1",
-        "release": "4.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-pyyaml-5.4.1-4.fc35.aarch64.rpm",
-        "checksum": "sha256:469ec3ace1ffa4e3153c772d5ec5a65f8cb6e98d07405134c6b06545796e31c2",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-rpm",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
         "check_gpg": true
       },
       {
@@ -10215,26 +10581,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-setuptools-57.4.0-1.fc35.noarch.rpm",
         "checksum": "sha256:6ef532ed239a81969b411c26394f31de7385a14431d334ca931e4dd559c52fb7",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-six",
-        "epoch": 0,
-        "version": "1.16.0",
-        "release": "4.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm",
-        "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-unbound",
-        "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
         "check_gpg": true
       },
       {
@@ -10268,16 +10614,6 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-build-libs",
-        "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
-        "check_gpg": true
-      },
-      {
         "name": "rpm-libs",
         "epoch": 0,
         "version": "4.17.0",
@@ -10298,23 +10634,33 @@
         "check_gpg": true
       },
       {
-        "name": "rpm-plugin-systemd-inhibit",
+        "name": "rsync",
         "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
+        "version": "3.2.3",
+        "release": "8.fc35",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rsync-3.2.3-8.fc35.aarch64.rpm",
+        "checksum": "sha256:ac16154e7ad3440e137a65b0d9bc96942f257651aaf1f41298f15329a216c2c6",
         "check_gpg": true
       },
       {
-        "name": "rpm-sign-libs",
+        "name": "rtl-sdr",
         "epoch": 0,
-        "version": "4.17.0",
-        "release": "1.fc35",
+        "version": "0.6.0",
+        "release": "10.fc35",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rtl-sdr-0.6.0-10.fc35.aarch64.rpm",
+        "checksum": "sha256:3b2989088d5a142d61120e445db12fe0eea145dbd21d6ffdae1483aa2c62a385",
+        "check_gpg": true
+      },
+      {
+        "name": "screen",
+        "epoch": 0,
+        "version": "4.8.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/screen-4.8.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:be32c0e88209b3e4c727c73bd7495523e2cb76f5d0b63f68a7e830bcb6b479d3",
         "check_gpg": true
       },
       {
@@ -10328,6 +10674,16 @@
         "check_gpg": true
       },
       {
+        "name": "setools-console",
+        "epoch": 0,
+        "version": "4.4.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setools-console-4.4.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:90c7b019374c9431f7b5419098362a6449dc8e6e4c6e0d87308bee6ec0aa4032",
+        "check_gpg": true
+      },
+      {
         "name": "setup",
         "epoch": 0,
         "version": "2.13.9.1",
@@ -10335,6 +10691,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
         "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/shared-mime-info-2.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:b4c8b4e130ddfec411a27fe72c8b55c8a9c4630b68dd10daa7e3729be3e545f4",
         "check_gpg": true
       },
       {
@@ -10348,13 +10714,13 @@
         "check_gpg": true
       },
       {
-        "name": "spice-vdagent",
+        "name": "slirp4netns",
         "epoch": 0,
-        "version": "0.21.0",
-        "release": "5.fc35",
+        "version": "1.1.12",
+        "release": "2.fc35",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/spice-vdagent-0.21.0-5.fc35.aarch64.rpm",
-        "checksum": "sha256:10190a125e7f12c0fb5c138b041c1c3625c43be574b1a42a845217cf2737cd88",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/slirp4netns-1.1.12-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7a78f9c1f9646ab9a4d3b76dbee078df943d520970445a4c0c075c29dc0aa99f",
         "check_gpg": true
       },
       {
@@ -10388,6 +10754,26 @@
         "check_gpg": true
       },
       {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tar-1.34-2.fc35.aarch64.rpm",
+        "checksum": "sha256:cd0292f293d1547a417cfd0cb4023a8fb23a46c0a5b56fe2fa9534ba12c5d4ae",
+        "check_gpg": true
+      },
+      {
+        "name": "tmux",
+        "epoch": 0,
+        "version": "3.2a",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tmux-3.2a-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f2bdf2e6ffceec804128ea284dad46caac869232d9997ba51b8d4bc7f2558b16",
+        "check_gpg": true
+      },
+      {
         "name": "tpm2-tss",
         "epoch": 0,
         "version": "3.1.0",
@@ -10395,6 +10781,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
         "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+        "check_gpg": true
+      },
+      {
+        "name": "traceroute",
+        "epoch": 3,
+        "version": "2.1.0",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/traceroute-2.1.0-14.fc35.aarch64.rpm",
+        "checksum": "sha256:97cba75d786761ac4a8dc22811c18403372671e4dc35ac326c83b91c10142296",
         "check_gpg": true
       },
       {
@@ -10418,13 +10814,23 @@
         "check_gpg": true
       },
       {
-        "name": "unbound-libs",
+        "name": "usbguard",
         "epoch": 0,
-        "version": "1.13.2",
-        "release": "1.fc35",
+        "version": "1.0.0",
+        "release": "6.fc35",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
-        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/usbguard-1.0.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:10202d4ab23cec2514530c824c118f566829b14c1784ade9db35079aacc7dabf",
+        "check_gpg": true
+      },
+      {
+        "name": "usbguard-selinux",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/usbguard-selinux-1.0.0-6.fc35.noarch.rpm",
+        "checksum": "sha256:9a5e4f31d85972d815ac080b9e39f741d1f4aeaf7e998fde7cef282a5527fffd",
         "check_gpg": true
       },
       {
@@ -10448,6 +10854,16 @@
         "check_gpg": true
       },
       {
+        "name": "volume_key-libs",
+        "epoch": 0,
+        "version": "0.3.12",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/v/volume_key-libs-0.3.12-14.fc35.aarch64.rpm",
+        "checksum": "sha256:1b7d568ae321ad117b5b48eb61dda25b02ba7762b8097f0abc87b461b4979998",
+        "check_gpg": true
+      },
+      {
         "name": "which",
         "epoch": 0,
         "version": "2.21",
@@ -10465,6 +10881,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
         "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "wireless-regdb",
+        "epoch": 0,
+        "version": "2021.07.14",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/wireless-regdb-2021.07.14-2.fc35.noarch.rpm",
+        "checksum": "sha256:66ffa480698ff5d048b1ffcfd5a78ecaaeb831831591c0457148b69b8d120d5d",
+        "check_gpg": true
+      },
+      {
+        "name": "wpa_supplicant",
+        "epoch": 1,
+        "version": "2.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/wpa_supplicant-2.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:e1d84083341116709a56a3aad727030a691d4e12b4d348eb75f7dc809d08ffe1",
         "check_gpg": true
       },
       {
@@ -10518,16 +10954,6 @@
         "check_gpg": true
       },
       {
-        "name": "yum",
-        "epoch": 0,
-        "version": "4.9.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
-        "check_gpg": true
-      },
-      {
         "name": "zchunk-libs",
         "epoch": 0,
         "version": "1.1.15",
@@ -10535,6 +10961,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
         "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+        "check_gpg": true
+      },
+      {
+        "name": "zezere-ignition",
+        "epoch": 0,
+        "version": "0.5",
+        "release": "9.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zezere-ignition-0.5-9.fc35.noarch.rpm",
+        "checksum": "sha256:190a2c0a742e9e3080107b4ea209bfa0adfd13f9892cbe99f4e203153724b93f",
         "check_gpg": true
       },
       {
@@ -10568,13 +11004,73 @@
         "check_gpg": true
       },
       {
-        "name": "alsa-lib",
-        "epoch": 0,
-        "version": "1.2.6.1",
-        "release": "3.fc35",
+        "name": "NetworkManager-wifi",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/a/alsa-lib-1.2.6.1-3.fc35.aarch64.rpm",
-        "checksum": "sha256:02f5457be9eac8a6ae4b19950895850da94f62a9c5e5f390a68a590092096c96",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-wifi-1.32.12-2.fc35.aarch64.rpm",
+        "checksum": "sha256:b4f37d46a28bebaf35b8f76f7680ff5530d09af6bd00cdd4d19db8181cc4cc23",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-wwan",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-wwan-1.32.12-2.fc35.aarch64.rpm",
+        "checksum": "sha256:13fb3e19cb7a637e64b94a049d756401c637c3871b99f51b0531db8602bf135f",
+        "check_gpg": true
+      },
+      {
+        "name": "arm-image-installer",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/a/arm-image-installer-3.5-1.fc35.noarch.rpm",
+        "checksum": "sha256:08809b3fc9e1a59314bba40beeccd2981f31f24b62baf276217b6e9eae193ad7",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.63",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/b/bluez-5.63-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8504180f7a9f66fe58c27bccca983655207037255c4471d797fa65c0b36912f7",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez-libs",
+        "epoch": 0,
+        "version": "5.63",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/b/bluez-libs-5.63-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ac087df3c8ed872cd579f257ec347a51923535add93ebc6190de7f9c482f3e00",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez-mesh",
+        "epoch": 0,
+        "version": "5.63",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/b/bluez-mesh-5.63-1.fc35.aarch64.rpm",
+        "checksum": "sha256:678a86552377e7ca081270778b0434fb8cfef3ecb0ecf4fca52f53afe0c66d9a",
+        "check_gpg": true
+      },
+      {
+        "name": "btrfs-progs",
+        "epoch": 0,
+        "version": "5.15.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/b/btrfs-progs-5.15.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ea062d3815a8b93462b1cf13d6e517d7d0ec69dfce33f55d66695504d0baf678",
         "check_gpg": true
       },
       {
@@ -10588,6 +11084,16 @@
         "check_gpg": true
       },
       {
+        "name": "catatonit",
+        "epoch": 0,
+        "version": "0.1.7",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/catatonit-0.1.7-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6318c5e457a2fa88c518f518866d9d8c3e6337fd0016debd04a58f72d9da6e6e",
+        "check_gpg": true
+      },
+      {
         "name": "checkpolicy",
         "epoch": 0,
         "version": "3.3",
@@ -10595,6 +11101,116 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/checkpolicy-3.3-1.fc35.aarch64.rpm",
         "checksum": "sha256:50d0b3571e271cce3c9f314f3fab80485b706c347cb6e9c710c28cf552c07ec5",
+        "check_gpg": true
+      },
+      {
+        "name": "clevis",
+        "epoch": 0,
+        "version": "18",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/clevis-18-4.fc35.aarch64.rpm",
+        "checksum": "sha256:c5027788836c69df20f78d0389ed9079e629453e18d69eff2e9efb826d0f937f",
+        "check_gpg": true
+      },
+      {
+        "name": "clevis-dracut",
+        "epoch": 0,
+        "version": "18",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/clevis-dracut-18-4.fc35.aarch64.rpm",
+        "checksum": "sha256:4e3887518cd02b033fc31d445ed18cb70cb0ab7568a2eb7e39eec43c5dcbe951",
+        "check_gpg": true
+      },
+      {
+        "name": "clevis-luks",
+        "epoch": 0,
+        "version": "18",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/clevis-luks-18-4.fc35.aarch64.rpm",
+        "checksum": "sha256:23d8e74f6ee55974f07a08ef7f881956029d52a03a6c3c4d93d2ba77d2b12739",
+        "check_gpg": true
+      },
+      {
+        "name": "clevis-pin-tpm2",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/clevis-pin-tpm2-0.5.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4f539ddd922dfc864123f8fd35ba364e19f9ccd9bbf6c9d480c65fef3f254782",
+        "check_gpg": true
+      },
+      {
+        "name": "clevis-systemd",
+        "epoch": 0,
+        "version": "18",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/clevis-systemd-18-4.fc35.aarch64.rpm",
+        "checksum": "sha256:d02201323b888e80d8559f8205d4e30eb068df4ac3bdf0699e52a543f687ef57",
+        "check_gpg": true
+      },
+      {
+        "name": "container-selinux",
+        "epoch": 2,
+        "version": "2.170.0",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/container-selinux-2.170.0-2.fc35.noarch.rpm",
+        "checksum": "sha256:a9847dcfcf017e55abce19fbbb3f9d7480ff433fc687d9a8a075d5be37da0fd6",
+        "check_gpg": true
+      },
+      {
+        "name": "containers-common",
+        "epoch": 4,
+        "version": "1",
+        "release": "32.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/containers-common-1-32.fc35.noarch.rpm",
+        "checksum": "sha256:8ceaa90de879f507b79e2b5319df475455b1df2db0652333f65551a61d72a193",
+        "check_gpg": true
+      },
+      {
+        "name": "criu",
+        "epoch": 0,
+        "version": "3.16.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/criu-3.16.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:38f2d755858d9d6e9ff7e30717a0974e4f731173943665cf1aba12213dd79732",
+        "check_gpg": true
+      },
+      {
+        "name": "criu-libs",
+        "epoch": 0,
+        "version": "3.16.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/criu-libs-3.16.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4b3dfb13a1aa92f00e3bf0ab38fc41c7fe98a519e3a1b5b32aae1ec3d8bec520",
+        "check_gpg": true
+      },
+      {
+        "name": "crun",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/crun-1.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:1679081e390beefe9b77ca83d0e9d5ce3731762b271582116b1b8f222bc3f84c",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-2.4.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30bd2714391cd78d2072d2ad5fc0d94adb1875b39159be8dfcf602ac36f31040",
         "check_gpg": true
       },
       {
@@ -10618,13 +11234,13 @@
         "check_gpg": true
       },
       {
-        "name": "dnf-plugins-core",
+        "name": "dnsmasq",
         "epoch": 0,
-        "version": "4.0.24",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
-        "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+        "version": "2.86",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dnsmasq-2.86-3.fc35.aarch64.rpm",
+        "checksum": "sha256:215c466fbf21d59ab899258513f6ce120a9a01ce09b544e6daa6fa23711a6434",
         "check_gpg": true
       },
       {
@@ -10645,6 +11261,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.aarch64.rpm",
         "checksum": "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-network",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-network-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:a8d1b6966d03bd23286c5a6f4192b921d89af5e9bb770756cf0442f22cc954b6",
         "check_gpg": true
       },
       {
@@ -10688,16 +11314,6 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release",
-        "epoch": 0,
-        "version": "35",
-        "release": "36",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
-        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
-        "check_gpg": true
-      },
-      {
         "name": "fedora-release-common",
         "epoch": 0,
         "version": "35",
@@ -10708,13 +11324,63 @@
         "check_gpg": true
       },
       {
-        "name": "fedora-release-identity-basic",
+        "name": "fedora-release-identity-iot",
         "epoch": 0,
         "version": "35",
         "release": "36",
         "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
-        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-iot-35-36.noarch.rpm",
+        "checksum": "sha256:641c5b454f3cefa3c9da1b9970486bb931852945398efd977e744684d1da781c",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-iot",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-iot-35-36.noarch.rpm",
+        "checksum": "sha256:a788fcf4b4145f95c9e1ef9d9119b5952eadd4596fcae90763319b079847af48",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fwupd-1.7.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e376e649c2be4f52e94b1d9e287668c78fa41eebba6d0cbc8f41ba4ea3a15e2e",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-flashrom",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fwupd-plugin-flashrom-1.7.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b8d733d55d2988b05b167b1b9d2542d35663c1529c00380ff1d940264fdd15ff",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-modem-manager",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fwupd-plugin-modem-manager-1.7.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:de15a0ecfb5316b527f2b599a5f536eb1f755ab0157cf1082c73db93a1059781",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-uefi-capsule-data",
+        "epoch": 0,
+        "version": "1.7.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fwupd-plugin-uefi-capsule-data-1.7.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4991a3c50f9f52859148b48cd2a251a4c14d7b9b510f6c2f27e7d849201dbfca",
         "check_gpg": true
       },
       {
@@ -10768,13 +11434,13 @@
         "check_gpg": true
       },
       {
-        "name": "glibc-langpack-en",
+        "name": "glibc-minimal-langpack",
         "epoch": 0,
         "version": "2.34",
         "release": "11.fc35",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-langpack-en-2.34-11.fc35.aarch64.rpm",
-        "checksum": "sha256:5437317aa8a5d94a9de9cd15d58399146783b4b96ee52a0a134c09b79933a8b0",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
         "check_gpg": true
       },
       {
@@ -10848,13 +11514,53 @@
         "check_gpg": true
       },
       {
-        "name": "hwdata",
+        "name": "ignition",
         "epoch": 0,
-        "version": "0.355",
+        "version": "2.13.0",
         "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/i/ignition-2.13.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:dbc885283d2a69517ffd1a601eda98a8e8d34bf4ea6e75d6f3dd28d574222e09",
+        "check_gpg": true
+      },
+      {
+        "name": "iwd",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/i/iwd-1.21-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2746f2c19fa38e489d55f0e0ee0c07bd6edbaf259dd84aee17381f3709cb58e2",
+        "check_gpg": true
+      },
+      {
+        "name": "iwl7260-firmware",
+        "epoch": 1,
+        "version": "25.30.13.0",
+        "release": "127.fc35",
         "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/h/hwdata-0.355-1.fc35.noarch.rpm",
-        "checksum": "sha256:5969e69eb5d24f65384e616513a940894f570a0423469dbcdead3d3b3d6c0b7f",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/i/iwl7260-firmware-25.30.13.0-127.fc35.noarch.rpm",
+        "checksum": "sha256:d7fe083650f0a0e0005ed0841a6a4c665b53104950388c87fedbae810d86df6f",
+        "check_gpg": true
+      },
+      {
+        "name": "iwlax2xx-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/i/iwlax2xx-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:8ff63ca096faa6ce047d3392e2ffc8cddec346ef03fbd0a395687f843a774e29",
+        "check_gpg": true
+      },
+      {
+        "name": "jitterentropy",
+        "epoch": 0,
+        "version": "3.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/j/jitterentropy-3.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6309f36857ff99d328e83a052186b819b92139c37da35160c91d1d5624a7ae1b",
         "check_gpg": true
       },
       {
@@ -10888,6 +11594,26 @@
         "check_gpg": true
       },
       {
+        "name": "kernel-tools",
+        "epoch": 0,
+        "version": "5.15.4",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-tools-5.15.4-200.fc35.aarch64.rpm",
+        "checksum": "sha256:4a3381116ae3fc1b08a6459eef839ee8e0e75d5bd83d00a24f132b34f7580d46",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-tools-libs",
+        "epoch": 0,
+        "version": "5.15.4",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-tools-libs-5.15.4-200.fc35.aarch64.rpm",
+        "checksum": "sha256:080dca65723955e080557603c34ac7f4961f438ec90f2a1183bad3d321ffd2c4",
+        "check_gpg": true
+      },
+      {
         "name": "less",
         "epoch": 0,
         "version": "590",
@@ -10895,26 +11621,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/less-590-2.fc35.aarch64.rpm",
         "checksum": "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97",
-        "check_gpg": true
-      },
-      {
-        "name": "libX11",
-        "epoch": 0,
-        "version": "1.7.3.1",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libX11-1.7.3.1-1.fc35.aarch64.rpm",
-        "checksum": "sha256:aca22d55edba0d7f60f4d6f8f5c064ce64df4561af9c44e592fa842d1b83110c",
-        "check_gpg": true
-      },
-      {
-        "name": "libX11-common",
-        "epoch": 0,
-        "version": "1.7.3.1",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libX11-common-1.7.3.1-1.fc35.noarch.rpm",
-        "checksum": "sha256:4c728458d61305c022946aa7199e2b462ac4449f04303def895923581b05d8c2",
         "check_gpg": true
       },
       {
@@ -10948,23 +11654,13 @@
         "check_gpg": true
       },
       {
-        "name": "libdrm",
+        "name": "libell",
         "epoch": 0,
-        "version": "2.4.109",
+        "version": "0.47",
         "release": "1.fc35",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libdrm-2.4.109-1.fc35.aarch64.rpm",
-        "checksum": "sha256:3f7252d59a6cafd37c6ce4851ba6ab13a0594e0a435bce4d8c392485888278a5",
-        "check_gpg": true
-      },
-      {
-        "name": "libfsverity",
-        "epoch": 0,
-        "version": "1.4",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
-        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libell-0.47-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9b5b0486a1d86998a6a446b951afb6246933644094cda1003e9cc620459d076f",
         "check_gpg": true
       },
       {
@@ -10998,6 +11694,16 @@
         "check_gpg": true
       },
       {
+        "name": "libgusb",
+        "epoch": 0,
+        "version": "0.3.9",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgusb-0.3.9-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ba48d9343b3223739a6744c723c68823307928b423375a18fe7c7c1cd2e5af82",
+        "check_gpg": true
+      },
+      {
         "name": "libibverbs",
         "epoch": 0,
         "version": "38.0",
@@ -11008,23 +11714,23 @@
         "check_gpg": true
       },
       {
-        "name": "libldb",
+        "name": "libjcat",
         "epoch": 0,
-        "version": "2.4.1",
+        "version": "0.1.9",
         "release": "1.fc35",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.aarch64.rpm",
-        "checksum": "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libjcat-0.1.9-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a784c4c3ccbae43e8693079ee023f0302837c7e79ef506053e6ab4c244547974",
         "check_gpg": true
       },
       {
-        "name": "libmaxminddb",
+        "name": "libqb",
         "epoch": 0,
-        "version": "1.6.0",
+        "version": "2.0.4",
         "release": "1.fc35",
         "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.aarch64.rpm",
-        "checksum": "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libqb-2.0.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b6440724382944ff5721c0c352ca59c714b1d0a1f76bbf2b810172c5923f39d3",
         "check_gpg": true
       },
       {
@@ -11078,26 +11784,6 @@
         "check_gpg": true
       },
       {
-        "name": "libsss_autofs",
-        "epoch": 0,
-        "version": "2.6.1",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.aarch64.rpm",
-        "checksum": "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1",
-        "check_gpg": true
-      },
-      {
-        "name": "libsss_certmap",
-        "epoch": 0,
-        "version": "2.6.1",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.aarch64.rpm",
-        "checksum": "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478",
-        "check_gpg": true
-      },
-      {
         "name": "libsss_idmap",
         "epoch": 0,
         "version": "2.6.1",
@@ -11138,6 +11824,16 @@
         "check_gpg": true
       },
       {
+        "name": "libudisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libudisks2-2.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5622830594978a3c99a778d66011211a058f95c80e421910bdd90118662d81e6",
+        "check_gpg": true
+      },
+      {
         "name": "libxcrypt",
         "epoch": 0,
         "version": "4.4.27",
@@ -11145,6 +11841,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm",
         "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libxmlb",
+        "epoch": 0,
+        "version": "0.3.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxmlb-0.3.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:586c904f0e704585041c3d71a83c891a124922e5348a02ec4834b8f1a17f3929",
         "check_gpg": true
       },
       {
@@ -11208,6 +11914,66 @@
         "check_gpg": true
       },
       {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.32.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/nspr-4.32.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:308fcc73237de6563a5343fd3b45fd29abb41338fc7517ca7818f74bf2e315b8",
+        "check_gpg": true
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.73.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/nss-3.73.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c537a18bde094f4a4202260cb2ecfb0893fab60adb06387462f6c8b36dc96d4c",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.73.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/nss-softokn-3.73.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8b5e4fd8efef5bfea6f8df721d56001e8139810222d7db6e16a94e05fb2fe67b",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.73.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/nss-softokn-freebl-3.73.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:53beb80220710bbd61de26573ca7d8fee1ec4cf914f5d9f84ad9e7f231f22bfc",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.73.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/nss-sysinit-3.73.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b653df1724c6a811905cd8d28eaac3dfaa088e84334e9e8306355bb6f1bfb1f6",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.73.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/nss-util-3.73.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:66105bec59eecac3dc1b3a08f8530271014df12c5b69cc1a699fb1959bd63058",
+        "check_gpg": true
+      },
+      {
         "name": "openssh",
         "epoch": 0,
         "version": "8.7p1",
@@ -11235,6 +12001,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.aarch64.rpm",
         "checksum": "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2022.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/ostree-2022.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e764f772148419feb7602ed81a6aa9ced35997931bd62d6699118957c5db86a",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2022.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/ostree-libs-2022.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d600334211805f9f0bcf64a6bc1a2ab4824fd7976e186f79fec9b92392d394f4",
         "check_gpg": true
       },
       {
@@ -11268,6 +12054,36 @@
         "check_gpg": true
       },
       {
+        "name": "podman",
+        "epoch": 3,
+        "version": "3.4.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/podman-3.4.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c23a8cdd67d918268714ace5939872365ff62039b4da08a8c6b57883052dac9d",
+        "check_gpg": true
+      },
+      {
+        "name": "podman-gvproxy",
+        "epoch": 3,
+        "version": "3.4.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/podman-gvproxy-3.4.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:87434169fd88f118042741c2a73188dbfbb4ed4f36d8cd4d78f7f1a580787447",
+        "check_gpg": true
+      },
+      {
+        "name": "podman-plugins",
+        "epoch": 3,
+        "version": "3.4.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/podman-plugins-3.4.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:db78601913c72afca547d7cc8308c618c948d050a9e3b9b62fa4528d951024ce",
+        "check_gpg": true
+      },
+      {
         "name": "policycoreutils",
         "epoch": 0,
         "version": "3.3",
@@ -11275,6 +12091,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
         "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils-python-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-python-utils-3.3-1.fc35.noarch.rpm",
+        "checksum": "sha256:cd39f952196a0241d1c3e9bea61cd86f4a6c3a8b9ba25b6b384860e22bd5a0f6",
         "check_gpg": true
       },
       {
@@ -11328,36 +12154,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-dnf-plugins-core",
-        "epoch": 0,
-        "version": "4.0.24",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
-        "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-gpg",
-        "epoch": 0,
-        "version": "1.15.1",
-        "release": "6.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
-        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-jsonpatch",
-        "epoch": 0,
-        "version": "1.21",
-        "release": "18.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-jsonpatch-1.21-18.fc35.noarch.rpm",
-        "checksum": "sha256:08956925cf2e579c63c9d551129fdbc819b908ce79f344b3fc42cb067503daa9",
-        "check_gpg": true
-      },
-      {
         "name": "python3-libs",
         "epoch": 0,
         "version": "3.10.1",
@@ -11398,56 +12194,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-pyrsistent",
-        "epoch": 0,
-        "version": "0.18.0",
-        "release": "8.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pyrsistent-0.18.0-8.fc35.aarch64.rpm",
-        "checksum": "sha256:fc05e6abb02bcb99462711686ddfc47783c0a5575bdb451a7fce641a3b809e8e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-pytz",
-        "epoch": 0,
-        "version": "2021.3",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-pytz-2021.3-1.fc35.noarch.rpm",
-        "checksum": "sha256:a700560fd265ab243b28cd90d4aa214bbd8237982430eb59a59be88d916e91a5",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-requests",
-        "epoch": 0,
-        "version": "2.27.0",
-        "release": "1.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-requests-2.27.0-1.fc35.noarch.rpm",
-        "checksum": "sha256:317c1448d68db44483845424597f6109c702da3492288402c0992d84d2da366e",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-urllib3",
-        "epoch": 0,
-        "version": "1.26.7",
-        "release": "2.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-urllib3-1.26.7-2.fc35.noarch.rpm",
-        "checksum": "sha256:2d41f3e6dd54005bc34f7088c639d16fdf73c12f6ab8c29974a25f5ec86e662f",
-        "check_gpg": true
-      },
-      {
-        "name": "qemu-guest-agent",
-        "epoch": 2,
-        "version": "6.1.0",
-        "release": "10.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qemu-guest-agent-6.1.0-10.fc35.aarch64.rpm",
-        "checksum": "sha256:137e82364adba68a95cf5af5369af68318afe9fea740c5deb6cd40f71727db34",
-        "check_gpg": true
-      },
-      {
         "name": "qrencode-libs",
         "epoch": 0,
         "version": "4.1.1",
@@ -11455,6 +12201,36 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm",
         "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+        "check_gpg": true
+      },
+      {
+        "name": "rng-tools",
+        "epoch": 0,
+        "version": "6.14",
+        "release": "2.git.b2b7934e.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/r/rng-tools-6.14-2.git.b2b7934e.fc35.aarch64.rpm",
+        "checksum": "sha256:fc4197a7f551c4d9580524cd5dc294bbd6fe52d45f479d1e92bab8f28ea3564b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2022.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/r/rpm-ostree-2022.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:796b15e590c5d726d63a3ca5bd7076b77a7d00bf844a6ed4b34d4de01cb0b089",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2022.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/r/rpm-ostree-libs-2022.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:95d047e12ecfe478b7f2a53803a528c3876c81cfdc36dc13f4f9345249e158fb",
         "check_gpg": true
       },
       {
@@ -11488,6 +12264,26 @@
         "check_gpg": true
       },
       {
+        "name": "shadow-utils-subid",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-subid-4.9-8.fc35.aarch64.rpm",
+        "checksum": "sha256:28024f873b855efd75f0a1cbd9149409a4fc553276c95811d136ff844aaaedd3",
+        "check_gpg": true
+      },
+      {
+        "name": "skopeo",
+        "epoch": 1,
+        "version": "1.5.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/skopeo-1.5.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:35eafd70242202d8a16226e1d792e940546d8c6f42d9211e0d286e7fe4d4abae",
+        "check_gpg": true
+      },
+      {
         "name": "sssd-client",
         "epoch": 0,
         "version": "2.6.1",
@@ -11495,36 +12291,6 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.aarch64.rpm",
         "checksum": "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95",
-        "check_gpg": true
-      },
-      {
-        "name": "sssd-common",
-        "epoch": 0,
-        "version": "2.6.1",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.aarch64.rpm",
-        "checksum": "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac",
-        "check_gpg": true
-      },
-      {
-        "name": "sssd-kcm",
-        "epoch": 0,
-        "version": "2.6.1",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.aarch64.rpm",
-        "checksum": "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d",
-        "check_gpg": true
-      },
-      {
-        "name": "sssd-nfs-idmap",
-        "epoch": 0,
-        "version": "2.6.1",
-        "release": "1.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.aarch64.rpm",
-        "checksum": "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad",
         "check_gpg": true
       },
       {
@@ -11558,16 +12324,6 @@
         "check_gpg": true
       },
       {
-        "name": "systemd-oomd-defaults",
-        "epoch": 0,
-        "version": "249.7",
-        "release": "2.fc35",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm",
-        "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
-        "check_gpg": true
-      },
-      {
         "name": "systemd-pam",
         "epoch": 0,
         "version": "249.7",
@@ -11598,6 +12354,26 @@
         "check_gpg": true
       },
       {
+        "name": "tpm2-pkcs11",
+        "epoch": 0,
+        "version": "1.7.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tpm2-pkcs11-1.7.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:69048b9660fd703a15817beb7248fbd14ee00c0b5e2e3d1c65a4ad9a994a5183",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tpm2-tools-5.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:67aac59b48fb8b8ce219306fff459a09a1b7e5dcb3ae24cf7ce48a6d9ef13ff8",
+        "check_gpg": true
+      },
+      {
         "name": "tzdata",
         "epoch": 0,
         "version": "2021e",
@@ -11605,6 +12381,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
         "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      },
+      {
+        "name": "uboot-images-armv8",
+        "epoch": 0,
+        "version": "2021.10",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/u/uboot-images-armv8-2021.10-3.fc35.noarch.rpm",
+        "checksum": "sha256:43adc18fc7e50377ea155a9679c7a7985ded3dfe4692019ca54ef1d65c702e43",
+        "check_gpg": true
+      },
+      {
+        "name": "udisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/u/udisks2-2.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f05c62d78957eb1ecabf42d5f95303b9381453e9754f01edf094674626260765",
         "check_gpg": true
       },
       {
@@ -11626,47 +12422,11 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.aarch64.rpm",
         "checksum": "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f",
         "check_gpg": true
-      },
-      {
-        "name": "xen-libs",
-        "epoch": 0,
-        "version": "4.15.1",
-        "release": "4.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/x/xen-libs-4.15.1-4.fc35.aarch64.rpm",
-        "checksum": "sha256:fdb23c2568785740578c8c2aef40f717f37cac51f71a8e2fc27c0ffd83bc7884",
-        "check_gpg": true
-      },
-      {
-        "name": "xen-licenses",
-        "epoch": 0,
-        "version": "4.15.1",
-        "release": "4.fc35",
-        "arch": "aarch64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/x/xen-licenses-4.15.1-4.fc35.aarch64.rpm",
-        "checksum": "sha256:cd38bc0d85c3664d68bc57e006a9b0d31abec2a71a56e0a5a11a81a673f90a2a",
-        "check_gpg": true
       }
     ]
   },
   "image-info": {
     "/etc/resolv.conf": [],
-    "boot-environment": {
-      "kernelopts": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac"
-    },
-    "bootloader": "unknown",
-    "bootmenu": [
-      {
-        "grub_arg": "--unrestricted",
-        "grub_class": "fedora",
-        "grub_users": "$grub_users",
-        "initrd": "/boot/initramfs-5.15.13-200.fc35.aarch64.img",
-        "linux": "/boot/vmlinuz-5.15.13-200.fc35.aarch64",
-        "options": "root=UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac ro no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8",
-        "title": "Fedora Linux (5.15.13-200.fc35.aarch64) 35 (Thirty Five)",
-        "version": "5.15.13-200.fc35.aarch64"
-      }
-    ],
     "chrony": {
       "leapsectz": [
         "right/UTC"
@@ -11675,127 +12435,7 @@
         "2.fedora.pool.ntp.org iburst"
       ]
     },
-    "cloud-init": {
-      "/etc/cloud": {
-        "cloud.cfg": {
-          "cloud_config_modules": [
-            "ssh-import-id",
-            "locale",
-            "set-passwords",
-            "spacewalk",
-            "yum-add-repo",
-            "ntp",
-            "timezone",
-            "disable-ec2-metadata",
-            "runcmd"
-          ],
-          "cloud_final_modules": [
-            "package-update-upgrade-install",
-            "puppet",
-            "chef",
-            "mcollective",
-            "salt-minion",
-            "reset_rmc",
-            "refresh_rmc_and_interface",
-            "rightscale_userdata",
-            "scripts-vendor",
-            "scripts-per-once",
-            "scripts-per-boot",
-            "scripts-per-instance",
-            "scripts-user",
-            "ssh-authkey-fingerprints",
-            "keys-to-console",
-            "phone-home",
-            "final-message",
-            "power-state-change"
-          ],
-          "cloud_init_modules": [
-            "migrator",
-            "seed_random",
-            "bootcmd",
-            "write-files",
-            "growpart",
-            "resizefs",
-            "disk_setup",
-            "mounts",
-            "set_hostname",
-            "update_hostname",
-            "update_etc_hosts",
-            "ca-certs",
-            "rsyslog",
-            "users-groups",
-            "ssh"
-          ],
-          "disable_root": true,
-          "mount_default_fields": [
-            null,
-            null,
-            "auto",
-            "defaults,nofail",
-            "0",
-            "2"
-          ],
-          "preserve_hostname": false,
-          "resize_rootfs_tmp": "/dev",
-          "ssh_pwauth": 0,
-          "system_info": {
-            "default_user": {
-              "gecos": "fedora Cloud User",
-              "groups": [
-                "wheel",
-                "adm",
-                "systemd-journal"
-              ],
-              "lock_passwd": true,
-              "name": "fedora",
-              "shell": "/bin/bash",
-              "sudo": [
-                "ALL=(ALL) NOPASSWD:ALL"
-              ]
-            },
-            "distro": "fedora",
-            "paths": {
-              "cloud_dir": "/var/lib/cloud/",
-              "templates_dir": "/etc/cloud/templates/"
-            },
-            "ssh_svcname": "sshd"
-          },
-          "users": [
-            "default"
-          ]
-        }
-      },
-      "/etc/cloud/cloud.cfg.d": {
-        "05_logging.cfg": {
-          "_log": [
-            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
-            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
-            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
-          ],
-          "log_cfgs": [
-            [
-              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
-              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
-            ]
-          ],
-          "output": {
-            "all": "| tee -a /var/log/cloud-init-output.log"
-          }
-        }
-      }
-    },
     "default-target": "graphical.target",
-    "dnf": {
-      "dnf.conf": {
-        "main": {
-          "best": "False",
-          "clean_requirements_on_remove": "True",
-          "gpgcheck": "1",
-          "installonly_limit": "3",
-          "skip_if_unavailable": "True"
-        }
-      }
-    },
     "dracut": {
       "/usr/lib/dracut/dracut.conf.d": {
         "01-dist.conf": {
@@ -11842,6 +12482,9 @@
         },
         "02-generic-image.conf": {
           "hostonly": "no"
+        },
+        "50-nss-softokn.conf": {
+          "add_dracutmodules": " nss-softokn "
         }
       }
     },
@@ -11850,34 +12493,22 @@
       "mdns",
       "dhcpv6-client"
     ],
-    "fstab": [
-      [
-        "UUID=46BB-8120",
-        "/boot/efi",
-        "vfat",
-        "umask=0077,shortname=winnt",
-        "0",
-        "2"
-      ],
-      [
-        "UUID=76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-        "/",
-        "ext4",
-        "defaults",
-        "1",
-        "1"
-      ]
-    ],
     "groups": [
+      "root:x:0:",
+      "wheel:x:10:"
+    ],
+    "groups-system": [
       "adm:x:4:",
       "audio:x:63:",
       "bin:x:1:",
       "cdrom:x:11:",
-      "chrony:x:993:",
+      "chrony:x:989:",
+      "clevis:x:991:",
       "daemon:x:2:",
       "dbus:x:81:",
       "dialout:x:18:",
       "disk:x:6:",
+      "dnsmasq:x:994:",
       "floppy:x:19:",
       "ftp:x:50:",
       "games:x:20:",
@@ -11890,10 +12521,12 @@
       "man:x:15:",
       "mem:x:8:",
       "nobody:x:65534:",
-      "polkitd:x:994:",
-      "redhat:x:1000:",
+      "parsec-clients:x:992:parsec",
+      "parsec:x:993:",
+      "polkitd:x:990:",
       "render:x:105:",
-      "root:x:0:",
+      "rtlsdr:x:995:",
+      "screen:x:84:",
       "sgx:x:106:",
       "ssh_keys:x:996:",
       "sshd:x:74:",
@@ -11905,9 +12538,8 @@
       "systemd-resolve:x:193:",
       "systemd-timesync:x:998:",
       "tape:x:33:",
-      "tss:x:59:",
+      "tss:x:59:clevis",
       "tty:x:5:",
-      "unbound:x:995:",
       "users:x:100:",
       "utempter:x:35:",
       "utmp:x:22:",
@@ -11919,23 +12551,10 @@
       "127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4",
       "::1         localhost localhost.localdomain localhost6 localhost6.localdomain6"
     ],
-    "image-format": {
-      "compat": "1.1",
-      "type": "qcow2"
-    },
     "locale": {
       "LANG": "en_US"
     },
     "machine-id": "",
-    "modprobe": {
-      "/usr/lib/modprobe.d": {
-        "dist-blacklist.conf": {
-          "blacklist": [
-            "chsc_sch"
-          ]
-        }
-      }
-    },
     "os-release": {
       "ANSI_COLOR": "0;38;2;60;110;180",
       "BUG_REPORT_URL": "https://bugzilla.redhat.com/",
@@ -11946,41 +12565,78 @@
       "LOGO": "fedora-logo-icon",
       "NAME": "Fedora Linux",
       "PLATFORM_ID": "platform:f35",
-      "PRETTY_NAME": "Fedora Linux 35 (Thirty Five)",
+      "PRETTY_NAME": "Fedora Linux 35 (IoT Edition)",
       "PRIVACY_POLICY_URL": "https://fedoraproject.org/wiki/Legal:PrivacyPolicy",
       "REDHAT_BUGZILLA_PRODUCT": "Fedora",
       "REDHAT_BUGZILLA_PRODUCT_VERSION": "35",
       "REDHAT_SUPPORT_PRODUCT": "Fedora",
       "REDHAT_SUPPORT_PRODUCT_VERSION": "35",
       "SUPPORT_URL": "https://ask.fedoraproject.org/",
-      "VERSION": "35 (Thirty Five)",
+      "VARIANT": "IoT Edition",
+      "VARIANT_ID": "iot",
+      "VERSION": "35 (IoT Edition)",
       "VERSION_CODENAME": "",
       "VERSION_ID": "35"
     },
+    "ostree": {
+      "refs": [
+        "fedora/35/aarch64/iot"
+      ],
+      "repo": {
+        "core.mode": "archive-z2"
+      }
+    },
     "packages": [
+      "ModemManager-1.18.2-1.fc35.aarch64",
+      "ModemManager-glib-1.18.2-1.fc35.aarch64",
       "NetworkManager-1.32.12-2.fc35.aarch64",
       "NetworkManager-libnm-1.32.12-2.fc35.aarch64",
+      "NetworkManager-wifi-1.32.12-2.fc35.aarch64",
+      "NetworkManager-wwan-1.32.12-2.fc35.aarch64",
       "acl-2.3.1-2.fc35.aarch64",
-      "alsa-lib-1.2.6.1-3.fc35.aarch64",
       "alternatives-1.19-1.fc35.aarch64",
+      "arm-image-installer-3.5-1.fc35.noarch",
+      "attr-2.5.1-3.fc35.aarch64",
       "audit-3.0.6-1.fc35.aarch64",
       "audit-libs-3.0.6-1.fc35.aarch64",
       "basesystem-11-12.fc35.noarch",
       "bash-5.1.8-2.fc35.aarch64",
+      "bash-completion-2.11-3.fc35.noarch",
+      "bcm2711-firmware-20210930-1.b5257da.fc35.aarch64",
+      "bcm2835-firmware-20210930-1.b5257da.fc35.aarch64",
+      "bcm283x-firmware-20210930-1.b5257da.fc35.aarch64",
+      "bcm283x-overlays-20210930-1.b5257da.fc35.aarch64",
+      "bluez-5.63-1.fc35.aarch64",
+      "bluez-libs-5.63-1.fc35.aarch64",
+      "bluez-mesh-5.63-1.fc35.aarch64",
+      "btrfs-progs-5.15.1-1.fc35.aarch64",
+      "bubblewrap-0.5.0-1.fc35.aarch64",
       "bzip2-libs-1.0.8-9.fc35.aarch64",
-      "c-ares-1.17.2-1.fc35.aarch64",
       "ca-certificates-2021.2.52-1.0.fc35.noarch",
+      "catatonit-0.1.7-1.fc35.aarch64",
       "checkpolicy-3.3-1.fc35.aarch64",
       "chkconfig-1.19-1.fc35.aarch64",
       "chrony-4.1-3.fc35.aarch64",
-      "cloud-init-20.4-7.fc35.noarch",
+      "clevis-18-4.fc35.aarch64",
+      "clevis-dracut-18-4.fc35.aarch64",
+      "clevis-luks-18-4.fc35.aarch64",
+      "clevis-pin-tpm2-0.5.0-1.fc35.aarch64",
+      "clevis-systemd-18-4.fc35.aarch64",
+      "conmon-2.0.30-2.fc35.aarch64",
+      "container-selinux-2.170.0-2.fc35.noarch",
+      "containernetworking-plugins-1.0.1-1.fc35.aarch64",
+      "containers-common-1-32.fc35.noarch",
       "coreutils-8.32-31.fc35.aarch64",
       "coreutils-common-8.32-31.fc35.aarch64",
       "cpio-2.13-11.fc35.aarch64",
       "cracklib-2.9.6-27.fc35.aarch64",
       "cracklib-dicts-2.9.6-27.fc35.aarch64",
+      "criu-3.16.1-2.fc35.aarch64",
+      "criu-libs-3.16.1-2.fc35.aarch64",
+      "crun-1.4-1.fc35.aarch64",
       "crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch",
       "crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch",
+      "cryptsetup-2.4.2-1.fc35.aarch64",
       "cryptsetup-libs-2.4.2-1.fc35.aarch64",
       "curl-7.79.1-1.fc35.aarch64",
       "cyrus-sasl-lib-2.1.27-13.fc35.aarch64",
@@ -11988,18 +12644,19 @@
       "dbus-broker-29-4.fc35.aarch64",
       "dbus-common-1.12.20-5.fc35.noarch",
       "dbus-libs-1.12.20-5.fc35.aarch64",
-      "dejavu-sans-fonts-2.37-17.fc35.noarch",
-      "deltarpm-3.6.2-10.fc35.aarch64",
+      "dbus-parsec-0.3.1-4.fc35.aarch64",
       "device-mapper-1.02.175-6.fc35.aarch64",
+      "device-mapper-event-1.02.175-6.fc35.aarch64",
+      "device-mapper-event-libs-1.02.175-6.fc35.aarch64",
       "device-mapper-libs-1.02.175-6.fc35.aarch64",
-      "dhcp-client-4.4.2-16.b1.fc35.aarch64",
-      "dhcp-common-4.4.2-16.b1.fc35.noarch",
+      "device-mapper-persistent-data-0.9.0-6.fc35.aarch64",
       "diffutils-3.8-1.fc35.aarch64",
-      "dnf-4.9.0-1.fc35.noarch",
-      "dnf-data-4.9.0-1.fc35.noarch",
-      "dnf-plugins-core-4.0.24-1.fc35.noarch",
+      "dmidecode-3.3-2.fc35.aarch64",
+      "dnsmasq-2.86-3.fc35.aarch64",
+      "dosfstools-4.2-2.fc35.aarch64",
       "dracut-055-6.fc35.aarch64",
       "dracut-config-generic-055-6.fc35.aarch64",
+      "dracut-network-055-6.fc35.aarch64",
       "e2fsprogs-1.46.3-1.fc35.aarch64",
       "e2fsprogs-libs-1.46.3-1.fc35.aarch64",
       "efi-filesystem-5-4.fc35.noarch",
@@ -12011,29 +12668,39 @@
       "elfutils-libs-0.186-1.fc35.aarch64",
       "expat-2.4.1-2.fc35.aarch64",
       "fedora-gpg-keys-35-1.noarch",
-      "fedora-release-35-36.noarch",
       "fedora-release-common-35-36.noarch",
-      "fedora-release-identity-basic-35-36.noarch",
+      "fedora-release-identity-iot-35-36.noarch",
+      "fedora-release-iot-35-36.noarch",
       "fedora-repos-35-1.noarch",
-      "fedora-repos-modular-35-1.noarch",
       "file-5.40-9.fc35.aarch64",
       "file-libs-5.40-9.fc35.aarch64",
       "filesystem-3.14-7.fc35.aarch64",
       "findutils-4.8.0-4.fc35.aarch64",
       "firewalld-1.0.1-2.fc35.noarch",
       "firewalld-filesystem-1.0.1-2.fc35.noarch",
-      "fonts-filesystem-2.0.5-6.fc35.noarch",
+      "flashrom-1.2-7.fc35.aarch64",
+      "fuse-2.9.9-13.fc35.aarch64",
+      "fuse-common-3.10.5-1.fc35.aarch64",
       "fuse-libs-2.9.9-13.fc35.aarch64",
+      "fuse-overlayfs-1.7.1-2.fc35.aarch64",
+      "fuse3-3.10.5-1.fc35.aarch64",
+      "fuse3-libs-3.10.5-1.fc35.aarch64",
+      "fwupd-1.7.3-1.fc35.aarch64",
+      "fwupd-efi-1.1-1.fc35.aarch64",
+      "fwupd-plugin-flashrom-1.7.3-1.fc35.aarch64",
+      "fwupd-plugin-modem-manager-1.7.3-1.fc35.aarch64",
+      "fwupd-plugin-uefi-capsule-data-1.7.3-1.fc35.aarch64",
       "gawk-5.1.0-4.fc35.aarch64",
       "gawk-all-langpacks-5.1.0-4.fc35.aarch64",
       "gdbm-libs-1.22-1.fc35.aarch64",
+      "gdisk-1.0.8-2.fc35.aarch64",
       "gettext-0.21-8.fc35.aarch64",
       "gettext-libs-0.21-8.fc35.aarch64",
       "glib2-2.70.2-1.fc35.aarch64",
       "glibc-2.34-11.fc35.aarch64",
       "glibc-common-2.34-11.fc35.aarch64",
       "glibc-gconv-extra-2.34-11.fc35.aarch64",
-      "glibc-langpack-en-2.34-11.fc35.aarch64",
+      "glibc-minimal-langpack-2.34-11.fc35.aarch64",
       "gmp-6.2.0-7.fc35.aarch64",
       "gnupg2-2.3.4-1.fc35.aarch64",
       "gnupg2-smime-2.3.4-1.fc35.aarch64",
@@ -12041,8 +12708,12 @@
       "gobject-introspection-1.70.0-1.fc35.aarch64",
       "gpg-pubkey-9867c58f-601c49ca",
       "gpgme-1.15.1-6.fc35.aarch64",
+      "greenboot-0.12.0-1.fc35.aarch64",
+      "greenboot-grub2-0.12.0-1.fc35.aarch64",
+      "greenboot-reboot-0.12.0-1.fc35.aarch64",
+      "greenboot-rpm-ostree-grub2-0.12.0-1.fc35.aarch64",
+      "greenboot-status-0.12.0-1.fc35.aarch64",
       "grep-3.6-4.fc35.aarch64",
-      "groff-base-1.22.4-8.fc35.aarch64",
       "grub2-common-2.06-10.fc35.noarch",
       "grub2-efi-aa64-2.06-10.fc35.aarch64",
       "grub2-tools-2.06-10.fc35.aarch64",
@@ -12050,17 +12721,11 @@
       "grubby-8.40-55.fc35.aarch64",
       "gzip-1.10-5.fc35.aarch64",
       "hostname-3.23-5.fc35.aarch64",
-      "hunspell-1.7.0-11.fc35.aarch64",
-      "hunspell-en-0.20140811.1-20.fc35.noarch",
-      "hunspell-en-GB-0.20140811.1-20.fc35.noarch",
-      "hunspell-en-US-0.20140811.1-20.fc35.noarch",
-      "hunspell-filesystem-1.7.0-11.fc35.aarch64",
-      "hwdata-0.355-1.fc35.noarch",
+      "ignition-2.13.0-1.fc35.aarch64",
       "ima-evm-utils-1.3.2-3.fc35.aarch64",
       "inih-49-4.fc35.aarch64",
       "initscripts-10.11-1.fc35.aarch64",
       "initscripts-service-10.11-1.fc35.noarch",
-      "ipcalc-1.0.1-2.fc35.aarch64",
       "iproute-5.13.0-2.fc35.aarch64",
       "iproute-tc-5.13.0-2.fc35.aarch64",
       "ipset-7.15-1.fc35.aarch64",
@@ -12069,88 +12734,102 @@
       "iptables-libs-1.8.7-13.fc35.aarch64",
       "iptables-nft-1.8.7-13.fc35.aarch64",
       "iputils-20210722-1.fc35.aarch64",
+      "iw-5.9-3.fc35.aarch64",
+      "iwd-1.21-1.fc35.aarch64",
+      "iwl7260-firmware-25.30.13.0-127.fc35.noarch",
+      "iwlax2xx-firmware-20211216-127.fc35.noarch",
       "jansson-2.13.1-3.fc35.aarch64",
+      "jitterentropy-3.3.1-1.fc35.aarch64",
+      "jose-11-3.fc35.aarch64",
+      "jq-1.6-10.fc35.aarch64",
       "json-c-0.15-2.fc35.aarch64",
+      "json-glib-1.6.6-1.fc35.aarch64",
       "kbd-2.4.0-8.fc35.aarch64",
       "kbd-misc-2.4.0-8.fc35.noarch",
       "kernel-5.15.13-200.fc35.aarch64",
       "kernel-core-5.15.13-200.fc35.aarch64",
       "kernel-modules-5.15.13-200.fc35.aarch64",
+      "kernel-tools-5.15.4-200.fc35.aarch64",
+      "kernel-tools-libs-5.15.4-200.fc35.aarch64",
+      "keyutils-1.6.1-3.fc35.aarch64",
       "keyutils-libs-1.6.1-3.fc35.aarch64",
       "kmod-29-4.fc35.aarch64",
       "kmod-libs-29-4.fc35.aarch64",
       "kpartx-0.8.6-5.fc35.aarch64",
       "krb5-libs-1.19.2-2.fc35.aarch64",
-      "langpacks-core-en-3.0-15.fc35.noarch",
-      "langpacks-core-font-en-3.0-15.fc35.noarch",
-      "langpacks-en-3.0-15.fc35.noarch",
       "less-590-2.fc35.aarch64",
-      "libX11-1.7.3.1-1.fc35.aarch64",
-      "libX11-common-1.7.3.1-1.fc35.noarch",
-      "libXau-1.0.9-7.fc35.aarch64",
-      "libXext-1.3.4-7.fc35.aarch64",
-      "libXfixes-6.0.0-2.fc35.aarch64",
-      "libXinerama-1.1.4-9.fc35.aarch64",
-      "libXrandr-1.5.2-7.fc35.aarch64",
-      "libXrender-0.9.10-15.fc35.aarch64",
       "libacl-2.3.1-2.fc35.aarch64",
+      "libaio-0.3.111-12.fc35.aarch64",
       "libarchive-3.5.2-2.fc35.aarch64",
       "libargon2-20171227-7.fc35.aarch64",
       "libassuan-2.5.5-3.fc35.aarch64",
+      "libatasmart-0.19-21.fc35.aarch64",
       "libattr-2.5.1-3.fc35.aarch64",
-      "libbasicobjects-0.1.1-48.fc35.aarch64",
       "libblkid-2.37.2-1.fc35.aarch64",
+      "libblockdev-2.26-1.fc35.aarch64",
+      "libblockdev-crypto-2.26-1.fc35.aarch64",
+      "libblockdev-fs-2.26-1.fc35.aarch64",
+      "libblockdev-loop-2.26-1.fc35.aarch64",
+      "libblockdev-mdraid-2.26-1.fc35.aarch64",
+      "libblockdev-part-2.26-1.fc35.aarch64",
+      "libblockdev-swap-2.26-1.fc35.aarch64",
+      "libblockdev-utils-2.26-1.fc35.aarch64",
       "libbrotli-1.0.9-6.fc35.aarch64",
+      "libbsd-0.10.0-8.fc35.aarch64",
+      "libbytesize-2.6-2.fc35.aarch64",
       "libcap-2.48-3.fc35.aarch64",
       "libcap-ng-0.8.2-8.fc35.aarch64",
       "libcap-ng-python3-0.8.2-8.fc35.aarch64",
       "libcbor-0.7.0-4.fc35.aarch64",
-      "libcollection-0.7.0-48.fc35.aarch64",
       "libcom_err-1.46.3-1.fc35.aarch64",
-      "libcomps-0.1.18-1.fc35.aarch64",
       "libcurl-7.79.1-1.fc35.aarch64",
       "libdb-5.3.28-50.fc35.aarch64",
-      "libdhash-0.5.0-48.fc35.aarch64",
-      "libdnf-0.64.0-1.fc35.aarch64",
-      "libdrm-2.4.109-1.fc35.aarch64",
       "libeconf-0.4.0-2.fc35.aarch64",
       "libedit-3.1-40.20210910cvs.fc35.aarch64",
+      "libell-0.47-1.fc35.aarch64",
       "libevent-2.1.12-4.fc35.aarch64",
       "libfdisk-2.37.2-1.fc35.aarch64",
-      "libfdt-1.6.1-2.fc35.aarch64",
       "libffi-3.1-29.fc35.aarch64",
       "libfido2-1.8.0-1.fc35.aarch64",
-      "libfsverity-1.4-6.fc35.aarch64",
+      "libftdi-1.5-2.fc35.aarch64",
+      "libgcab1-1.4-5.fc35.aarch64",
       "libgcc-11.2.1-7.fc35.aarch64",
       "libgcrypt-1.9.4-1.fc35.aarch64",
       "libgomp-11.2.1-7.fc35.aarch64",
       "libgpg-error-1.43-1.fc35.aarch64",
+      "libgpiod-1.6.3-3.fc35.aarch64",
+      "libgpiod-utils-1.6.3-3.fc35.aarch64",
+      "libgudev-237-1.fc35.aarch64",
+      "libgusb-0.3.9-1.fc35.aarch64",
       "libibverbs-38.0-1.fc35.aarch64",
       "libidn2-2.3.2-3.fc35.aarch64",
-      "libini_config-1.3.1-48.fc35.aarch64",
+      "libjcat-0.1.9-1.fc35.aarch64",
+      "libjose-11-3.fc35.aarch64",
       "libkcapi-1.3.1-3.fc35.aarch64",
       "libkcapi-hmaccalc-1.3.1-3.fc35.aarch64",
       "libksba-1.6.0-2.fc35.aarch64",
-      "libldb-2.4.1-1.fc35.aarch64",
-      "libmaxminddb-1.6.0-1.fc35.aarch64",
+      "libluksmeta-9-12.fc35.aarch64",
+      "libmbim-1.26.0-1.fc35.aarch64",
+      "libmbim-utils-1.26.0-1.fc35.aarch64",
       "libmnl-1.0.4-14.fc35.aarch64",
       "libmodulemd-2.13.0-3.fc35.aarch64",
       "libmount-2.37.2-1.fc35.aarch64",
       "libndp-1.8-2.fc35.aarch64",
+      "libnet-1.2-4.fc35.aarch64",
       "libnetfilter_conntrack-1.0.8-3.fc35.aarch64",
       "libnfnetlink-1.0.1-20.fc35.aarch64",
-      "libnfsidmap-2.5.4-2.rc3.fc35.aarch64",
       "libnftnl-1.2.0-2.fc35.aarch64",
       "libnghttp2-1.45.1-1.fc35.aarch64",
       "libnl3-3.5.0-8.fc35.aarch64",
       "libnsl2-1.3.0-4.fc35.aarch64",
-      "libpath_utils-0.2.1-48.fc35.aarch64",
       "libpcap-1.10.1-2.fc35.aarch64",
-      "libpciaccess-0.16-5.fc35.aarch64",
-      "libpipeline-1.5.3-3.fc35.aarch64",
+      "libpkgconf-1.8.0-1.fc35.aarch64",
       "libpsl-0.21.1-4.fc35.aarch64",
       "libpwquality-1.4.4-6.fc35.aarch64",
-      "libref_array-0.1.5-48.fc35.aarch64",
+      "libqb-2.0.4-1.fc35.aarch64",
+      "libqmi-1.30.2-1.fc35.aarch64",
+      "libqmi-utils-1.30.2-1.fc35.aarch64",
+      "libqrtr-glib-1.0.0-2.fc35.aarch64",
       "librepo-1.14.2-1.fc35.aarch64",
       "libreport-filesystem-2.15.2-6.fc35.noarch",
       "libseccomp-2.5.3-1.fc35.aarch64",
@@ -12160,55 +12839,62 @@
       "libsemanage-3.3-1.fc35.aarch64",
       "libsepol-3.3-2.fc35.aarch64",
       "libsigsegv-2.13-3.fc35.aarch64",
+      "libslirp-4.6.1-2.fc35.aarch64",
       "libsmartcols-2.37.2-1.fc35.aarch64",
       "libsolv-0.7.19-3.fc35.aarch64",
       "libss-1.46.3-1.fc35.aarch64",
       "libssh-0.9.6-1.fc35.aarch64",
       "libssh-config-0.9.6-1.fc35.noarch",
-      "libsss_autofs-2.6.1-1.fc35.aarch64",
-      "libsss_certmap-2.6.1-1.fc35.aarch64",
       "libsss_idmap-2.6.1-1.fc35.aarch64",
       "libsss_nss_idmap-2.6.1-1.fc35.aarch64",
       "libsss_sudo-2.6.1-1.fc35.aarch64",
       "libstdc++-11.2.1-7.fc35.aarch64",
-      "libtalloc-2.3.3-2.fc35.aarch64",
       "libtasn1-4.16.0-6.fc35.aarch64",
-      "libtdb-1.4.4-3.fc35.aarch64",
-      "libtevent-0.11.0-1.fc35.aarch64",
       "libtirpc-1.3.2-1.fc35.aarch64",
+      "libudisks2-2.9.4-1.fc35.aarch64",
       "libunistring-0.9.10-14.fc35.aarch64",
-      "liburing-2.0-2.fc35.aarch64",
       "libusb1-1.0.24-4.fc35.aarch64",
       "libuser-0.63-7.fc35.aarch64",
       "libutempter-1.2.1-5.fc35.aarch64",
       "libuuid-2.37.2-1.fc35.aarch64",
       "libverto-0.3.2-2.fc35.aarch64",
-      "libxcb-1.13.1-8.fc35.aarch64",
       "libxcrypt-4.4.27-1.fc35.aarch64",
       "libxkbcommon-1.3.1-1.fc35.aarch64",
       "libxml2-2.9.12-6.fc35.aarch64",
+      "libxmlb-0.3.6-1.fc35.aarch64",
       "libyaml-0.2.5-6.fc35.aarch64",
       "libzstd-1.5.1-4.fc35.aarch64",
       "linux-atm-libs-2.5.1-30.fc35.aarch64",
       "linux-firmware-20211216-127.fc35.noarch",
       "linux-firmware-whence-20211216-127.fc35.noarch",
-      "lmdb-libs-0.9.29-2.fc35.aarch64",
       "lua-libs-5.4.3-2.fc35.aarch64",
+      "luksmeta-9-12.fc35.aarch64",
+      "lvm2-2.03.11-6.fc35.aarch64",
+      "lvm2-libs-2.03.11-6.fc35.aarch64",
       "lz4-libs-1.9.3-3.fc35.aarch64",
-      "man-db-2.9.4-2.fc35.aarch64",
+      "lzo-2.10-5.fc35.aarch64",
+      "mdadm-4.2-rc2.fc35.aarch64",
       "memstrack-0.2.4-1.fc35.aarch64",
       "mkpasswd-5.5.10-2.fc35.aarch64",
       "mokutil-0.5.0-1.fc35.aarch64",
       "mozjs78-78.15.0-1.fc35.aarch64",
       "mpdecimal-2.5.1-2.fc35.aarch64",
       "mpfr-4.1.0-8.fc35.aarch64",
-      "ncurses-6.2-8.20210508.fc35.aarch64",
       "ncurses-base-6.2-8.20210508.fc35.noarch",
       "ncurses-libs-6.2-8.20210508.fc35.aarch64",
-      "net-tools-2.0-0.60.20160912git.fc35.aarch64",
       "nettle-3.7.3-2.fc35.aarch64",
       "nftables-1.0.0-1.fc35.aarch64",
       "npth-1.6-7.fc35.aarch64",
+      "nspr-4.32.0-4.fc35.aarch64",
+      "nss-3.73.0-1.fc35.aarch64",
+      "nss-altfiles-2.18.1-19.fc35.aarch64",
+      "nss-softokn-3.73.0-1.fc35.aarch64",
+      "nss-softokn-freebl-3.73.0-1.fc35.aarch64",
+      "nss-sysinit-3.73.0-1.fc35.aarch64",
+      "nss-util-3.73.0-1.fc35.aarch64",
+      "ntfs-3g-libs-2021.8.22-2.fc35.aarch64",
+      "ntfsprogs-2021.8.22-2.fc35.aarch64",
+      "oniguruma-6.9.7.1-1.fc35.1.aarch64",
       "openldap-2.4.59-3.fc35.aarch64",
       "openssh-8.7p1-3.fc35.aarch64",
       "openssh-clients-8.7p1-3.fc35.aarch64",
@@ -12216,11 +12902,15 @@
       "openssl-libs-1.1.1l-2.fc35.aarch64",
       "openssl-pkcs11-0.4.11-4.fc35.aarch64",
       "os-prober-1.77-8.fc35.aarch64",
+      "ostree-2022.1-1.fc35.aarch64",
+      "ostree-libs-2022.1-1.fc35.aarch64",
       "p11-kit-0.23.22-4.fc35.aarch64",
       "p11-kit-trust-0.23.22-4.fc35.aarch64",
       "pam-1.5.2-5.fc35.aarch64",
+      "parsec-0.7.0-3.fc35.aarch64",
       "parted-3.4-6.fc35.aarch64",
       "passwd-0.80-11.fc35.aarch64",
+      "pciutils-libs-3.7.0-4.fc35.aarch64",
       "pcre-8.45-1.fc35.aarch64",
       "pcre2-10.37-4.fc35.aarch64",
       "pcre2-syntax-10.37-4.fc35.noarch",
@@ -12229,15 +12919,20 @@
       "pcsc-lite-libs-1.9.5-1.fc35.aarch64",
       "pigz-2.5-2.fc35.aarch64",
       "pinentry-1.2.0-1.fc35.aarch64",
-      "plymouth-0.9.5-3.20210331git1ea1020.fc35.aarch64",
-      "plymouth-core-libs-0.9.5-3.20210331git1ea1020.fc35.aarch64",
-      "plymouth-scripts-0.9.5-3.20210331git1ea1020.fc35.aarch64",
+      "pkgconf-1.8.0-1.fc35.aarch64",
+      "pkgconf-m4-1.8.0-1.fc35.noarch",
+      "pkgconf-pkg-config-1.8.0-1.fc35.aarch64",
+      "podman-3.4.4-1.fc35.aarch64",
+      "podman-gvproxy-3.4.4-1.fc35.aarch64",
+      "podman-plugins-3.4.4-1.fc35.aarch64",
       "policycoreutils-3.3-1.fc35.aarch64",
+      "policycoreutils-python-utils-3.3-1.fc35.noarch",
       "polkit-0.120-1.fc35.aarch64",
       "polkit-libs-0.120-1.fc35.aarch64",
       "polkit-pkla-compat-0.1-20.fc35.aarch64",
       "popt-1.18-6.fc35.aarch64",
       "procps-ng-3.3.17-3.fc35.aarch64",
+      "protobuf-3.14.0-6.fc35.aarch64",
       "protobuf-c-1.4.0-1.fc35.aarch64",
       "psmisc-23.4-2.fc35.aarch64",
       "publicsuffix-list-dafsa-20210518-2.fc35.noarch",
@@ -12245,137 +12940,92 @@
       "python-setuptools-wheel-57.4.0-1.fc35.noarch",
       "python-unversioned-command-3.10.1-2.fc35.noarch",
       "python3-3.10.1-2.fc35.aarch64",
-      "python3-attrs-21.2.0-4.fc35.noarch",
       "python3-audit-3.0.6-1.fc35.aarch64",
-      "python3-babel-2.9.1-4.fc35.noarch",
-      "python3-cffi-1.14.6-2.fc35.aarch64",
-      "python3-charset-normalizer-2.0.4-1.fc35.noarch",
-      "python3-configobj-5.0.6-25.fc35.noarch",
-      "python3-cryptography-3.4.7-5.fc35.aarch64",
-      "python3-dateutil-2.8.1-7.fc35.noarch",
       "python3-dbus-1.2.18-2.fc35.aarch64",
-      "python3-distro-1.6.0-1.fc35.noarch",
-      "python3-dnf-4.9.0-1.fc35.noarch",
-      "python3-dnf-plugins-core-4.0.24-1.fc35.noarch",
       "python3-firewall-1.0.1-2.fc35.noarch",
       "python3-gobject-base-3.42.0-1.fc35.aarch64",
-      "python3-gpg-1.15.1-6.fc35.aarch64",
-      "python3-hawkey-0.64.0-1.fc35.aarch64",
-      "python3-idna-3.2-1.fc35.noarch",
-      "python3-jinja2-3.0.1-2.fc35.noarch",
-      "python3-jsonpatch-1.21-18.fc35.noarch",
-      "python3-jsonpointer-2.0-4.fc35.noarch",
-      "python3-jsonschema-3.2.0-12.fc35.noarch",
-      "python3-jwt+crypto-2.1.0-2.fc35.noarch",
-      "python3-jwt-2.1.0-2.fc35.noarch",
-      "python3-libcomps-0.1.18-1.fc35.aarch64",
-      "python3-libdnf-0.64.0-1.fc35.aarch64",
       "python3-libs-3.10.1-2.fc35.aarch64",
       "python3-libselinux-3.3-1.fc35.aarch64",
       "python3-libsemanage-3.3-1.fc35.aarch64",
-      "python3-markupsafe-2.0.0-2.fc35.aarch64",
       "python3-nftables-1.0.0-1.fc35.aarch64",
-      "python3-oauthlib+signedtoken-3.0.2-11.fc35.noarch",
-      "python3-oauthlib-3.0.2-11.fc35.noarch",
-      "python3-ply-3.11-13.fc35.noarch",
       "python3-policycoreutils-3.3-1.fc35.noarch",
-      "python3-prettytable-0.7.2-27.fc35.noarch",
-      "python3-pycparser-2.20-5.fc35.noarch",
-      "python3-pyrsistent-0.18.0-8.fc35.aarch64",
-      "python3-pyserial-3.4-12.fc35.noarch",
-      "python3-pysocks-1.7.1-11.fc35.noarch",
-      "python3-pytz-2021.3-1.fc35.noarch",
-      "python3-pyyaml-5.4.1-4.fc35.aarch64",
-      "python3-requests-2.27.0-1.fc35.noarch",
-      "python3-rpm-4.17.0-1.fc35.aarch64",
       "python3-setools-4.4.0-3.fc35.aarch64",
       "python3-setuptools-57.4.0-1.fc35.noarch",
-      "python3-six-1.16.0-4.fc35.noarch",
-      "python3-unbound-1.13.2-1.fc35.aarch64",
-      "python3-urllib3-1.26.7-2.fc35.noarch",
-      "qemu-guest-agent-6.1.0-10.fc35.aarch64",
       "qrencode-libs-4.1.1-1.fc35.aarch64",
       "readline-8.1-3.fc35.aarch64",
+      "rng-tools-6.14-2.git.b2b7934e.fc35.aarch64",
       "rootfiles-8.1-30.fc35.noarch",
       "rpm-4.17.0-1.fc35.aarch64",
-      "rpm-build-libs-4.17.0-1.fc35.aarch64",
       "rpm-libs-4.17.0-1.fc35.aarch64",
+      "rpm-ostree-2022.1-2.fc35.aarch64",
+      "rpm-ostree-libs-2022.1-2.fc35.aarch64",
       "rpm-plugin-selinux-4.17.0-1.fc35.aarch64",
-      "rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64",
-      "rpm-sign-libs-4.17.0-1.fc35.aarch64",
+      "rsync-3.2.3-8.fc35.aarch64",
+      "rtl-sdr-0.6.0-10.fc35.aarch64",
+      "screen-4.8.0-6.fc35.aarch64",
       "sed-4.8-8.fc35.aarch64",
       "selinux-policy-35.8-1.fc35.noarch",
       "selinux-policy-targeted-35.8-1.fc35.noarch",
+      "setools-console-4.4.0-3.fc35.aarch64",
       "setup-2.13.9.1-2.fc35.noarch",
       "shadow-utils-4.9-8.fc35.aarch64",
+      "shadow-utils-subid-4.9-8.fc35.aarch64",
+      "shared-mime-info-2.1-3.fc35.aarch64",
       "shim-aa64-15.4-5.aarch64",
-      "spice-vdagent-0.21.0-5.fc35.aarch64",
+      "skopeo-1.5.2-1.fc35.aarch64",
+      "slirp4netns-1.1.12-2.fc35.aarch64",
       "sqlite-libs-3.36.0-3.fc35.aarch64",
       "sssd-client-2.6.1-1.fc35.aarch64",
-      "sssd-common-2.6.1-1.fc35.aarch64",
-      "sssd-kcm-2.6.1-1.fc35.aarch64",
-      "sssd-nfs-idmap-2.6.1-1.fc35.aarch64",
       "sudo-1.9.7p2-2.fc35.aarch64",
       "sudo-python-plugin-1.9.7p2-2.fc35.aarch64",
       "systemd-249.7-2.fc35.aarch64",
       "systemd-libs-249.7-2.fc35.aarch64",
       "systemd-networkd-249.7-2.fc35.aarch64",
-      "systemd-oomd-defaults-249.7-2.fc35.noarch",
       "systemd-pam-249.7-2.fc35.aarch64",
       "systemd-resolved-249.7-2.fc35.aarch64",
       "systemd-udev-249.7-2.fc35.aarch64",
+      "tar-1.34-2.fc35.aarch64",
+      "tmux-3.2a-2.fc35.aarch64",
+      "tpm2-pkcs11-1.7.0-1.fc35.aarch64",
+      "tpm2-tools-5.2-1.fc35.aarch64",
       "tpm2-tss-3.1.0-3.fc35.aarch64",
+      "traceroute-2.1.0-14.fc35.aarch64",
       "trousers-0.3.15-4.fc35.aarch64",
       "trousers-lib-0.3.15-4.fc35.aarch64",
       "tzdata-2021e-1.fc35.noarch",
-      "unbound-libs-1.13.2-1.fc35.aarch64",
+      "uboot-images-armv8-2021.10-3.fc35.noarch",
+      "udisks2-2.9.4-1.fc35.aarch64",
+      "usbguard-1.0.0-6.fc35.aarch64",
+      "usbguard-selinux-1.0.0-6.fc35.noarch",
       "util-linux-2.37.2-1.fc35.aarch64",
       "util-linux-core-2.37.2-1.fc35.aarch64",
       "vim-data-8.2.4006-1.fc35.noarch",
       "vim-minimal-8.2.4006-1.fc35.aarch64",
+      "volume_key-libs-0.3.12-14.fc35.aarch64",
       "which-2.21-27.fc35.aarch64",
       "whois-nls-5.5.10-2.fc35.noarch",
-      "xen-libs-4.15.1-4.fc35.aarch64",
-      "xen-licenses-4.15.1-4.fc35.aarch64",
+      "wireless-regdb-2021.07.14-2.fc35.noarch",
+      "wpa_supplicant-2.9-13.fc35.aarch64",
       "xfsprogs-5.12.0-2.fc35.aarch64",
       "xkeyboard-config-2.33-2.fc35.noarch",
       "xz-5.2.5-7.fc35.aarch64",
       "xz-libs-5.2.5-7.fc35.aarch64",
       "yajl-2.1.0-17.fc35.aarch64",
-      "yum-4.9.0-1.fc35.noarch",
       "zchunk-libs-1.1.15-2.fc35.aarch64",
+      "zezere-ignition-0.5-9.fc35.noarch",
       "zlib-1.2.11-30.fc35.aarch64"
     ],
-    "partition-table": "gpt",
-    "partition-table-id": "8DFDFF87-C96E-EA48-A3A6-9408F1F6B1EF",
-    "partitions": [
-      {
-        "bootable": false,
-        "fstype": "vfat",
-        "label": "EFI-SYSTEM",
-        "partuuid": "02C1E068-1D2F-4DA3-91FD-8DD76A955C9D",
-        "size": 498073600,
-        "start": 1048576,
-        "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-        "uuid": "46BB-8120"
-      },
-      {
-        "bootable": false,
-        "fstype": "ext4",
-        "label": null,
-        "partuuid": "8D760010-FAAE-46D1-9E5B-4A2EAC5030CD",
-        "size": 1647296000,
-        "start": 500170752,
-        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-        "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
-      }
-    ],
     "passwd": [
+      "root:x:0:0:root:/root:/bin/bash"
+    ],
+    "passwd-system": [
       "adm:x:3:4:adm:/var/adm:/sbin/nologin",
       "bin:x:1:1:bin:/bin:/sbin/nologin",
-      "chrony:x:994:993::/var/lib/chrony:/sbin/nologin",
+      "chrony:x:992:989::/var/lib/chrony:/sbin/nologin",
+      "clevis:x:994:991:Clevis Decryption Framework unprivileged user:/var/cache/clevis:/usr/sbin/nologin",
       "daemon:x:2:2:daemon:/sbin:/sbin/nologin",
       "dbus:x:81:81:System message bus:/:/sbin/nologin",
+      "dnsmasq:x:996:994:Dnsmasq DHCP and DNS server:/var/lib/dnsmasq:/sbin/nologin",
       "ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin",
       "games:x:12:100:games:/usr/games:/sbin/nologin",
       "halt:x:7:0:halt:/sbin:/sbin/halt",
@@ -12383,9 +13033,8 @@
       "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
       "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
       "operator:x:11:0:operator:/root:/sbin/nologin",
-      "polkitd:x:995:994:User for polkitd:/:/sbin/nologin",
-      "redhat:x:1000:1000::/home/redhat:/bin/bash",
-      "root:x:0:0:root:/root:/bin/bash",
+      "parsec:x:995:993:PARSEC service:/var/lib/parsec:/sbin/nologin",
+      "polkitd:x:993:990:User for polkitd:/:/sbin/nologin",
       "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
       "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
       "sync:x:5:0:sync:/sbin:/bin/sync",
@@ -12394,33 +13043,14 @@
       "systemd-oom:x:999:999:systemd Userspace OOM Killer:/:/usr/sbin/nologin",
       "systemd-resolve:x:193:193:systemd Resolver:/:/usr/sbin/nologin",
       "systemd-timesync:x:998:998:systemd Time Synchronization:/:/usr/sbin/nologin",
-      "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
-      "unbound:x:996:995:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
+      "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin"
     ],
-    "rpm-verify": {
-      "changed": {
-        "/boot/efi/EFI": ".M.......",
-        "/boot/efi/EFI/BOOT/BOOTAA64.EFI": ".......T.",
-        "/boot/efi/EFI/BOOT/fbaa64.efi": ".......T.",
-        "/boot/efi/EFI/fedora/BOOTAA64.CSV": ".......T.",
-        "/boot/efi/EFI/fedora/grubaa64.efi": ".......T.",
-        "/boot/efi/EFI/fedora/mmaa64.efi": ".......T.",
-        "/boot/efi/EFI/fedora/shim.efi": ".......T.",
-        "/boot/efi/EFI/fedora/shimaa64.efi": ".......T.",
-        "/etc/machine-id": ".M.......",
-        "/etc/udev/hwdb.bin": ".M.......",
-        "/proc": ".M.......",
-        "/sys": ".M.......",
-        "/var/log/lastlog": ".M....G.."
-      },
-      "missing": []
-    },
     "selinux": {
       "context-mismatch": [
         {
-          "actual": "system_u:object_r:unlabeled_t:s0",
-          "expected": "system_u:object_r:lost_found_t:s0",
-          "filename": "/lost+found"
+          "actual": "system_u:object_r:mnt_t:s0",
+          "expected": "system_u:object_r:default_t:s0",
+          "filename": "/proc"
         }
       ],
       "policy": {
@@ -12429,34 +13059,48 @@
       }
     },
     "services-disabled": [
-      "arp-ethers.service",
+      "blk-availability.service",
+      "bluetooth-mesh.service",
       "chrony-wait.service",
+      "clevis-luks-askpass.path",
+      "cni-dhcp.service",
+      "cni-dhcp.socket",
       "console-getty.service",
+      "cpupower.service",
       "debug-shell.service",
+      "dnsmasq.service",
+      "ead.service",
       "exit.target",
+      "fwupd-refresh.timer",
+      "greenboot-loading-message.service",
       "halt.target",
+      "iwd.service",
       "kexec.target",
       "loadmodules.service",
-      "man-db-restart-cache-update.service",
+      "mdcheck_continue.timer",
+      "mdcheck_start.timer",
+      "mdmonitor-oneshot.timer",
       "nftables.service",
       "nis-domainname.service",
+      "ostree-finalize-staged.path",
+      "podman-auto-update.service",
+      "podman-auto-update.timer",
+      "podman-restart.service",
+      "podman.service",
+      "podman.socket",
       "poweroff.target",
       "proc-sys-fs-binfmt_misc.mount",
       "rdisc.service",
       "remote-cryptsetup.target",
       "remote-veritysetup.target",
+      "rpm-ostree-bootstatus.service",
+      "rpm-ostree-countme.timer",
+      "rpm-ostreed-automatic.timer",
       "runlevel0.target",
       "selinux-check-proper-disable.service",
       "serial-getty@.service",
       "sshd-keygen@.service",
       "sshd.socket",
-      "sssd-autofs.socket",
-      "sssd-nss.socket",
-      "sssd-pac.socket",
-      "sssd-pam-priv.socket",
-      "sssd-pam.socket",
-      "sssd-ssh.socket",
-      "sssd-sudo.socket",
       "systemd-boot-check-no-failures.service",
       "systemd-network-generator.service",
       "systemd-networkd-wait-online.service",
@@ -12466,49 +13110,65 @@
       "systemd-sysext.service",
       "systemd-time-wait-sync.service",
       "systemd-timesyncd.service",
-      "tcsd.service"
+      "tcsd.service",
+      "usbguard.service",
+      "wpa_supplicant.service"
     ],
     "services-enabled": [
+      "ModemManager.service",
       "NetworkManager-dispatcher.service",
       "NetworkManager-wait-online.service",
       "NetworkManager.service",
       "auditd.service",
       "autovt@.service",
+      "bluetooth.service",
       "chronyd.service",
-      "cloud-config.service",
-      "cloud-final.service",
-      "cloud-init-local.service",
-      "cloud-init.service",
       "ctrl-alt-del.target",
       "dbus-broker.service",
+      "dbus-org.bluez.service",
       "dbus-org.fedoraproject.FirewallD1.service",
+      "dbus-org.freedesktop.ModemManager1.service",
       "dbus-org.freedesktop.home1.service",
       "dbus-org.freedesktop.nm-dispatcher.service",
       "dbus-org.freedesktop.oom1.service",
       "dbus-org.freedesktop.resolve1.service",
+      "dbus-parsec.service",
       "dbus.service",
       "dbus.socket",
-      "dnf-makecache.timer",
+      "dm-event.socket",
       "firewalld.service",
       "fstrim.timer",
       "getty@.service",
+      "greenboot-grub2-set-counter.service",
+      "greenboot-grub2-set-success.service",
+      "greenboot-healthcheck.service",
+      "greenboot-rpm-ostree-grub2-check-fallback.service",
+      "greenboot-status.service",
+      "greenboot-task-runner.service",
       "import-state.service",
+      "lvm2-lvmpolld.socket",
+      "lvm2-monitor.service",
+      "mdmonitor.service",
+      "ostree-remount.service",
+      "parsec.service",
       "pcscd.socket",
-      "qemu-guest-agent.service",
+      "raid-check.timer",
       "reboot.target",
+      "redboot-auto-reboot.service",
+      "redboot-task-runner.service",
       "remote-fs.target",
+      "rngd.service",
       "rpmdb-rebuild.service",
       "runlevel6.target",
       "selinux-autorelabel-mark.service",
       "sshd.service",
-      "sssd-kcm.socket",
-      "sssd.service",
       "systemd-homed-activate.service",
       "systemd-homed.service",
       "systemd-oomd.service",
       "systemd-resolved.service",
       "systemd-userdbd.socket",
-      "unbound-anchor.timer"
+      "udisks2.service",
+      "zezere_ignition.timer"
     ],
     "ssh_config": {
       "/etc/ssh": {
@@ -12624,30 +13284,17 @@
           "Unit": {
             "RefuseManualStop": "true"
           }
-        },
-        "user@.service.d": {
-          "Service": {
-            "ManagedOOMMemoryPressure": "kill",
-            "ManagedOOMMemoryPressureLimit": "50%"
-          }
         }
       }
     },
     "timezone": "UTC",
     "tmpfiles.d": {
       "/usr/lib/tmpfiles.d": {
-        "cloud-init.conf": [
-          "d /run/cloud-init 0700 root root - -"
+        "criu.conf": [
+          "d /run/criu 0755 root root -"
         ],
         "cryptsetup.conf": [
           "d /run/cryptsetup 0700 root root -"
-        ],
-        "dnf.conf": [
-          "R /var/tmp/dnf*/locks/*",
-          "r /var/cache/dnf/download_lock.pid",
-          "r /var/cache/dnf/metadata_lock.pid",
-          "r /var/lib/dnf/rpmdb_lock.pid",
-          "r /var/log/log_lock.pid"
         ],
         "etc.conf": [
           "L /etc/os-release - - - - ../usr/lib/os-release",
@@ -12656,6 +13303,9 @@
           "C! /etc/nsswitch.conf - - - -",
           "C! /etc/pam.d - - - -",
           "C! /etc/issue - - - -"
+        ],
+        "greenboot-status-motd.conf": [
+          "f   /run/motd.d/boot-status     -   -   -   -   -"
         ],
         "home.conf": [
           "Q /home 0755 - - -",
@@ -12677,8 +13327,15 @@
         "libselinux.conf": [
           "d /run/setrans 0755 root root"
         ],
-        "man-db.conf": [
-          "d /var/cache/man 0755 root root 1w"
+        "lvm2.conf": [
+          "d /run/lock/lvm 0700 root root -",
+          "d /run/lvm 0700 root root -"
+        ],
+        "mdadm.conf": [
+          "d /run/mdadm 0710 root root -"
+        ],
+        "ostree-tmpfiles.conf": [
+          "R! /var/tmp/ostree-unlock-ovl.*"
         ],
         "pam.conf": [
           "d /run/console 0755 root root -",
@@ -12687,8 +13344,113 @@
           "d /run/motd.d 0755 root root -",
           "f /var/log/tallylog 0600 root root -"
         ],
+        "parsec.conf": [
+          "d       /run/parsec   750  parsec parsec-clients   -           -"
+        ],
+        "podman.conf": [
+          "x /tmp/podman-run-*",
+          "x /tmp/containers-user-*",
+          "x /tmp/run-*/libpod",
+          "D! /run/podman 0700 root root",
+          "D! /var/lib/cni/networks"
+        ],
         "portables.conf": [
           "Q /var/lib/portables 0700"
+        ],
+        "rpm-ostree-0-integration.conf": [
+          "d /var/home 0755 root root -",
+          "d /var/opt 0755 root root -",
+          "d /var/srv 0755 root root -",
+          "d /var/roothome 0700 root root -",
+          "d /var/usrlocal 0755 root root -",
+          "d /var/usrlocal/bin 0755 root root -",
+          "d /var/usrlocal/etc 0755 root root -",
+          "d /var/usrlocal/games 0755 root root -",
+          "d /var/usrlocal/include 0755 root root -",
+          "d /var/usrlocal/lib 0755 root root -",
+          "d /var/usrlocal/man 0755 root root -",
+          "d /var/usrlocal/sbin 0755 root root -",
+          "d /var/usrlocal/share 0755 root root -",
+          "d /var/usrlocal/src 0755 root root -",
+          "d /var/mnt 0755 root root -",
+          "d /run/media 0755 root root -",
+          "d /var/lib 0755 root root -",
+          "L /var/lib/rpm - - - - ../../usr/share/rpm"
+        ],
+        "rpm-ostree-1-autovar.conf": [
+          "L /var/lib/rpm - - - - ../../usr/share/rpm",
+          "L /var/lock - - - - ../run/lock",
+          "L /var/mail - - - - spool/mail",
+          "d /var/adm 0755 root root - -",
+          "d /var/cache 0755 root root - -",
+          "d /var/cache/bpf 0755 root root - -",
+          "d /var/cache/fwupd 0755 root root - -",
+          "d /var/cache/ldconfig 0700 root root - -",
+          "d /var/cache/private 0700 root root - -",
+          "d /var/db 0755 root root - -",
+          "d /var/db/sudo 0700 root root - -",
+          "d /var/db/sudo/lectured 0700 root root - -",
+          "d /var/empty 0755 root root - -",
+          "d /var/ftp 0755 root root - -",
+          "d /var/games 0755 root root - -",
+          "d /var/kerberos 0755 root root - -",
+          "d /var/kerberos/krb5 0755 root root - -",
+          "d /var/kerberos/krb5/user 0755 root root - -",
+          "d /var/lib 0755 root root - -",
+          "d /var/lib/NetworkManager 0700 root root - -",
+          "d /var/lib/alternatives 0755 root root - -",
+          "d /var/lib/bluetooth 0755 root root - -",
+          "d /var/lib/bluetooth/mesh 0755 root root - -",
+          "d /var/lib/chrony 0750 chrony chrony - -",
+          "d /var/lib/containers 0755 root root - -",
+          "d /var/lib/containers/sigstore 0755 root root - -",
+          "d /var/lib/dbus-parsec 0755 root root - -",
+          "d /var/lib/dnsmasq 0755 root dnsmasq - -",
+          "d /var/lib/ead 0755 root root - -",
+          "d /var/lib/fwupd 0755 root root - -",
+          "d /var/lib/games 0755 root root - -",
+          "d /var/lib/initramfs 0755 root root - -",
+          "d /var/lib/iwd 0755 root root - -",
+          "d /var/lib/misc 0755 root root - -",
+          "d /var/lib/os-prober 0755 root root - -",
+          "d /var/lib/parsec 0750 parsec parsec - -",
+          "d /var/lib/polkit-1 0750 root polkitd - -",
+          "d /var/lib/polkit-1/localauthority 0755 root root - -",
+          "d /var/lib/polkit-1/localauthority/10-vendor.d 0755 root root - -",
+          "d /var/lib/polkit-1/localauthority/20-org.d 0755 root root - -",
+          "d /var/lib/polkit-1/localauthority/30-site.d 0755 root root - -",
+          "d /var/lib/polkit-1/localauthority/50-local.d 0755 root root - -",
+          "d /var/lib/polkit-1/localauthority/90-mandatory.d 0755 root root - -",
+          "d /var/lib/portables 0700 root root - -",
+          "d /var/lib/private 0700 root root - -",
+          "d /var/lib/rpm-state 0755 root root - -",
+          "d /var/lib/selinux 0755 root root - -",
+          "d /var/lib/selinux/final 0700 root root - -",
+          "d /var/lib/selinux/targeted 0755 root root - -",
+          "d /var/lib/selinux/tmp 0755 root root - -",
+          "d /var/lib/systemd 0755 root root - -",
+          "d /var/lib/systemd/catalog 0755 root root - -",
+          "d /var/lib/systemd/coredump 0755 root root - -",
+          "d /var/lib/tpm 0700 tss tss - -",
+          "d /var/lib/udisks2 0700 root root - -",
+          "d /var/local 0755 root root - -",
+          "d /var/log 0755 root root - -",
+          "d /var/log/audit 0700 root root - -",
+          "d /var/log/chrony 0750 chrony chrony - -",
+          "d /var/log/journal 2755 root systemd-journal - -",
+          "d /var/log/private 0700 root root - -",
+          "d /var/log/usbguard 0755 root root - -",
+          "d /var/nis 0755 root root - -",
+          "d /var/opt 0755 root root - -",
+          "d /var/preserve 0755 root root - -",
+          "d /var/spool 0755 root root - -",
+          "d /var/spool/lpd 0755 root root - -",
+          "d /var/spool/mail 0775 root mail - -",
+          "d /var/tmp 1777 root root - -",
+          "d /var/yp 0755 root root - -"
+        ],
+        "screen.conf": [
+          "d /run/screen 0775 root screen"
         ],
         "selinux-policy.conf": [
           "z /sys/devices/system/cpu/online - - -",
@@ -12699,9 +13461,6 @@
         "setup.conf": [
           "f /run/motd 0644 root root -",
           "d /run/motd.d 0755 root root -"
-        ],
-        "spice-vdagentd.conf": [
-          "d /run/spice-vdagentd 0755 root root -"
         ],
         "static-nodes-permissions.conf": [
           "z /dev/snd/seq      0660 - audio -",
@@ -12774,6 +13533,9 @@
           "d       /run/tpm2-tss/eventlog                2775 tss  tss   -           -",
           "a+      /run/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx"
         ],
+        "udisks2.conf": [
+          "d /run/media 0755 root root"
+        ],
         "var.conf": [
           "q /var 0755 - - -",
           "L /var/run - - - - ../run",
@@ -12795,6 +13557,7 @@
         ]
       }
     },
+    "type": "ostree/commit",
     "yum_repos": {
       "/etc/yum.repos.d": {
         "fedora-cisco-openh264.repo": {
@@ -12818,114 +13581,6 @@
             "name": "Fedora $releasever openh264 (From Cisco) - $basearch - Debug",
             "repo_gpgcheck": "0",
             "skip_if_unavailable": "True",
-            "type": "rpm"
-          }
-        },
-        "fedora-modular.repo": {
-          "fedora-modular": {
-            "countme": "1",
-            "enabled": "1",
-            "gpgcheck": "1",
-            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
-            "metadata_expire": "7d",
-            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch",
-            "name": "Fedora Modular $releasever - $basearch",
-            "repo_gpgcheck": "0",
-            "skip_if_unavailable": "False",
-            "type": "rpm"
-          },
-          "fedora-modular-debuginfo": {
-            "enabled": "0",
-            "gpgcheck": "1",
-            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
-            "metadata_expire": "7d",
-            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-debug-$releasever&arch=$basearch",
-            "name": "Fedora Modular $releasever - $basearch - Debug",
-            "repo_gpgcheck": "0",
-            "skip_if_unavailable": "False",
-            "type": "rpm"
-          },
-          "fedora-modular-source": {
-            "enabled": "0",
-            "gpgcheck": "1",
-            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
-            "metadata_expire": "7d",
-            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-source-$releasever&arch=$basearch",
-            "name": "Fedora Modular $releasever - Source",
-            "repo_gpgcheck": "0",
-            "skip_if_unavailable": "False",
-            "type": "rpm"
-          }
-        },
-        "fedora-updates-modular.repo": {
-          "updates-modular": {
-            "countme": "1",
-            "enabled": "1",
-            "gpgcheck": "1",
-            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
-            "metadata_expire": "6h",
-            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch",
-            "name": "Fedora Modular $releasever - $basearch - Updates",
-            "repo_gpgcheck": "0",
-            "skip_if_unavailable": "False",
-            "type": "rpm"
-          },
-          "updates-modular-debuginfo": {
-            "enabled": "0",
-            "gpgcheck": "1",
-            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
-            "metadata_expire": "6h",
-            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-debug-f$releasever&arch=$basearch",
-            "name": "Fedora Modular $releasever - $basearch - Updates - Debug",
-            "repo_gpgcheck": "0",
-            "skip_if_unavailable": "False",
-            "type": "rpm"
-          },
-          "updates-modular-source": {
-            "enabled": "0",
-            "gpgcheck": "1",
-            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
-            "metadata_expire": "6h",
-            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-source-f$releasever&arch=$basearch",
-            "name": "Fedora Modular $releasever - Updates Source",
-            "repo_gpgcheck": "0",
-            "skip_if_unavailable": "False",
-            "type": "rpm"
-          }
-        },
-        "fedora-updates-testing-modular.repo": {
-          "updates-testing-modular": {
-            "countme": "1",
-            "enabled": "0",
-            "gpgcheck": "1",
-            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
-            "metadata_expire": "6h",
-            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-f$releasever&arch=$basearch",
-            "name": "Fedora Modular $releasever - $basearch - Test Updates",
-            "repo_gpgcheck": "0",
-            "skip_if_unavailable": "False",
-            "type": "rpm"
-          },
-          "updates-testing-modular-debuginfo": {
-            "enabled": "0",
-            "gpgcheck": "1",
-            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
-            "metadata_expire": "6h",
-            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-debug-f$releasever&arch=$basearch",
-            "name": "Fedora Modular $releasever - $basearch - Test Updates Debug",
-            "repo_gpgcheck": "0",
-            "skip_if_unavailable": "False",
-            "type": "rpm"
-          },
-          "updates-testing-modular-source": {
-            "enabled": "0",
-            "gpgcheck": "1",
-            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch",
-            "metadata_expire": "6h",
-            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-testing-modular-source-f$releasever&arch=$basearch",
-            "name": "Fedora Modular $releasever - Test Updates Source",
-            "repo_gpgcheck": "0",
-            "skip_if_unavailable": "False",
             "type": "rpm"
           }
         },

--- a/test/data/manifests/fedora_35-aarch64-oci-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-oci-boot.json
@@ -3653,6 +3653,1708 @@
     }
   },
   "rpmmd": {
+    "blueprint": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm",
+        "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm",
+        "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm",
+        "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
+        "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm",
+        "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm",
+        "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm",
+        "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm",
+        "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
+        "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm",
+        "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm",
+        "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm",
+        "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm",
+        "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm",
+        "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
+        "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm",
+        "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm",
+        "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm",
+        "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm",
+        "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm",
+        "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm",
+        "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm",
+        "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
     "build-packages": [
       {
         "name": "acl",

--- a/test/data/manifests/fedora_35-aarch64-qcow2-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-qcow2-boot.json
@@ -3677,6 +3677,1708 @@
     }
   },
   "rpmmd": {
+    "blueprint": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm",
+        "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm",
+        "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm",
+        "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
+        "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm",
+        "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm",
+        "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm",
+        "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm",
+        "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
+        "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm",
+        "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm",
+        "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm",
+        "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm",
+        "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm",
+        "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
+        "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm",
+        "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm",
+        "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm",
+        "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm",
+        "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm",
+        "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm",
+        "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm",
+        "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
     "build-packages": [
       {
         "name": "acl",

--- a/test/data/manifests/fedora_35-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-qcow2_customize-boot.json
@@ -3781,6 +3781,3178 @@
     }
   },
   "rpmmd": {
+    "blueprint": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm",
+        "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65",
+        "check_gpg": true
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75",
+        "check_gpg": true
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chrony-4.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3eecb51a03f9eed59710f6c6cbc5d66aea9bc521940d0b8d73fca835f1402897",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm",
+        "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm",
+        "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
+        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.aarch64.rpm",
+        "checksum": "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm",
+        "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
+        "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm",
+        "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm",
+        "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/firewalld-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/firewalld-filesystem-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/geolite2-city-20191217-5.fc35.noarch.rpm",
+        "checksum": "sha256:47073336fc560a28cd2b11f6c8f3fead340a4f443494d2178afcce534b28c7a3",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/geolite2-country-20191217-5.fc35.noarch.rpm",
+        "checksum": "sha256:824f0a1ef06204d74a8a3c5a72f31a0bb1a0bf117fe6a0e043305f8cfade634a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.70.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gobject-introspection-1.70.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30c4143715cbe6d44c23039777276fe7b900130ea6193d75512f5d4651e52e13",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm",
+        "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.aarch64.rpm",
+        "checksum": "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm",
+        "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.aarch64.rpm",
+        "checksum": "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm",
+        "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute-tc",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipset-7.15-1.fc35.aarch64.rpm",
+        "checksum": "sha256:1f81a2122f9b9482a6b41b2bd98ec47a9f06697a4f3d08ed81dfaca7ee7b1c6c",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipset-libs-7.15-1.fc35.aarch64.rpm",
+        "checksum": "sha256:95f62c37836b177bbaff44da7e94c70bd9badddbd873cc0b470f14c56257eee5",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-nft-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:8a93cb5f7a78270157d8bc5272478d64104a7d89dccfea2dd227d8692fc510c3",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20210722",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/jansson-2.13.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:972e63fdf149b8fa4cc48d07c77a5b2a8d630b2a71deee28d78c8eb260df65b0",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm",
+        "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
+        "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm",
+        "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm",
+        "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.aarch64.rpm",
+        "checksum": "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm",
+        "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.aarch64.rpm",
+        "checksum": "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "40.20210910cvs.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.aarch64.rpm",
+        "checksum": "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
+        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm",
+        "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.aarch64.rpm",
+        "checksum": "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.5.4",
+        "release": "2.rc3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.aarch64.rpm",
+        "checksum": "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnftnl-1.2.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7bc35d9fda6ebfe33a63cf1093a2c64b03da111461fce2b213f4fc5e91519eaa",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.aarch64.rpm",
+        "checksum": "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
+        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm",
+        "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.aarch64.rpm",
+        "checksum": "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm",
+        "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm",
+        "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm",
+        "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.aarch64.rpm",
+        "checksum": "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.aarch64.rpm",
+        "checksum": "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
+        "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs78",
+        "epoch": 0,
+        "version": "78.15.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nftables-1.0.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:717d52dab884a42e0c346dd8d2b6f5bcb80b85703c7a208df04ff96ec4114f6f",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm",
+        "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm",
+        "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm",
+        "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/parted-3.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.aarch64.rpm",
+        "checksum": "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm",
+        "checksum": "sha256:07fd0548f64b358ffd9ce32e885b7b91dc7e6208171d7efb9874923aead0fa5c",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-core-libs-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm",
+        "checksum": "sha256:6c5f9498b18f3634aff99c8c07148876906a35357a86d473ff62f1073059a7aa",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-scripts-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm",
+        "checksum": "sha256:97c959173adc41a960200043e95347cb2ef9035dd7eec79d5489b11e3332a23d",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "7.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm",
+        "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.aarch64.rpm",
+        "checksum": "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-firewall-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-gobject-base-3.42.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:501d1c9a812d927bc37ec65f11d818fef9f0647d711f132c91c1718124c32dc4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-nftables-1.0.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:31e3038cdc752f890970d60653b510eb815e56be7854ba627ef7843b4c760ec9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "30.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm",
+        "checksum": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm",
+        "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm",
+        "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm",
+        "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.aarch64.rpm",
+        "checksum": "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-rescue-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:93ef166ef633109718d61c580210a47a65a21eb8a178a11dd7bc577706595e27",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.70.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/less-590-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-python3-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:01c4eedbedec34f5413a98f2dae6a84466270a71aceb647206e84e64b452ed96",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-atm-libs",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.aarch64.rpm",
+        "checksum": "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.4.36",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm",
+        "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm",
+        "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm",
+        "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm",
+        "checksum": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/z/zram-generator-1.1.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:097de2cb18e9011f37bf4fb4f093346ef1d786cdda1663b5ba9a66a977ac4ffe",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/z/zram-generator-defaults-1.1.1-3.fc35.noarch.rpm",
+        "checksum": "sha256:6acdd7238cecc7a50fa0a4c334550a1ff1d2b4984ae25be711322bef8f773a0d",
+        "check_gpg": true
+      }
+    ],
     "build-packages": [
       {
         "name": "acl",

--- a/test/data/manifests/fedora_35-x86_64-ami-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-ami-boot.json
@@ -3646,6 +3646,1718 @@
     }
   },
   "rpmmd": {
+    "blueprint": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm",
+        "checksum": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm",
+        "checksum": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
+        "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm",
+        "checksum": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm",
+        "checksum": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm",
+        "checksum": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
+        "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm",
+        "checksum": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm",
+        "checksum": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm",
+        "checksum": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm",
+        "checksum": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm",
+        "checksum": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm",
+        "checksum": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm",
+        "checksum": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
+        "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm",
+        "checksum": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm",
+        "checksum": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
+        "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm",
+        "checksum": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm",
+        "checksum": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm",
+        "checksum": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm",
+        "checksum": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm",
+        "checksum": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm",
+        "checksum": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
+        "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm",
+        "checksum": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm",
+        "checksum": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm",
+        "checksum": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:9ecb8e5c854c5627dab136cb5731ef6c073400d6deb81dfd24a6a44bd0b9ad4a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:8ce8dfdbfce7c27275408198827f17889b22f3c0597e3b64548542cf8af4327d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:18c9bc1629e34ba5328184a29314c7e751177731fdcbc98371f4587f97fe399b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm",
+        "checksum": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
     "build-packages": [
       {
         "name": "acl",

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_commit-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_commit-boot.json
@@ -4227,6 +4227,1718 @@
     }
   },
   "rpmmd": {
+    "blueprint": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm",
+        "checksum": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm",
+        "checksum": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
+        "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm",
+        "checksum": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm",
+        "checksum": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm",
+        "checksum": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
+        "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm",
+        "checksum": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm",
+        "checksum": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm",
+        "checksum": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm",
+        "checksum": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm",
+        "checksum": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm",
+        "checksum": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm",
+        "checksum": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
+        "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm",
+        "checksum": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm",
+        "checksum": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
+        "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm",
+        "checksum": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm",
+        "checksum": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm",
+        "checksum": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm",
+        "checksum": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm",
+        "checksum": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm",
+        "checksum": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
+        "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm",
+        "checksum": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm",
+        "checksum": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm",
+        "checksum": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:9ecb8e5c854c5627dab136cb5731ef6c073400d6deb81dfd24a6a44bd0b9ad4a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:8ce8dfdbfce7c27275408198827f17889b22f3c0597e3b64548542cf8af4327d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:18c9bc1629e34ba5328184a29314c7e751177731fdcbc98371f4587f97fe399b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm",
+        "checksum": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
     "build-packages": [
       {
         "name": "acl",

--- a/test/data/manifests/fedora_35-x86_64-fedora_iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-fedora_iot_commit_debug-boot.json
@@ -4233,6 +4233,1718 @@
     }
   },
   "rpmmd": {
+    "blueprint": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm",
+        "checksum": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm",
+        "checksum": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
+        "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm",
+        "checksum": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm",
+        "checksum": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm",
+        "checksum": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
+        "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm",
+        "checksum": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm",
+        "checksum": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm",
+        "checksum": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm",
+        "checksum": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm",
+        "checksum": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm",
+        "checksum": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm",
+        "checksum": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
+        "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm",
+        "checksum": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm",
+        "checksum": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
+        "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm",
+        "checksum": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm",
+        "checksum": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm",
+        "checksum": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm",
+        "checksum": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm",
+        "checksum": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm",
+        "checksum": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
+        "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm",
+        "checksum": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm",
+        "checksum": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm",
+        "checksum": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-debug",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-debug-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:0b8acdcd6d999a38c5ddc19d58303d7875d886b53582467a5cfdfe8d03c92648",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-debug-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-debug-core-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:4b25c9756793ed5c7f7ccf9313d58628c154ad35d584c38ae4998e9953d5c4e7",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-debug-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-debug-modules-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:9ee7d9f51a8905db1c64ba3e004ab9f66e2b739f84eeb2b5b46a2d5f68f74a25",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm",
+        "checksum": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
     "build-packages": [
       {
         "name": "acl",

--- a/test/data/manifests/fedora_35-x86_64-oci-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-oci-boot.json
@@ -3721,6 +3721,1718 @@
     }
   },
   "rpmmd": {
+    "blueprint": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm",
+        "checksum": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm",
+        "checksum": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
+        "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm",
+        "checksum": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm",
+        "checksum": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm",
+        "checksum": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
+        "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm",
+        "checksum": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm",
+        "checksum": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm",
+        "checksum": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm",
+        "checksum": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm",
+        "checksum": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm",
+        "checksum": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm",
+        "checksum": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
+        "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm",
+        "checksum": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm",
+        "checksum": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
+        "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm",
+        "checksum": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm",
+        "checksum": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm",
+        "checksum": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm",
+        "checksum": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm",
+        "checksum": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm",
+        "checksum": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
+        "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm",
+        "checksum": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm",
+        "checksum": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm",
+        "checksum": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:9ecb8e5c854c5627dab136cb5731ef6c073400d6deb81dfd24a6a44bd0b9ad4a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:8ce8dfdbfce7c27275408198827f17889b22f3c0597e3b64548542cf8af4327d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:18c9bc1629e34ba5328184a29314c7e751177731fdcbc98371f4587f97fe399b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm",
+        "checksum": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
     "build-packages": [
       {
         "name": "acl",

--- a/test/data/manifests/fedora_35-x86_64-openstack-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-openstack-boot.json
@@ -3805,6 +3805,1718 @@
     }
   },
   "rpmmd": {
+    "blueprint": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm",
+        "checksum": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm",
+        "checksum": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
+        "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm",
+        "checksum": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm",
+        "checksum": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm",
+        "checksum": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
+        "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm",
+        "checksum": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm",
+        "checksum": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm",
+        "checksum": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm",
+        "checksum": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm",
+        "checksum": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm",
+        "checksum": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm",
+        "checksum": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
+        "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm",
+        "checksum": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm",
+        "checksum": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
+        "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm",
+        "checksum": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm",
+        "checksum": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm",
+        "checksum": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm",
+        "checksum": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm",
+        "checksum": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm",
+        "checksum": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
+        "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm",
+        "checksum": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm",
+        "checksum": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm",
+        "checksum": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:9ecb8e5c854c5627dab136cb5731ef6c073400d6deb81dfd24a6a44bd0b9ad4a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:8ce8dfdbfce7c27275408198827f17889b22f3c0597e3b64548542cf8af4327d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:18c9bc1629e34ba5328184a29314c7e751177731fdcbc98371f4587f97fe399b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm",
+        "checksum": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
     "build-packages": [
       {
         "name": "acl",

--- a/test/data/manifests/fedora_35-x86_64-qcow2-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-qcow2-boot.json
@@ -3745,6 +3745,1718 @@
     }
   },
   "rpmmd": {
+    "blueprint": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm",
+        "checksum": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm",
+        "checksum": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
+        "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm",
+        "checksum": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm",
+        "checksum": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm",
+        "checksum": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
+        "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm",
+        "checksum": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm",
+        "checksum": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm",
+        "checksum": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm",
+        "checksum": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm",
+        "checksum": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm",
+        "checksum": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm",
+        "checksum": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
+        "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm",
+        "checksum": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm",
+        "checksum": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
+        "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm",
+        "checksum": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm",
+        "checksum": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm",
+        "checksum": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm",
+        "checksum": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm",
+        "checksum": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm",
+        "checksum": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
+        "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm",
+        "checksum": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm",
+        "checksum": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm",
+        "checksum": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:9ecb8e5c854c5627dab136cb5731ef6c073400d6deb81dfd24a6a44bd0b9ad4a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:8ce8dfdbfce7c27275408198827f17889b22f3c0597e3b64548542cf8af4327d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:18c9bc1629e34ba5328184a29314c7e751177731fdcbc98371f4587f97fe399b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm",
+        "checksum": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
     "build-packages": [
       {
         "name": "acl",

--- a/test/data/manifests/fedora_35-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-qcow2_customize-boot.json
@@ -3849,6 +3849,3188 @@
     }
   },
   "rpmmd": {
+    "blueprint": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:537bbb4888324722c268e61e55507c49cdf332562b6106599aa62993c395cbda",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm",
+        "checksum": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:42510fc2fc78334ce4ff5e01c1776ae19d8ff856ab532b52596bd1fedd488f5b",
+        "check_gpg": true
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2fdb91587fb70d5835cec683d1033a5c59069d6dc8f1ac462d1cd1c388174a04",
+        "check_gpg": true
+      },
+      {
+        "name": "chrony",
+        "epoch": 0,
+        "version": "4.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/chrony-4.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:24ef51a567ab5ad68258bc3c4958d086f11c8626c57efbd89705d9399411586e",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm",
+        "checksum": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:dff5837ed139df9d8f468045a6992d644ed5209ab64c3ba68154b581a87e73b4",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm",
+        "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.x86_64.rpm",
+        "checksum": "sha256:3681a2bfa9526b157a63bf8876db3b7e7bdf77158f8045fb073c5987aa4ef860",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm",
+        "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
+        "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm",
+        "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm",
+        "checksum": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/firewalld-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/firewalld-filesystem-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/geolite2-city-20191217-5.fc35.noarch.rpm",
+        "checksum": "sha256:47073336fc560a28cd2b11f6c8f3fead340a4f443494d2178afcce534b28c7a3",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/geolite2-country-20191217-5.fc35.noarch.rpm",
+        "checksum": "sha256:824f0a1ef06204d74a8a3c5a72f31a0bb1a0bf117fe6a0e043305f8cfade634a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.70.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gobject-introspection-1.70.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:7d85a31b893836536f151d1697cb4c693ff1c0445df84c3471d3d721f25c04d8",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm",
+        "checksum": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.x86_64.rpm",
+        "checksum": "sha256:95c00ff3e832f2f89925eff9007fecfdcb5a85d22cd81aeb2897575c58d7b464",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm",
+        "checksum": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
+        "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.x86_64.rpm",
+        "checksum": "sha256:154cb55953505aee6e0546b7b1496a742ad1d01ae59262e1bd3dd473040903ff",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1543cae4d98b7e701c42218004ead3680f01b403a3694dcd56ab504e715690a8",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm",
+        "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f9583368a339e13987f4cd287883661c5c08c4ddf29734cd84b7434d2959321",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:6d714a00ad0f50d11149f199390440caed8765dd417b480816f21724bb9ad76f",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute-tc",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:3e342a4cf63be7ea0fde629a074e71b1caa29c0cfb387b14aaf39451cb7e1cb1",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ipset-7.15-1.fc35.x86_64.rpm",
+        "checksum": "sha256:7d17182f998b2e5b2c11c97b03ac5c0a1924b7d66c6ee3a539357d8a923fdfc7",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ipset-libs-7.15-1.fc35.x86_64.rpm",
+        "checksum": "sha256:8266ce704418cde8abe89215dc55aee64a37b4a273aa639ceb8d07c7f7e1c67d",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ec557ec85dcaebfbe1e464c68cd5dd826190e3d9a1456c028e2bd1ea7f1c53",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-nft-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f140ad437bba386c948ac0a37cd6c1119383fba4a42eb78214927a79e4e0d535",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20210722",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.x86_64.rpm",
+        "checksum": "sha256:257cfc8c56a77471d8cff02ef7f7c4709676a49a564c0e7538d4eef02532634a",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/jansson-2.13.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:7d477896ce7c50c8ab915a4e0a95b462fbadb4a05a1dad5597899005f33b5315",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm",
+        "checksum": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.x86_64.rpm",
+        "checksum": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.x86_64.rpm",
+        "checksum": "sha256:361c435856f76b6e2e112534c0592ba1021490e38ff37ef93926f95733dc3da5",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm",
+        "checksum": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm",
+        "checksum": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d833e17b640e9c8e2c77faa38cb19fed867874754f8998e55b04f0615a221a1e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.x86_64.rpm",
+        "checksum": "sha256:ecc39f8297bdbe5d797d8c02a530d576ab1c39448c2c6e2c278f3458489d22e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm",
+        "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm",
+        "checksum": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.x86_64.rpm",
+        "checksum": "sha256:b86188f018b8ee782fa4df439c15bf8dc78443a0f95c7a144871c6ed5904d9ae",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "40.20210910cvs.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.x86_64.rpm",
+        "checksum": "sha256:492a776ef88d62abcc7ade5a4998d44663981d72af87bc30f8cc866ffbc4d4c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm",
+        "checksum": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2706fac0d312be173d045cf8ae230791f77f7fed69f08242183d45ff0f679280",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.x86_64.rpm",
+        "checksum": "sha256:1f4684fd8720319d2baa1bdad8a5ee6cf2484acb1368fd5e0bc6be8c5126bb79",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.x86_64.rpm",
+        "checksum": "sha256:eefb89e40edd33bdce33983423e40682b4672e0ede42da3a33be17b6d57e4067",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9ffcca99e2ca01870a82cda02fa484c7ff85d054b277e02910df05ab292cda83",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.x86_64.rpm",
+        "checksum": "sha256:2324289e2fa73baaa2d28b12b6a7f523ef5ef6c956bfa84ef8c0b4da866d3592",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "20.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.x86_64.rpm",
+        "checksum": "sha256:8a510e37acc96dc2462243ea530ba77ed2e6b16964b0737c4f9fa883ff36aa07",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.5.4",
+        "release": "2.rc3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.x86_64.rpm",
+        "checksum": "sha256:2e76f51592fe919f3583063e9548c665d2cd0688f5abe3e3d9eb2711271d5d6c",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnftnl-1.2.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:086e4f8ca49ea270b2e8b12ef81b7b33815e614e5ad9a99cd28fecae864904ec",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.x86_64.rpm",
+        "checksum": "sha256:2a1a1b20558b7fabf55512347ee7404a48c90562bbce8375ecaacc2bc4562e56",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:38be4bfe2b3d381d0253cdd39e163ad02f17735b25dd78bf4cc6c48d0b3f4a1b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.x86_64.rpm",
+        "checksum": "sha256:596cc0621aeca6e0432894236d28fb2685b9fb01edb6a3369dcea06a02440f10",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
+        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm",
+        "checksum": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm",
+        "checksum": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm",
+        "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:c04936fcd9ceb64a2ebc037d476b2d713f563d03bb6e1017e3f72bf5e983fecb",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm",
+        "checksum": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.x86_64.rpm",
+        "checksum": "sha256:1a57f5ae44250b9eb783efe030fb1b9b4907bb4344badef62a6a461ceeb6f8e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:7ac6af3c01c31e098d4a0bc786bb9b0ae6c854a5d37f32b2b5b4de442b4f4fe0",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
+        "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.x86_64.rpm",
+        "checksum": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.x86_64.rpm",
+        "checksum": "sha256:50c54584c8a1a34ff2d5f8edda843c5344dff6ad179e5392bd2efafc95cd4b0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm",
+        "checksum": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm",
+        "checksum": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.x86_64.rpm",
+        "checksum": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.x86_64.rpm",
+        "checksum": "sha256:7219d267c71b81586418726d9a8b395b29c4051f48b99b2d4c425788ce6f0e73",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d187b43a783c72bb0f6b9c9372d4ed8f9555a70476a5bc5bb1cb0e0c3f75eb98",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
+        "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs78",
+        "epoch": 0,
+        "version": "78.15.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:d16f8f8e8bcddba1941542ba7c54cb166028fc262ad349289d31ebba188a2e9f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nftables-1.0.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:011444abd567c69e6fc589e7d74c883ae0749df41b6c3c460b97292bc5fe69ad",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/npth-1.6-7.fc35.x86_64.rpm",
+        "checksum": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm",
+        "checksum": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm",
+        "checksum": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm",
+        "checksum": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm",
+        "checksum": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/parted-3.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:94b669b65c5a7ac7c4957ad7c9efb982e65ee0b22f1ae844f78837ab823ca69c",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.x86_64.rpm",
+        "checksum": "sha256:a8fc6c3a5bce70d7f68e328a69533da48f80e4df1587ffdfac58cf7f60563c66",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm",
+        "checksum": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/plymouth-0.9.5-3.20210331git1ea1020.fc35.x86_64.rpm",
+        "checksum": "sha256:90b4501a932693c1bed585b809ab15dca10edf4ecd0eadb34663ddba04ce89af",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/plymouth-core-libs-0.9.5-3.20210331git1ea1020.fc35.x86_64.rpm",
+        "checksum": "sha256:c2bf24657611e4f1e988e55b24904d60abff918981e7cd1772bce29b116ab274",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/plymouth-scripts-0.9.5-3.20210331git1ea1020.fc35.x86_64.rpm",
+        "checksum": "sha256:022cf3dbbd9dd9d3362c0bc6a42ea219c29abe1b22bcaf0972943b73abfa0550",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "20.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.x86_64.rpm",
+        "checksum": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm",
+        "checksum": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
+        "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9fe58a0ba8b3b641d0d568a00ddc9ffd6a3ea18deaa80a65762f845bb888513c",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "7.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm",
+        "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f639f8c74dea5304f5afa5ca359c3935e8ba93165d342b52327960d98b912633",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-firewall-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-gobject-base-3.42.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:f693a388244b30744d1c219b26e00f5044c8f5e396a2a2dd3ce35864e646fe30",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm",
+        "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-nftables-1.0.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6271b15b3b82e339216dec104060b6aac4a635c71ecc2517897684f021af3115",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "30.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm",
+        "checksum": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm",
+        "checksum": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:b5a1fe4789e8fde6873b432cd3a6dfb1e3025245beaf89e62e37fd23e169639a",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ba47f541e53846685c1033028452e4ba9da122ffa10e0765e5576c667e99ab21",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm",
+        "checksum": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm",
+        "checksum": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.x86_64.rpm",
+        "checksum": "sha256:01feeac42a5067e0d93d26be4fdfbb9e6b98a0199308e5c6fcca3190ad3083ab",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.x86_64.rpm",
+        "checksum": "sha256:7ba84d10050c41fa26eb2602057e234cd7554dafa68529bedc5c51ce15d93182",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-config-rescue-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:b1163282c68d42bed61523230431dc06e97c630f6f1e694e2f39bd1b53de5b00",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.70.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:3527a0a6349dd42551b08da5574c4dd993f593b1f2ad8253240aa82834004680",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.x86_64.rpm",
+        "checksum": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:9ecb8e5c854c5627dab136cb5731ef6c073400d6deb81dfd24a6a44bd0b9ad4a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:8ce8dfdbfce7c27275408198827f17889b22f3c0597e3b64548542cf8af4327d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:18c9bc1629e34ba5328184a29314c7e751177731fdcbc98371f4587f97fe399b",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/less-590-2.fc35.x86_64.rpm",
+        "checksum": "sha256:460008c60bfe5ef76c671949906ec6028ad3e883f829ee071215baaf4505935d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-python3-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:70d7f22b24741ce3a874646f46e111fc6f450433da2e50a4721a686891c2c36b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm",
+        "checksum": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2816abc40eb06525f3e48664243708e4fd648bc40a22d04d3c3fc4653a05beb7",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b1914e9500f619aa12834d3018d5c53556b15f8fa801948850ad38f8ec9b223d",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1c0981c43460e63693f80bb15559d5016ce11d3d445e4fc69c61ab61a61deae8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b99b28317bf01d270af6da14b5cb755e492708e034f10d46fa872c82113e1659",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2382a1df3dc5a598eb3b2dd09995ca1964010af291265c965b7fc2906a98084b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:fb08e2d2a145964c84ada417b579b7deb8bf917fb15d4d69df33755a7e7b5ac1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b492545e958e49bb04288536508b249396e691d7d47c1f322c31af050f57f367",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:97caa631cd7385314bc217c2a910faeb3b1ccf89cee700ae62671a6a12e2a107",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-atm-libs",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.x86_64.rpm",
+        "checksum": "sha256:b07af17dcbf638dc969aa55572e0fb300583a87b4c2ef755f359e4d7c1a91f4f",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:c8a4fc5b29a5f55805fd9b0d51817ab39ca26a5a12b25e7fd2a1b670a33048c4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:7f95f92e23d855ce83b3740e5a7888bb0a4b35cf70b68b3e66ce847f09e0a131",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9b3871c88738f18840741a1654a164574e72ed1c9cbf405fa6da5a84cb6a4abe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.x86_64.rpm",
+        "checksum": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.4.36",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm",
+        "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a2ebffa755a9962dd761fb7984d48f5240e9e9cfcf9c22e913c4487b8dffdfdb",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:fa8c4d43af9adcb7230cc38180381bb01ebc97fb8ce31834c3fde3cb34849bae",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:874779944e2f10107b64356e3797733051d043bc683bf79cda3425e106bd8ea1",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:f28b0afa37f734b359f898180566e82ce63bd508b153bb28fb47f179f6b1338c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm",
+        "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm",
+        "checksum": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c34b4c7349367ad9ec44d4858eb989b916fb118acdec4f07ae1506b257918bd2",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/z/zram-generator-1.1.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:c318ea2de3bcf9f76bb541eb62fdd38640906d4691f87f3d6a6cc6452e1b973c",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/z/zram-generator-defaults-1.1.1-3.fc35.noarch.rpm",
+        "checksum": "sha256:6acdd7238cecc7a50fa0a4c334550a1ff1d2b4984ae25be711322bef8f773a0d",
+        "check_gpg": true
+      }
+    ],
     "build-packages": [
       {
         "name": "acl",

--- a/test/data/manifests/fedora_35-x86_64-vhd-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-vhd-boot.json
@@ -3472,6 +3472,1718 @@
     }
   },
   "rpmmd": {
+    "blueprint": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm",
+        "checksum": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm",
+        "checksum": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
+        "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm",
+        "checksum": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm",
+        "checksum": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm",
+        "checksum": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
+        "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm",
+        "checksum": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm",
+        "checksum": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm",
+        "checksum": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm",
+        "checksum": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm",
+        "checksum": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm",
+        "checksum": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm",
+        "checksum": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
+        "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm",
+        "checksum": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm",
+        "checksum": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
+        "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm",
+        "checksum": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm",
+        "checksum": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm",
+        "checksum": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm",
+        "checksum": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm",
+        "checksum": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm",
+        "checksum": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
+        "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm",
+        "checksum": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm",
+        "checksum": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm",
+        "checksum": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:9ecb8e5c854c5627dab136cb5731ef6c073400d6deb81dfd24a6a44bd0b9ad4a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:8ce8dfdbfce7c27275408198827f17889b22f3c0597e3b64548542cf8af4327d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:18c9bc1629e34ba5328184a29314c7e751177731fdcbc98371f4587f97fe399b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm",
+        "checksum": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
     "build-packages": [
       {
         "name": "acl",

--- a/test/data/manifests/fedora_35-x86_64-vmdk-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-vmdk-boot.json
@@ -3745,6 +3745,1718 @@
     }
   },
   "rpmmd": {
+    "blueprint": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm",
+        "checksum": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm",
+        "checksum": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
+        "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm",
+        "checksum": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm",
+        "checksum": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm",
+        "checksum": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
+        "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm",
+        "checksum": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm",
+        "checksum": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm",
+        "checksum": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm",
+        "checksum": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm",
+        "checksum": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm",
+        "checksum": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm",
+        "checksum": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
+        "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm",
+        "checksum": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm",
+        "checksum": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
+        "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm",
+        "checksum": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm",
+        "checksum": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm",
+        "checksum": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm",
+        "checksum": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm",
+        "checksum": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm",
+        "checksum": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
+        "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm",
+        "checksum": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm",
+        "checksum": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm",
+        "checksum": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:9ecb8e5c854c5627dab136cb5731ef6c073400d6deb81dfd24a6a44bd0b9ad4a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:8ce8dfdbfce7c27275408198827f17889b22f3c0597e3b64548542cf8af4327d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:18c9bc1629e34ba5328184a29314c7e751177731fdcbc98371f4587f97fe399b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm",
+        "checksum": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
     "build-packages": [
       {
         "name": "acl",

--- a/tools/test-case-generators/distro-arch-imagetype-map.json
+++ b/tools/test-case-generators/distro-arch-imagetype-map.json
@@ -28,6 +28,7 @@
         ],
         "aarch64": [
             "ami",
+            "fedora-iot-commit",
             "openstack",
             "qcow2",
             "oci"

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -171,7 +171,10 @@
         }
       }
     },
-    "overrides": {}
+    "overrides": {},
+    "supported_arches": [
+      "x86_64"
+    ]
   },
   "openstack": {
     "boot": {


### PR DESCRIPTION
This pull request includes:

- [X] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
- [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

This PR adds the `fedora-iot-commit` for aarch64 in fedora. As part of the effort to include the new type, the code has been refactored to align with the existing design in the RHEL distributions, mainly the usage of a `map[string]rmmd.PackageSet` structure to store the different packages (build and OS packages) before merging them into a single list for Included and Excluded.

The list of packages align with the ones listed here:
https://pagure.io/fedora-iot/ostree/blob/1c0a8aa02f10e1a9b2a8c9802d8bd7028fca5752/f/fedora-iot-base.json

@gicmo @achilleas-k can you take a look when you have some spare time? I'd like to hear your input on this. 
