### PR TITLE
templates/packer: Remove -u flag from creds mapping script

### DIFF
--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_external_creds.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_external_creds.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 source /tmp/cloud_init_vars
 
 echo "Deploy cloud credentials for workers."


### PR DESCRIPTION
We test if specific variables are set, and -u interferes with that.

