### PR TITLE
🍏  Make CI green again

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -473,8 +473,9 @@ Installer:
     matrix:
       - RUNNER:
           - rhos-01/rhel-8.6-nightly-x86_64
-          - rhos-01/rhel-9.0-nightly-x86_64
-          - rhos-01/centos-stream-9-x86_64
+          # disable until https://bugzilla.redhat.com/show_bug.cgi?id=2059565 is fixed
+          #- rhos-01/rhel-9.0-nightly-x86_64
+          #- rhos-01/centos-stream-9-x86_64
 
 SCHEDULED_CLOUD_CLEANER:
   stage: cleanup


### PR DESCRIPTION
Temporarily disable Installer test case in the CI on RHEL-9 and CentOS
Stream 9 until https://bugzilla.redhat.com/show_bug.cgi?id=2059565 is
resolved. This test case is now consistently failing due to the
mentioned bug and makes it impossible for the CI to pass cleanly.

Signed-off-by: Tomas Hozza <thozza@redhat.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
