### PR TITLE
weldr: Run on unsupported distros

### DIFF
--- a/internal/reporegistry/reporegistry.go
+++ b/internal/reporegistry/reporegistry.go
@@ -76,17 +76,6 @@ func (r *RepoRegistry) reposByImageTypeName(distro, arch, imageType string) ([]r
 	return repositories, nil
 }
 
-// ReposByArch returns a slice of rpmmd.RepoConfig instances, which should be used for building image types for the
-// specific architecture. This includes by default all repositories without any image type tags specified.
-// Depending on the `includeTagged` argument value, repositories with image type tags set will be added to the returned
-// slice or not.
-func (r *RepoRegistry) ReposByArch(arch distro.Arch, includeTagged bool) ([]rpmmd.RepoConfig, error) {
-	if arch.Distro() == nil || reflect.ValueOf(arch.Distro()).IsNil() {
-		return nil, fmt.Errorf("there is no distribution associated with the provided architecture")
-	}
-	return r.ReposByArchName(arch.Distro().Name(), arch.Name(), includeTagged)
-}
-
 // reposByArchName returns a slice of rpmmd.RepoConfig instances, which should be used for building image types for the
 // specific architecture and distribution. This includes by default all repositories without any image type tags specified.
 // Depending on the `includeTagged` argument value, repositories with image type tags set will be added to the returned

--- a/internal/reporegistry/reporegistry_test.go
+++ b/internal/reporegistry/reporegistry_test.go
@@ -277,21 +277,9 @@ func TestReposByArch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := rr.ReposByArch(tt.args.arch, tt.args.taggedRepos)
+			got, err := rr.ReposByArchName(tt.args.arch.Distro().Name(), tt.args.arch.Name(), tt.args.taggedRepos)
 			assert.Nil(t, err)
-
-			var gotNames []string
-			for _, r := range got {
-				gotNames = append(gotNames, r.Name)
-			}
-
-			if !reflect.DeepEqual(gotNames, tt.want) {
-				t.Errorf("ReposByArch() =\n got: %#v\n want: %#v", gotNames, tt.want)
-			}
-
-			got, err = rr.ReposByArchName(tt.args.arch.Distro().Name(), tt.args.arch.Name(), tt.args.taggedRepos)
-			assert.Nil(t, err)
-			gotNames = []string{}
+			gotNames := []string{}
 			for _, r := range got {
 				gotNames = append(gotNames, r.Name)
 			}
@@ -309,12 +297,13 @@ func TestInvalidReposByArch(t *testing.T) {
 	rr := getTestingRepoRegistry()
 
 	ta := test_distro.TestArch{}
+	td := test_distro.TestDistro{}
 
-	repos, err := rr.ReposByArch(&ta, false)
+	repos, err := rr.ReposByArchName(td.Name(), ta.Name(), false)
 	assert.Nil(t, repos)
 	assert.NotNil(t, err)
 
-	repos, err = rr.ReposByArch(&ta, true)
+	repos, err = rr.ReposByArchName(td.Name(), ta.Name(), false)
 	assert.Nil(t, repos)
 	assert.NotNil(t, err)
 }

--- a/internal/store/json.go
+++ b/internal/store/json.go
@@ -378,6 +378,9 @@ func imageTypeToCompatString(imgType distro.ImageType) string {
 }
 
 func imageTypeFromCompatString(input string, arch distro.Arch) distro.ImageType {
+	if arch == nil {
+		return nil
+	}
 	for k, v := range imageTypeCompatMapping {
 		if v == input {
 			imgType, err := arch.GetImageType(k)


### PR DESCRIPTION
Added a new distro definition which acts as a fallback for when the host distro is not supported.  The distribution supports all known architectures, but doesn't specify any image types.  This makes osbuild-composer capable of running on unknown distros for cross-distro building.

Tested on Arch Linux:
```
❯ cat /etc/os-release
NAME="Arch Linux"
PRETTY_NAME="Arch Linux"
ID=arch
BUILD_ID=rolling
ANSI_COLOR="38;2;23;147;209"
HOME_URL="https://archlinux.org/"
DOCUMENTATION_URL="https://wiki.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://bugs.archlinux.org/"
LOGO=archlinux-logo

❯ composer-cli status show
API server status:
    Database version:   0
    Database supported: true
    Schema version:     0
    API version:        1
    Backend:            osbuild-composer
    Build:              devel

❯ composer-cli compose types
ERROR: DistroError: Unknown distribution: [unknown]
```

And a CS9 VM with a modified `/etc/os-release`:
```
$ cat /etc/os-release
NAME="CentOS Stream"
VERSION="10"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="10"
PLATFORM_ID="platform:el9"
PRETTY_NAME="CentOS Stream 9"
ANSI_COLOR="0;31"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:centos:centos:9"
HOME_URL="https://centos.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux 9"
REDHAT_SUPPORT_PRODUCT_VERSION="CentOS Stream"

$ composer-cli status show
API server status:
    Database version:   0
    Database supported: true
    Schema version:     0
    API version:        1
    Backend:            osbuild-composer
    Build:              devel

$ composer-cli compose types
ERROR: DistroError: Unknown distribution: [unknown]
```

Sample journal log from VM:
```
Mar 07 19:03:15 centos9-unknownver-vm osbuild-composer[31188]: 2022/03/07 19:03:15 Failed to load subscriptions. osbuild-composer will fail to build images if the configured repositories require them: no matching key and certificate pair
Mar 07 19:03:15 centos9-unknownver-vm osbuild-composer[31188]: 2022/03/07 19:03:15 host distro "centos-10" is not supported: only cross-distro builds are available
Mar 07 19:03:15 centos9-unknownver-vm osbuild-composer[31188]: 2022/03/07 19:03:15 Loaded repository configuration file: /etc/osbuild-composer/repositories/centos-8.json
...
Mar 07 19:03:15 centos9-unknownver-vm osbuild-composer[31188]: 2022/03/07 19:03:15 loaded repository definitions don't contain any for the host distro/arch: there are no repositories for distribution '[unknown]' and architecture 'x86_64'
```