### PR TITLE
github workflows: modify Gitlab CI trigger

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,3 +136,17 @@ jobs:
 
       - name: Run rpmlint
         run: rpmlint rpmbuild/SRPMS/*
+
+  gitlab-ci-helper:
+    name: "Gitlab CI trigger helper"
+    runs-on: ubuntu-latest
+    env:
+      SKIP_CI: ${{ (github.event.pull_request.draft == true || contains(github.event.pull_request.labels.*.name, 'WIP')) && !contains(github.event.pull_request.labels.*.name, 'WIP+test') }}
+    steps:
+      - name: Write PR status
+        run: echo "$SKIP_CI" > SKIP_CI.txt
+      - name: Upload status
+        uses: actions/upload-artifact@v3
+        with:
+          name: PR_STATUS
+          path: SKIP_CI.txt

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SCHUTZBOT_SSH_KEY: ${{ secrets.SCHUTZBOT_SSH_KEY }}
-      SKIP_CI: ${{ (github.event.pull_request.draft == true || contains(github.event.pull_request.labels.*.name, 'WIP')) && !contains(github.event.pull_request.labels.*.name, 'WIP+test') }}
     steps:
       - name: Report status
         uses: haya14busa/action-workflow_run-status@v1
@@ -51,6 +50,30 @@ jobs:
             git checkout ${{ github.event.workflow_run.head_branch }}
           fi
 
+      - name: Download artifacts
+        uses: actions/github-script@v5
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "PR_STATUS"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/PR_STATUS.zip`, Buffer.from(download.data));
+
+      - name: Unzip artifact
+        run: unzip PR_STATUS.zip
+
       - name: Push to gitlab
         run: |
           mkdir -p ~/.ssh
@@ -59,5 +82,6 @@ jobs:
           touch ~/.ssh/known_hosts
           ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
           git remote add ci git@gitlab.com:osbuild/ci/osbuild-composer.git
+          SKIP_CI=$(cat SKIP_CI.txt)
           [[ "${SKIP_CI}" == true ]] && PUSH_OPTION='-o ci.variable="SKIP_CI=true"' || PUSH_OPTION=""
           git push -f ${PUSH_OPTION} ci


### PR DESCRIPTION
In 5e639cba6f0a3ea34f8db83b212e23c36674e6a3 the context of the Trigger
Gitalb CI workflow changed and the context
"github.event.pull_request.draft" is no longer available so the
condition for SKIP_CI didn't work. This can be fixed by getting the
variable in the previous workflow and passin it as artifact. Docs:
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow

I've tested this quite a bit in a separate repo https://github.com/jrusz/test-actions/actions and I'm fairly confident this will work. 

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
