### PR TITLE
dnf-json: use the default connection timeout

### DIFF
--- a/dnf-json
+++ b/dnf-json
@@ -118,9 +118,6 @@ class Solver():
         # building images, I don't care if we download even more.
         self.base.conf.zchunk = False
 
-        # Try another mirror if it takes longer than 5 seconds to connect.
-        self.base.conf.timeout = 5
-
         # Set the rest of the dnf configuration.
         self.base.conf.module_platform_id = module_platform_id
         self.base.conf.config_file_path = "/dev/null"


### PR DESCRIPTION
By default `timeout` is 30 seconds, but we had it set to 5. Drop
the override and use the default.

This has two effects: it increases the time before we give up on
connecting (as it says on the tin), and it also increases the time
download has to be slow for before we give up.

Internally, we were seing failures in downlaoding metadata from ODCS
and similar issues have occurred in CI too.

The potential downside to this is in case of having several mirrors
this means it takes longer before giving up on a bad one and trying
a better one. But slow is better than broken, so for now rever to
the default behavior.

Signed-off-by: Tom Gundersen <teg@jklm.no>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
