### PR TITLE
use app-sre packer image

### DIFF
--- a/distribution/Dockerfile-ubi-packer
+++ b/distribution/Dockerfile-ubi-packer
@@ -1,13 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-
-RUN curl --location --output /etc/yum.repos.d/hashicorp.repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
-RUN microdnf install packer jq openssh-clients unzip rsync python3 rust cargo gcc python3-devel openssl-devel
-RUN pip3 install setuptools-rust
-RUN pip3 install ansible
-RUN ansible-galaxy collection install ansible.posix
-RUN curl https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip -o /tmp/awscli.zip
-RUN unzip /tmp/awscli.zip
-RUN aws/install
+FROM quay.io/app-sre/packer:latest
 
 # copy in entire workspace
 COPY . /osbuild-composer


### PR DESCRIPTION
Use app-sre packer image as base image, help to reduce packer build job running time.

https://github.com/app-sre/container-images/blob/master/packer/Dockerfile

Signed-off-by: Feng Huang <fehuang@redhat.com>