### PR TITLE
github: fix job names and IDs for the tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,8 @@ on:
       - main
 
 jobs:
-  lint:
-    name: "⌨ Lint"
+  unit-tests:
+    name: "🛃 Unit tests"
     runs-on: ubuntu-20.04
     steps:
 
@@ -51,8 +51,8 @@ jobs:
       run: |
         python3 -m pylint dnf-json
 
-  unit-tests:
-    name: "🛃 Unit tests"
+  lint:
+    name: "⌨ Lint"
     runs-on: ubuntu-20.04
     steps:
 


### PR DESCRIPTION
Flip the incorrect flip that happened in e4baddfad119f0826b22081cb68d29ec47ea5cde
