### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -5,9 +5,7 @@
 package main
 
 import (
-	"io/ioutil"
 	"net/http"
-	"os"
 	"path"
 	"testing"
 
@@ -63,9 +61,7 @@ func TestCrossArchDepsolve(t *testing.T) {
 			t.Parallel()
 
 			// Set up temporary directory for rpm/dnf cache
-			dir, err := ioutil.TempDir("/tmp", "rpmmd-test-")
-			require.Nilf(t, err, "Failed to create tmp dir for depsolve test: %v", err)
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			// use a fullpath to dnf-json, this allows this test to have an arbitrary
 			// working directory

--- a/internal/cloudapi/v2/v2_koji_test.go
+++ b/internal/cloudapi/v2/v2_koji_test.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
@@ -28,10 +26,7 @@ type jobResult struct {
 }
 
 func TestKojiCompose(t *testing.T) {
-	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	kojiServer, workerServer, _, cancel := newV2Server(t, dir, []string{""}, false)
+	kojiServer, workerServer, _, cancel := newV2Server(t, t.TempDir(), []string{""}, false)
 	handler := kojiServer.Handler("/api/image-builder-composer/v2")
 	workerHandler := workerServer.Handler()
 	defer cancel()
@@ -461,10 +456,7 @@ func TestKojiCompose(t *testing.T) {
 }
 
 func TestKojiRequest(t *testing.T) {
-	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	server, _, _, cancel := newV2Server(t, dir, []string{""}, false)
+	server, _, _, cancel := newV2Server(t, t.TempDir(), []string{""}, false)
 	handler := server.Handler("/api/image-builder-composer/v2")
 	defer cancel()
 
@@ -476,7 +468,7 @@ func TestKojiRequest(t *testing.T) {
 	resp := rec.Result()
 
 	var status api.Status
-	err = json.NewDecoder(resp.Body).Decode(&status)
+	err := json.NewDecoder(resp.Body).Decode(&status)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 
@@ -493,10 +485,7 @@ func TestKojiRequest(t *testing.T) {
 }
 
 func TestKojiJobTypeValidation(t *testing.T) {
-	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	server, workers, _, cancel := newV2Server(t, dir, []string{""}, false)
+	server, workers, _, cancel := newV2Server(t, t.TempDir(), []string{""}, false)
 	handler := server.Handler("/api/image-builder-composer/v2")
 	defer cancel()
 

--- a/internal/cloudapi/v2/v2_multi_tenancy_test.go
+++ b/internal/cloudapi/v2/v2_multi_tenancy_test.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
-	"os"
 	"testing"
 	"time"
 
@@ -191,13 +189,9 @@ func runNextJob(t *testing.T, jobs []uuid.UUID, workerHandler http.Handler, orgI
 // that all jobs are assigned to the correct channel, therefore we need also
 // this test.
 func TestMultitenancy(t *testing.T) {
-	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
 	// Passing an empty list as depsolving channels, we want to do depsolves
 	// ourselvess
-	apiServer, workerServer, q, cancel := newV2Server(t, dir, []string{}, true)
+	apiServer, workerServer, q, cancel := newV2Server(t, t.TempDir(), []string{}, true)
 	handler := apiServer.Handler("/api/image-builder-composer/v2")
 	defer cancel()
 

--- a/internal/cloudapi/v2/v2_test.go
+++ b/internal/cloudapi/v2/v2_test.go
@@ -45,7 +45,12 @@ func newV2Server(t *testing.T, dir string, depsolveChannels []string, enableJWT 
 	depsolveContext, cancel := context.WithCancel(context.Background())
 	go func() {
 		for {
-			_, token, _, _, _, err := workerServer.RequestJob(context.Background(), test_distro.TestDistroName, []string{"depsolve"}, depsolveChannels)
+			_, token, _, _, _, err := workerServer.RequestJob(depsolveContext, test_distro.TestDistroName, []string{"depsolve"}, depsolveChannels)
+			select {
+			case <-depsolveContext.Done():
+				return
+			default:
+			}
 			if err != nil {
 				continue
 			}

--- a/internal/cloudapi/v2/v2_test.go
+++ b/internal/cloudapi/v2/v2_test.go
@@ -69,10 +69,7 @@ func newV2Server(t *testing.T, dir string, depsolveChannels []string, enableJWT 
 }
 
 func TestUnknownRoute(t *testing.T) {
-	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	srv, _, _, cancel := newV2Server(t, dir, []string{""}, false)
+	srv, _, _, cancel := newV2Server(t, t.TempDir(), []string{""}, false)
 	defer cancel()
 
 	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "GET", "/api/image-builder-composer/v2/badroute", ``, http.StatusNotFound, `
@@ -86,10 +83,7 @@ func TestUnknownRoute(t *testing.T) {
 }
 
 func TestGetError(t *testing.T) {
-	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	srv, _, _, cancel := newV2Server(t, dir, []string{""}, false)
+	srv, _, _, cancel := newV2Server(t, t.TempDir(), []string{""}, false)
 	defer cancel()
 
 	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "GET", "/api/image-builder-composer/v2/errors/4", ``, http.StatusOK, `
@@ -112,10 +106,7 @@ func TestGetError(t *testing.T) {
 }
 
 func TestGetErrorList(t *testing.T) {
-	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	srv, _, _, cancel := newV2Server(t, dir, []string{""}, false)
+	srv, _, _, cancel := newV2Server(t, t.TempDir(), []string{""}, false)
 	defer cancel()
 
 	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "GET", "/api/image-builder-composer/v2/errors?page=3&size=1", ``, http.StatusOK, `
@@ -134,6 +125,7 @@ func TestGetErrorList(t *testing.T) {
 }
 
 func TestCompose(t *testing.T) {
+	// Test is flaky if we use t.TempDir()
 	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -555,10 +547,7 @@ func TestCompose(t *testing.T) {
 }
 
 func TestComposeStatusSuccess(t *testing.T) {
-	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	srv, wrksrv, _, cancel := newV2Server(t, dir, []string{""}, false)
+	srv, wrksrv, _, cancel := newV2Server(t, t.TempDir(), []string{""}, false)
 	defer cancel()
 
 	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "POST", "/api/image-builder-composer/v2/compose", fmt.Sprintf(`
@@ -628,10 +617,7 @@ func TestComposeStatusSuccess(t *testing.T) {
 }
 
 func TestComposeStatusFailure(t *testing.T) {
-	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	srv, wrksrv, _, cancel := newV2Server(t, dir, []string{""}, false)
+	srv, wrksrv, _, cancel := newV2Server(t, t.TempDir(), []string{""}, false)
 	defer cancel()
 
 	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "POST", "/api/image-builder-composer/v2/compose", fmt.Sprintf(`
@@ -687,10 +673,7 @@ func TestComposeStatusFailure(t *testing.T) {
 }
 
 func TestComposeLegacyError(t *testing.T) {
-	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	srv, wrksrv, _, cancel := newV2Server(t, dir, []string{""}, false)
+	srv, wrksrv, _, cancel := newV2Server(t, t.TempDir(), []string{""}, false)
 	defer cancel()
 
 	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "POST", "/api/image-builder-composer/v2/compose", fmt.Sprintf(`
@@ -749,10 +732,7 @@ func TestComposeLegacyError(t *testing.T) {
 }
 
 func TestComposeJobError(t *testing.T) {
-	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	srv, wrksrv, _, cancel := newV2Server(t, dir, []string{""}, false)
+	srv, wrksrv, _, cancel := newV2Server(t, t.TempDir(), []string{""}, false)
 	defer cancel()
 
 	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "POST", "/api/image-builder-composer/v2/compose", fmt.Sprintf(`
@@ -814,6 +794,7 @@ func TestComposeJobError(t *testing.T) {
 }
 
 func TestComposeCustomizations(t *testing.T) {
+	// Test is flaky if we use t.TempDir()
 	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -863,6 +844,7 @@ func TestComposeCustomizations(t *testing.T) {
 }
 
 func TestImageTypes(t *testing.T) {
+	// Test is flaky if we use t.TempDir()
 	dir, err := ioutil.TempDir("", "osbuild-composer-test-api-v2-")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)

--- a/internal/jobqueue/fsjobqueue/fsjobqueue_test.go
+++ b/internal/jobqueue/fsjobqueue/fsjobqueue_test.go
@@ -1,8 +1,6 @@
 package fsjobqueue_test
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,16 +12,12 @@ import (
 
 func TestJobQueueInterface(t *testing.T) {
 	jobqueuetest.TestJobQueue(t, func() (jobqueue.JobQueue, func(), error) {
-		dir, err := ioutil.TempDir("", "jobqueue-test-")
-		if err != nil {
-			return nil, nil, err
-		}
+		dir := t.TempDir()
 		q, err := fsjobqueue.New(dir)
 		if err != nil {
 			return nil, nil, err
 		}
 		stop := func() {
-			_ = os.RemoveAll(dir)
 		}
 		return q, stop, nil
 	})

--- a/internal/jsondb/db_private_test.go
+++ b/internal/jsondb/db_private_test.go
@@ -11,13 +11,7 @@ import (
 )
 
 func TestWriteFileAtomically(t *testing.T) {
-	dir, err := ioutil.TempDir("", "jsondb-test-")
-	require.NoError(t, err)
-
-	defer func() {
-		err := os.RemoveAll(dir)
-		require.NoError(t, err)
-	}()
+	dir := t.TempDir()
 
 	t.Run("success", func(t *testing.T) {
 		octopus := []byte("🐙\n")
@@ -25,7 +19,7 @@ func TestWriteFileAtomically(t *testing.T) {
 		// use an uncommon mode to check it's set correctly
 		perm := os.FileMode(0750)
 
-		err = writeFileAtomically(dir, "octopus", perm, func(f *os.File) error {
+		err := writeFileAtomically(dir, "octopus", perm, func(f *os.File) error {
 			_, err := f.Write(octopus)
 			return err
 		})
@@ -48,12 +42,12 @@ func TestWriteFileAtomically(t *testing.T) {
 	})
 
 	t.Run("error", func(t *testing.T) {
-		err = writeFileAtomically(dir, "no-octopus", 0750, func(f *os.File) error {
+		err := writeFileAtomically(dir, "no-octopus", 0750, func(f *os.File) error {
 			return errors.New("something went wrong")
 		})
 		require.Error(t, err)
 
-		_, err := os.Stat(path.Join(dir, "no-octopus"))
+		_, err = os.Stat(path.Join(dir, "no-octopus"))
 		require.Error(t, err)
 
 		// ensure there are no stray temporary files

--- a/internal/jsondb/db_test.go
+++ b/internal/jsondb/db_test.go
@@ -17,11 +17,6 @@ type document struct {
 	CanSwim bool   `json:"can-swim"`
 }
 
-func cleanupTempDir(t *testing.T, dir string) {
-	err := os.RemoveAll(dir)
-	require.NoError(t, err)
-}
-
 // If the passed directory is not readable (writable), we should notice on the
 // first read (write).
 func TestDegenerate(t *testing.T) {
@@ -42,14 +37,12 @@ func TestDegenerate(t *testing.T) {
 	})
 
 	t.Run("invalid-json", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "jsondb-test-")
-		require.NoError(t, err)
-		defer cleanupTempDir(t, dir)
+		dir := t.TempDir()
 
 		db := jsondb.New(dir, 0755)
 
 		// write-only file
-		err = ioutil.WriteFile(path.Join(dir, "one.json"), []byte("{"), 0600)
+		err := ioutil.WriteFile(path.Join(dir, "one.json"), []byte("{"), 0600)
 		require.NoError(t, err)
 
 		var d document
@@ -59,11 +52,9 @@ func TestDegenerate(t *testing.T) {
 }
 
 func TestCorrupt(t *testing.T) {
-	dir, err := ioutil.TempDir("", "jsondb-test-")
-	require.NoError(t, err)
-	defer cleanupTempDir(t, dir)
+	dir := t.TempDir()
 
-	err = ioutil.WriteFile(path.Join(dir, "one.json"), []byte("{"), 0600)
+	err := ioutil.WriteFile(path.Join(dir, "one.json"), []byte("{"), 0600)
 	require.NoError(t, err)
 
 	db := jsondb.New(dir, 0755)
@@ -73,11 +64,9 @@ func TestCorrupt(t *testing.T) {
 }
 
 func TestRead(t *testing.T) {
-	dir, err := ioutil.TempDir("", "jsondb-test-")
-	require.NoError(t, err)
-	defer cleanupTempDir(t, dir)
+	dir := t.TempDir()
 
-	err = ioutil.WriteFile(path.Join(dir, "one.json"), []byte("true"), 0600)
+	err := ioutil.WriteFile(path.Join(dir, "one.json"), []byte("true"), 0600)
 	require.NoError(t, err)
 
 	db := jsondb.New(dir, 0755)
@@ -106,9 +95,7 @@ func TestRead(t *testing.T) {
 }
 
 func TestMultiple(t *testing.T) {
-	dir, err := ioutil.TempDir("", "jsondb-test-")
-	require.NoError(t, err)
-	defer cleanupTempDir(t, dir)
+	dir := t.TempDir()
 
 	perm := os.FileMode(0600)
 	documents := map[string]document{
@@ -120,7 +107,7 @@ func TestMultiple(t *testing.T) {
 	db := jsondb.New(dir, perm)
 
 	for name, doc := range documents {
-		err = db.Write(name, doc)
+		err := db.Write(name, doc)
 		require.NoError(t, err)
 	}
 	names, err := db.List()

--- a/internal/kojiapi/server_test.go
+++ b/internal/kojiapi/server_test.go
@@ -4,11 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -43,13 +40,7 @@ func newTestKojiServer(t *testing.T, dir string) (*kojiapi.Server, *worker.Serve
 }
 
 func TestStatus(t *testing.T) {
-	dir, err := ioutil.TempDir("", "osbuild-composer-test-kojiapi-")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	kojiServer, _ := newTestKojiServer(t, dir)
+	kojiServer, _ := newTestKojiServer(t, t.TempDir())
 	handler := kojiServer.Handler("/api/composer-koji/v1")
 	test.TestRoute(t, handler, false, "GET", "/api/composer-koji/v1/status", ``, http.StatusOK, `{"status":"OK"}`, "message")
 }
@@ -59,13 +50,7 @@ type jobResult struct {
 }
 
 func TestCompose(t *testing.T) {
-	dir, err := ioutil.TempDir("", "osbuild-composer-test-kojiapi-")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	kojiServer, workerServer := newTestKojiServer(t, dir)
+	kojiServer, workerServer := newTestKojiServer(t, t.TempDir())
 	handler := kojiServer.Handler("/api/composer-koji/v1")
 	workerHandler := workerServer.Handler()
 
@@ -455,13 +440,7 @@ func TestCompose(t *testing.T) {
 }
 
 func TestRequest(t *testing.T) {
-	dir, err := ioutil.TempDir("", "osbuild-composer-test-kojiapi-")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	server, _ := newTestKojiServer(t, dir)
+	server, _ := newTestKojiServer(t, t.TempDir())
 	handler := server.Handler("/api/composer-koji/v1")
 
 	// Make request to an invalid route
@@ -472,7 +451,7 @@ func TestRequest(t *testing.T) {
 	resp := rec.Result()
 
 	var status api.Status
-	err = json.NewDecoder(resp.Body).Decode(&status)
+	err := json.NewDecoder(resp.Body).Decode(&status)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 
@@ -489,11 +468,7 @@ func TestRequest(t *testing.T) {
 }
 
 func TestJobTypeValidation(t *testing.T) {
-	dir, err := ioutil.TempDir("", "osbuild-composer-test-kojiapi-")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	server, workers := newTestKojiServer(t, dir)
 	handler := server.Handler("/api/composer-koji/v1")

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,8 +1,6 @@
 package store
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -112,18 +110,11 @@ func (suite *storeTest) SetupSuite() {
 
 //setup before each test
 func (suite *storeTest) SetupTest() {
-	tmpDir, err := ioutil.TempDir("/tmp", "osbuild-composer-test-")
-	suite.NoError(err)
 	distro := test_distro.New()
 	arch, err := distro.GetArch(test_distro.TestArchName)
 	suite.NoError(err)
-	suite.dir = tmpDir
+	suite.dir = suite.T().TempDir()
 	suite.myStore = New(&suite.dir, arch, nil)
-}
-
-//teardown after each test
-func (suite *storeTest) TearDownTest() {
-	os.RemoveAll(suite.dir)
 }
 
 func (suite *storeTest) TestRandomSHA1String() {

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -125,11 +125,7 @@ func TestBasic(t *testing.T) {
 		{"/api/v1/compose/types?distro=fedora-1", http.StatusBadRequest, `{"status":false,"errors":[{"id":"DistroError","msg":"Invalid distro: fedora-1"}]}`},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-
-	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
+	api, _ := createWeldrAPI(t.TempDir(), rpmmd_mock.BaseFixture)
 	for _, c := range cases {
 		test.TestRoute(t, api, true, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)
 	}
@@ -153,9 +149,7 @@ func TestBlueprintsNew(t *testing.T) {
 		{"POST", "/api/v0/blueprints/new", `{"name":"test","description":"Test","distro":"fedora-1","packages":[],"version":""}`, http.StatusBadRequest, `{"status":false,"errors":[{"id":"BlueprintsError","msg":"'fedora-1' is not a valid distribution"}]}`},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
@@ -164,10 +158,6 @@ func TestBlueprintsNew(t *testing.T) {
 }
 
 func TestBlueprintsNewToml(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-
 	blueprint := `
 name = "test"
 description = "Test"
@@ -181,7 +171,7 @@ version = "2.4.*"`
 	req.Header.Set("Content-Type", "text/x-toml")
 	recorder := httptest.NewRecorder()
 
-	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
+	api, _ := createWeldrAPI(t.TempDir(), rpmmd_mock.BaseFixture)
 	api.ServeHTTP(recorder, req)
 
 	r := recorder.Result()
@@ -189,15 +179,11 @@ version = "2.4.*"`
 }
 
 func TestBlueprintsEmptyToml(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-
 	req := httptest.NewRequest("POST", "/api/v0/blueprints/new", bytes.NewReader(nil))
 	req.Header.Set("Content-Type", "text/x-toml")
 	recorder := httptest.NewRecorder()
 
-	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
+	api, _ := createWeldrAPI(t.TempDir(), rpmmd_mock.BaseFixture)
 	api.ServeHTTP(recorder, req)
 
 	r := recorder.Result()
@@ -205,10 +191,6 @@ func TestBlueprintsEmptyToml(t *testing.T) {
 }
 
 func TestBlueprintsInvalidToml(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-
 	blueprint := `
 name = "test"
 description = "Test"
@@ -222,7 +204,7 @@ version = "2.4.*"`
 	req.Header.Set("Content-Type", "text/x-toml")
 	recorder := httptest.NewRecorder()
 
-	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
+	api, _ := createWeldrAPI(t.TempDir(), rpmmd_mock.BaseFixture)
 	api.ServeHTTP(recorder, req)
 
 	r := recorder.Result()
@@ -242,9 +224,7 @@ func TestBlueprintsWorkspaceJSON(t *testing.T) {
 		{"POST", "/api/v0/blueprints/workspace", ``, http.StatusBadRequest, `{"status":false,"errors":[{"id":"BlueprintsError","msg":"Missing blueprint"}]}`},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
@@ -253,10 +233,6 @@ func TestBlueprintsWorkspaceJSON(t *testing.T) {
 }
 
 func TestBlueprintsWorkspaceTOML(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-
 	blueprint := `
 name = "test"
 description = "Test"
@@ -270,7 +246,7 @@ version = "2.4.*"`
 	req.Header.Set("Content-Type", "text/x-toml")
 	recorder := httptest.NewRecorder()
 
-	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
+	api, _ := createWeldrAPI(t.TempDir(), rpmmd_mock.BaseFixture)
 	api.ServeHTTP(recorder, req)
 
 	r := recorder.Result()
@@ -278,15 +254,11 @@ version = "2.4.*"`
 }
 
 func TestBlueprintsWorkspaceEmptyTOML(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-
 	req := httptest.NewRequest("POST", "/api/v0/blueprints/workspace", bytes.NewReader(nil))
 	req.Header.Set("Content-Type", "text/x-toml")
 	recorder := httptest.NewRecorder()
 
-	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
+	api, _ := createWeldrAPI(t.TempDir(), rpmmd_mock.BaseFixture)
 	api.ServeHTTP(recorder, req)
 
 	r := recorder.Result()
@@ -294,10 +266,6 @@ func TestBlueprintsWorkspaceEmptyTOML(t *testing.T) {
 }
 
 func TestBlueprintsWorkspaceInvalidTOML(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-
 	blueprint := `
 name = "test"
 description = "Test"
@@ -311,7 +279,7 @@ version = "2.4.*"`
 	req.Header.Set("Content-Type", "text/x-toml")
 	recorder := httptest.NewRecorder()
 
-	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
+	api, _ := createWeldrAPI(t.TempDir(), rpmmd_mock.BaseFixture)
 	api.ServeHTTP(recorder, req)
 
 	r := recorder.Result()
@@ -333,9 +301,7 @@ func TestBlueprintsInfo(t *testing.T) {
 		{"GET", "/api/v0/blueprints/info/test3-non", ``, http.StatusOK, `{"blueprints":[],"changes":[],"errors":[{"id":"UnknownBlueprint","msg":"test3-non: "}]}`},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
@@ -349,11 +315,7 @@ func TestBlueprintsInfo(t *testing.T) {
 }
 
 func TestBlueprintsInfoToml(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-
-	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
+	api, _ := createWeldrAPI(t.TempDir(), rpmmd_mock.BaseFixture)
 	test.SendHTTP(api, true, "POST", "/api/v0/blueprints/new", `{"name":"test1","description":"Test","packages":[{"name":"httpd","version":"2.4.*"}],"version":"0.0.0"}`)
 
 	req := httptest.NewRequest("GET", "/api/v0/blueprints/info/test1?format=toml", nil)
@@ -364,7 +326,7 @@ func TestBlueprintsInfoToml(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	var got blueprint.Blueprint
-	_, err = toml.DecodeReader(resp.Body, &got)
+	_, err := toml.DecodeReader(resp.Body, &got)
 	require.NoErrorf(t, err, "error decoding toml file")
 
 	expected := blueprint.Blueprint{
@@ -384,11 +346,7 @@ func TestBlueprintsInfoToml(t *testing.T) {
 }
 
 func TestNonExistentBlueprintsInfoToml(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-
-	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
+	api, _ := createWeldrAPI(t.TempDir(), rpmmd_mock.BaseFixture)
 	req := httptest.NewRequest("GET", "/api/v0/blueprints/info/test3-non?format=toml", nil)
 	recorder := httptest.NewRecorder()
 	api.ServeHTTP(recorder, req)
@@ -453,9 +411,7 @@ func TestBlueprintsFreeze(t *testing.T) {
 			{rpmmd_mock.BaseFixture, "/api/v0/blueprints/freeze/test,test2", http.StatusOK, `{"blueprints":[{"blueprint":{"name":"test","description":"Test","distro":"","version":"0.0.1","packages":[{"name":"dep-package1","version":"1.33-2.fc30.x86_64"},{"name":"dep-package3","version":"7:3.0.3-1.fc30.x86_64"}],"modules":[{"name":"dep-package2","version":"2.9-1.fc30.x86_64"}],"groups":[]}},{"blueprint":{"name":"test2","description":"Test","distro":"","version":"0.0.0","packages":[{"name":"dep-package1","version":"1.33-2.fc30.x86_64"},{"name":"dep-package3","version":"7:3.0.3-1.fc30.x86_64"}],"modules":[{"name":"dep-package2","version":"2.9-1.fc30.x86_64"}],"groups":[]}}],"errors":[]}`},
 		}
 
-		tempdir, err := ioutil.TempDir("", "weldr-tests-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tempdir)
+		tempdir := t.TempDir()
 
 		for _, c := range cases {
 			api, _ := createWeldrAPI(tempdir, c.Fixture)
@@ -476,9 +432,7 @@ func TestBlueprintsFreeze(t *testing.T) {
 			{rpmmd_mock.BaseFixture, "/api/v0/blueprints/freeze/missing?format=toml", http.StatusOK, ""},
 		}
 
-		tempdir, err := ioutil.TempDir("", "weldr-tests-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tempdir)
+		tempdir := t.TempDir()
 
 		for _, c := range cases {
 			api, _ := createWeldrAPI(tempdir, c.Fixture)
@@ -497,9 +451,7 @@ func TestBlueprintsFreeze(t *testing.T) {
 			{rpmmd_mock.BaseFixture, "/api/v0/blueprints/freeze/test,test2?format=toml", http.StatusBadRequest, "{\"status\":false,\"errors\":[{\"id\":\"HTTPError\",\"msg\":\"toml format only supported when requesting one blueprint\"}]}"},
 		}
 
-		tempdir, err := ioutil.TempDir("", "weldr-tests-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tempdir)
+		tempdir := t.TempDir()
 
 		for _, c := range cases {
 			api, _ := createWeldrAPI(tempdir, c.Fixture)
@@ -521,9 +473,7 @@ func TestBlueprintsDiff(t *testing.T) {
 		{"GET", "/api/v0/blueprints/diff/test/NEWEST/WORKSPACE", ``, http.StatusOK, `{"diff":[{"new":{"Package":{"name":"systemd","version":"123"}},"old":null},{"new":null,"old":{"Package":{"name":"httpd","version":"2.4.*"}}}]}`},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
@@ -546,9 +496,7 @@ func TestBlueprintsDelete(t *testing.T) {
 		{"DELETE", "/api/v0/blueprints/delete/test3-non", ``, http.StatusBadRequest, `{"status":false,"errors":[{"id":"BlueprintsError","msg":"Unknown blueprint: test3-non"}]}`},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
@@ -559,11 +507,7 @@ func TestBlueprintsDelete(t *testing.T) {
 }
 
 func TestBlueprintsChanges(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-
-	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
+	api, _ := createWeldrAPI(t.TempDir(), rpmmd_mock.BaseFixture)
 	rand.Seed(time.Now().UnixNano())
 	// math/rand is good enough in this case
 	/* #nosec G404 */
@@ -590,9 +534,7 @@ func TestBlueprintsDepsolve(t *testing.T) {
 		{rpmmd_mock.BadDepsolve, http.StatusOK, `{"blueprints":[{"blueprint":{"name":"test","description":"Test","distro":"","version":"0.0.1","packages":[{"name":"dep-package1","version":"*"}],"groups":[],"modules":[{"name":"dep-package3","version":"*"}]},"dependencies":[]}],"errors":[{"id":"BlueprintsError","msg":"test: DNF error occured: DepsolveError: There was a problem depsolving ['go2rpm']: \n Problem: conflicting requests\n  - nothing provides askalono-cli needed by go2rpm-1-4.fc31.noarch"}]}`},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, c.Fixture)
@@ -605,11 +547,7 @@ func TestBlueprintsDepsolve(t *testing.T) {
 // TestOldBlueprintsUndo run tests with blueprint changes after a service restart
 // Old blueprints are not saved, after a restart the changes are listed, but cannot be recalled
 func TestOldBlueprintsUndo(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-
-	api, _ := createWeldrAPI(tempdir, rpmmd_mock.OldChangesFixture)
+	api, _ := createWeldrAPI(t.TempDir(), rpmmd_mock.OldChangesFixture)
 	rand.Seed(time.Now().UnixNano())
 	// math/rand is good enough in this case
 	/* #nosec G404 */
@@ -643,11 +581,7 @@ func TestOldBlueprintsUndo(t *testing.T) {
 
 // TestNewBlueprintsUndo run tests with blueprint changes without a service restart
 func TestNewBlueprintsUndo(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-
-	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
+	api, _ := createWeldrAPI(t.TempDir(), rpmmd_mock.BaseFixture)
 	rand.Seed(time.Now().UnixNano())
 	// math/rand is good enough in this case
 	/* #nosec G404 */
@@ -949,9 +883,7 @@ func TestCompose(t *testing.T) {
 		},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, s := createWeldrAPI(tempdir, rpmmd_mock.NoComposesFixture)
@@ -997,9 +929,7 @@ func TestComposeDelete(t *testing.T) {
 		{"/api/v0/compose/delete/30000000-0000-0000-0000-000000000003,42000000-0000-0000-0000-000000000000", `{"uuids":[{"uuid":"30000000-0000-0000-0000-000000000003","status":true}],"errors":[{"id":"UnknownUUID","msg":"compose 42000000-0000-0000-0000-000000000000 doesn't exist"}]}`, []string{"30000000-0000-0000-0000-000000000000", "30000000-0000-0000-0000-000000000001", "30000000-0000-0000-0000-000000000002", "30000000-0000-0000-0000-000000000004"}},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, s := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
@@ -1036,9 +966,7 @@ func TestComposeStatus(t *testing.T) {
 		t.Skip("This test is for internal testing only")
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
@@ -1065,9 +993,7 @@ func TestComposeInfo(t *testing.T) {
 		t.Skip("This test is for internal testing only")
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
@@ -1095,9 +1021,7 @@ func TestComposeLogs(t *testing.T) {
 		{"/api/v1/compose/results/30000000-0000-0000-0000-000000000002", "attachment; filename=30000000-0000-0000-0000-000000000002.tar", "application/x-tar", "30000000-0000-0000-0000-000000000002.json", "{\"sources\":{},\"pipeline\":{}}"},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range successCases {
 		api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
@@ -1166,9 +1090,7 @@ func TestComposeLog(t *testing.T) {
 		t.Skip("This test is for internal testing only")
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
@@ -1194,9 +1116,7 @@ func TestComposeQueue(t *testing.T) {
 		t.Skip("This test is for internal testing only")
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, c.Fixture)
@@ -1222,9 +1142,7 @@ func TestComposeFinished(t *testing.T) {
 		t.Skip("This test is for internal testing only")
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, c.Fixture)
@@ -1250,9 +1168,7 @@ func TestComposeFailed(t *testing.T) {
 		t.Skip("This test is for internal testing only")
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, c.Fixture)
@@ -1281,9 +1197,7 @@ func TestSourcesNew(t *testing.T) {
 		{"POST", "/api/v1/projects/source/new", `{"id": "fish","name":"fish repo","url": "https://download.opensuse.org/repositories/shells:/fish:/release:/3/Fedora_29/","type": "yum-baseurl","check_ssl": false,"check_gpg": false,"distros":["fedora-1"]}`, http.StatusBadRequest, `{"status":false, "errors":[{"id":"ProjectsError", "msg":"Invalid distributions: fedora-1"}]}`},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
@@ -1293,9 +1207,7 @@ func TestSourcesNew(t *testing.T) {
 }
 
 func TestSourcesNewTomlV0(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	sources := []string{`
 name = "fish"
@@ -1327,9 +1239,7 @@ check_gpg = false
 
 // Empty TOML, and invalid TOML should return an error
 func TestSourcesNewWrongTomlV0(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	sources := []string{``, `
 url = "https://download.opensuse.org/repositories/shells:/fish:/release:/3/Fedora_29/"
@@ -1352,9 +1262,7 @@ check_gpg = false
 
 // TestSourcesNewTomlV1 tests the v1 sources API with id and name
 func TestSourcesNewTomlV1(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	sources := []string{`
 id = "fish"
@@ -1393,10 +1301,6 @@ check_gpg = false
 }
 
 func TestSourcesInfoTomlV1(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-
 	source := `
 id = "fish"
 name = "fish"
@@ -1411,7 +1315,7 @@ rhsm = true
 	req.Header.Set("Content-Type", "text/x-toml")
 	recorder := httptest.NewRecorder()
 
-	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
+	api, _ := createWeldrAPI(t.TempDir(), rpmmd_mock.BaseFixture)
 	api.ServeHTTP(recorder, req)
 
 	r := recorder.Result()
@@ -1422,9 +1326,7 @@ rhsm = true
 
 // TestSourcesNewWrongTomlV1 Tests that Empty TOML, and invalid TOML should return an error
 func TestSourcesNewWrongTomlV1(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	sources := []string{``, `
 url = "https://download.opensuse.org/repositories/shells:/fish:/release:/3/Fedora_29/"
@@ -1458,13 +1360,9 @@ check_gpg = false
 }
 
 func TestSourcesInfo(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-
 	sourceStr := `{"name":"fish","type":"yum-baseurl","url":"https://download.opensuse.org/repositories/shells:/fish:/release:/3/Fedora_29/","check_gpg":false,"check_ssl":false,"system":false}`
 
-	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
+	api, _ := createWeldrAPI(t.TempDir(), rpmmd_mock.BaseFixture)
 	test.SendHTTP(api, true, "POST", "/api/v0/projects/source/new", sourceStr)
 	test.TestRoute(t, api, true, "GET", "/api/v0/projects/source/info/fish", ``, 200, `{"sources":{"fish":`+sourceStr+`},"errors":[]}`)
 	test.TestRoute(t, api, true, "GET", "/api/v0/projects/source/info/fish?format=json", ``, 200, `{"sources":{"fish":`+sourceStr+`},"errors":[]}`)
@@ -1472,13 +1370,9 @@ func TestSourcesInfo(t *testing.T) {
 }
 
 func TestSourcesInfoToml(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-
 	sourceStr := `{"name":"fish","type":"yum-baseurl","url":"https://download.opensuse.org/repositories/shells:/fish:/release:/3/Fedora_29/","check_gpg":false,"check_ssl":false,"system":false}`
 
-	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
+	api, _ := createWeldrAPI(t.TempDir(), rpmmd_mock.BaseFixture)
 	test.SendHTTP(api, true, "POST", "/api/v0/projects/source/new", sourceStr)
 
 	req := httptest.NewRequest("GET", "/api/v0/projects/source/info/fish?format=toml", nil)
@@ -1487,7 +1381,7 @@ func TestSourcesInfoToml(t *testing.T) {
 	resp := recorder.Result()
 
 	var sources map[string]store.SourceConfig
-	_, err = toml.DecodeReader(resp.Body, &sources)
+	_, err := toml.DecodeReader(resp.Body, &sources)
 	require.NoErrorf(t, err, "error decoding toml file")
 
 	expected := map[string]store.SourceConfig{
@@ -1514,9 +1408,7 @@ func TestSourcesDelete(t *testing.T) {
 		{"DELETE", "/api/v0/projects/source/delete/unknown", ``, http.StatusBadRequest, `{"status":false,"errors":[{"id":"UnknownSource","msg":"unknown is not a valid source."}]}`},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
@@ -1540,9 +1432,7 @@ func TestProjectsDepsolve(t *testing.T) {
 		{rpmmd_mock.BaseFixture, "/api/v0/projects/depsolve/fish?distro=fedora-1", http.StatusBadRequest, `{"status":false,"errors":[{"id":"DistroError","msg":"Invalid distro: fedora-1"}]}`},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, c.Fixture)
@@ -1567,9 +1457,7 @@ func TestProjectsInfo(t *testing.T) {
 		{rpmmd_mock.BaseFixture, "/api/v0/projects/info/package16?distro=fedora-1", http.StatusBadRequest, `{"status":false,"errors":[{"id":"DistroError","msg":"Invalid distro: fedora-1"}]}`},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, c.Fixture)
@@ -1596,9 +1484,7 @@ func TestModulesInfo(t *testing.T) {
 		{rpmmd_mock.BaseFixture, "/api/v1/modules/info/package16?distro=fedora-1", http.StatusBadRequest, `{"status":false,"errors":[{"id":"DistroError","msg":"Invalid distro: fedora-1"}]}`},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, c.Fixture)
@@ -1621,9 +1507,7 @@ func TestProjectsList(t *testing.T) {
 		{rpmmd_mock.BaseFixture, "/api/v0/projects/list?distro=fedora-1&offset=1&limit=1", http.StatusBadRequest, `{"status":false,"errors":[{"id":"DistroError","msg":"Invalid distro: fedora-1"}]}`},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, c.Fixture)
@@ -1649,9 +1533,7 @@ func TestModulesList(t *testing.T) {
 		{rpmmd_mock.BaseFixture, "/api/v0/modules/list/package2*,package16?distro=fedora-1&offset=1&limit=1", http.StatusBadRequest, `{"status":false,"errors":[{"id":"DistroError","msg":"Invalid distro: fedora-1"}]}`},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI(tempdir, c.Fixture)
@@ -1729,9 +1611,7 @@ func TestComposeTypes_ImageTypeDenylist(t *testing.T) {
 		},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, _ := createWeldrAPI2(tempdir, rpmmd_mock.BaseFixture, c.ImageTypeDenylist)
@@ -1891,9 +1771,7 @@ func TestComposePOST_ImageTypeDenylist(t *testing.T) {
 		},
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	for _, c := range cases {
 		api, s := createWeldrAPI2(tempdir, rpmmd_mock.NoComposesFixture, c.imageTypeDenylist)

--- a/internal/weldr/compose_test.go
+++ b/internal/weldr/compose_test.go
@@ -3,7 +3,6 @@ package weldr
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -22,11 +21,7 @@ func TestComposeStatusFromLegacyError(t *testing.T) {
 		t.Skip("This test is for internal testing only")
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-
-	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
+	api, _ := createWeldrAPI(t.TempDir(), rpmmd_mock.BaseFixture)
 
 	distroStruct := test_distro.New()
 	arch, err := distroStruct.GetArch(test_distro.TestArchName)
@@ -68,11 +63,7 @@ func TestComposeStatusFromJobError(t *testing.T) {
 		t.Skip("This test is for internal testing only")
 	}
 
-	tempdir, err := ioutil.TempDir("", "weldr-tests-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-
-	api, _ := createWeldrAPI(tempdir, rpmmd_mock.BaseFixture)
+	api, _ := createWeldrAPI(t.TempDir(), rpmmd_mock.BaseFixture)
 
 	distroStruct := test_distro.New()
 	arch, err := distroStruct.GetArch(test_distro.TestArchName)


### PR DESCRIPTION
A testing enhancement.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
