### PR TITLE
Pass repo name to `dnf-json` and use it in `dnf-json`

### DIFF
--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -18,6 +18,7 @@ import (
 )
 
 type repository struct {
+	Name       string `json:"name,omitempty"`
 	BaseURL    string `json:"baseurl,omitempty"`
 	Metalink   string `json:"metalink,omitempty"`
 	MirrorList string `json:"mirrorlist,omitempty"`
@@ -102,8 +103,12 @@ func main() {
 
 	repos := make([]rpmmd.RepoConfig, len(composeRequest.Repositories))
 	for i, repo := range composeRequest.Repositories {
+		repoName := repo.Name
+		if repoName == "" {
+			repoName = fmt.Sprintf("repo-%d", i)
+		}
 		repos[i] = rpmmd.RepoConfig{
-			Name:       fmt.Sprintf("repo-%d", i),
+			Name:       repoName,
 			BaseURL:    repo.BaseURL,
 			Metalink:   repo.Metalink,
 			MirrorList: repo.MirrorList,

--- a/dnf-json
+++ b/dnf-json
@@ -139,6 +139,8 @@ class Solver():
 
         repo = dnf.repo.Repo(desc["id"], parent_conf)
 
+        if "name" in desc:
+            repo.name = desc["name"]
         if "baseurl" in desc:
             repo.baseurl = desc["baseurl"]
         elif "metalink" in desc:

--- a/dnf-json
+++ b/dnf-json
@@ -205,7 +205,7 @@ class Solver():
                 "summary": package.summary,
                 "description": package.description,
                 "url": package.url,
-                "repo_id": package.reponame,
+                "repo_id": package.repoid,
                 "epoch": package.epoch,
                 "version": package.version,
                 "release": package.release,
@@ -235,7 +235,7 @@ class Solver():
                 "version": package.version,
                 "release": package.release,
                 "arch": package.arch,
-                "repo_id": package.reponame,
+                "repo_id": package.repoid,
                 "path": package.relativepath,
                 "remote_location": package.remote_location(),
                 "checksum": (

--- a/internal/rpmmd/repository.go
+++ b/internal/rpmmd/repository.go
@@ -406,8 +406,8 @@ func NewRPMMD(cacheDir string) RPMMD {
 	}
 }
 
-func (repo RepoConfig) toDNFRepoConfig(rpmmd *rpmmdImpl, i int, arch, releasever string) (dnfRepoConfig, error) {
-	id := strconv.Itoa(i)
+func (repo RepoConfig) toDNFRepoConfig(rpmmd *rpmmdImpl, repoID int, arch, releasever string) (dnfRepoConfig, error) {
+	id := strconv.Itoa(repoID)
 	dnfRepo := dnfRepoConfig{
 		ID:             id,
 		Name:           repo.Name,

--- a/internal/rpmmd/repository.go
+++ b/internal/rpmmd/repository.go
@@ -34,6 +34,7 @@ type repository struct {
 
 type dnfRepoConfig struct {
 	ID             string `json:"id"`
+	Name           string `json:"name,omitempty"`
 	BaseURL        string `json:"baseurl,omitempty"`
 	Metalink       string `json:"metalink,omitempty"`
 	MirrorList     string `json:"mirrorlist,omitempty"`
@@ -409,6 +410,7 @@ func (repo RepoConfig) toDNFRepoConfig(rpmmd *rpmmdImpl, i int, arch, releasever
 	id := strconv.Itoa(i)
 	dnfRepo := dnfRepoConfig{
 		ID:             id,
+		Name:           repo.Name,
 		BaseURL:        repo.BaseURL,
 		Metalink:       repo.Metalink,
 		MirrorList:     repo.MirrorList,


### PR DESCRIPTION
- dnf-json: do not use reponame as repoid
- rpmmd: pass repo name to dnf-json
- dnf-json: use repository name from the request if provided
- rpmmd: rename toDNFRepoConfig() argument i -> repoID
- osbuild-pipeline: use repo name from the request if provided