### PR TITLE
Dashboards - Minor fixes

### DIFF
--- a/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-image-builder-composer-general.configmap.yml
@@ -29,13 +29,10 @@ data:
         ]
       },
       "editable": true,
-      "fiscalYearStartMonth": 0,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 219,
-      "iteration": 1638547440887,
+      "iteration": 1647253765879,
       "links": [],
-      "liveNow": false,
       "panels": [
         {
           "collapsed": false,
@@ -130,7 +127,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "1 - sum(increase(image_builder_composer_total_failed_compose_requests[$__range]))/sum(increase(image_builder_composer_total_compose_requests[$__range]))",
+              "expr": "1 - (\n  (\n    sum(increase(image_builder_composer_total_failed_compose_requests[$__range]))\n    /\n    sum(increase(image_builder_composer_total_compose_requests[$__range]))\n  ) OR on() vector(0) # set a fallback if the query result is empty\n)",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -282,7 +279,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(rate(image_builder_composer_total_compose_requests[$interval])) - sum(rate(image_builder_composer_total_failed_compose_requests[$interval]))",
+              "expr": "(sum(rate(image_builder_composer_total_compose_requests[$interval])) OR on() vector(0)) \n- \n(sum(rate(image_builder_composer_total_failed_compose_requests[$interval])) OR on() vector(0))",
               "hide": false,
               "interval": "",
               "legendFormat": "success/sec",
@@ -290,7 +287,7 @@ data:
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(image_builder_composer_total_failed_compose_requests[$interval]))",
+              "expr": "(sum(rate(image_builder_composer_total_failed_compose_requests[$interval])) OR on() vector(0))",
               "hide": false,
               "interval": "",
               "legendFormat": "errors/sec",
@@ -371,7 +368,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(rate(image_builder_composer_total_failed_compose_requests[$interval]))/sum(rate(image_builder_composer_total_compose_requests[$interval]))",
+              "expr": "(\n  sum(rate(image_builder_composer_total_failed_compose_requests[$interval]))\n  /\n  sum(rate(image_builder_composer_total_compose_requests[$interval]))\n) OR on() vector(0)",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -465,7 +462,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "28 * 24 * (1 - $stability_slo) / ((sum(rate(image_builder_composer_total_failed_compose_requests[28d]))/ sum(rate(image_builder_composer_total_compose_requests[28d]))) + 0.001)",
+              "expr": "28 * 24 * (1 - $stability_slo)\n/\n(\n  (\n    sum(rate(image_builder_composer_total_failed_compose_requests[28d]))\n    / \n    sum(rate(image_builder_composer_total_compose_requests[28d]))\n  ) OR on() vector(0.01) # set fallback incase the above query result is empty\n)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -560,11 +557,11 @@ data:
               "mode": "single"
             }
           },
-          "pluginVersion": "8.1.5",
+          "pluginVersion": "8.2.1",
           "targets": [
             {
               "exemplar": true,
-              "expr": "1 - ((1 - sum(increase(image_builder_composer_total_failed_compose_requests[28d]))/sum(increase(image_builder_composer_total_compose_requests[28d]))) - $stability_slo)/ (1 - $stability_slo)",
+              "expr": "1 - (\n  (\n    1 - $stability_slo - (\n      (\n        sum(increase(image_builder_composer_total_failed_compose_requests[28d]))\n        /\n        sum(increase(image_builder_composer_total_compose_requests[28d]))\n      ) OR on() vector(0) # set fallback for empty query result\n    )\n  )\n)\n/\n(1 - $stability_slo)",
               "instant": false,
               "interval": "",
               "intervalFactor": 10,
@@ -1059,7 +1056,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "28 * 24 * (1 - $latency_slo) / (1 - sum(rate(image_builder_composer_http_duration_seconds_bucket{le=\"0.2\"}[$__range]))/sum(rate(image_builder_composer_http_duration_seconds_count[$__range])))",
+              "expr": "28 * 24 * (1 - $latency_slo) \n/\n(\n  1.001 - (\n    (\n      sum(rate(image_builder_composer_http_duration_seconds_bucket{le=\"0.2\"}[$__range]))\n      /\n      sum(rate(image_builder_composer_http_duration_seconds_count[$__range]))\n    ) OR on() vector(1) # set fallback incase the above query result is empty\n  ) \n)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -1153,11 +1150,11 @@ data:
               "mode": "single"
             }
           },
-          "pluginVersion": "8.1.5",
+          "pluginVersion": "8.2.1",
           "targets": [
             {
               "exemplar": true,
-              "expr": "1 - ((sum(increase(image_builder_composer_http_duration_seconds_bucket{le=\"0.2\"}[28d]))/sum(increase(image_builder_composer_http_duration_seconds_count[28d]))) - $latency_slo)/ (1 - $latency_slo)",
+              "expr": "1 - (\n  (\n    (\n      sum(increase(image_builder_composer_http_duration_seconds_bucket{le=\"0.2\"}[28d]))\n      /\n      sum(increase(image_builder_composer_http_duration_seconds_count[28d]))\n    ) OR on() vector(1)\n  ) - $latency_slo\n)\n/ \n(1 - $latency_slo)",
               "instant": false,
               "interval": "",
               "intervalFactor": 10,
@@ -1172,7 +1169,7 @@ data:
         }
       ],
       "refresh": false,
-      "schemaVersion": 31,
+      "schemaVersion": 30,
       "style": "dark",
       "tags": [],
       "templating": {
@@ -1324,5 +1321,5 @@ data:
       "timezone": "",
       "title": "Image Builder Composer",
       "uid": "image-builder-composer",
-      "version": 3
+      "version": 4
     }

--- a/templates/dashboards/grafana-dashboard-image-builder-worker-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-image-builder-worker-general.configmap.yml
@@ -31,7 +31,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1645525186957,
+      "iteration": 1647253881137,
       "links": [],
       "panels": [
         {
@@ -1356,7 +1356,6 @@ data:
               },
               "mappings": [],
               "max": 1,
-              "min": 3,
               "noValue": "0",
               "thresholds": {
                 "mode": "absolute",
@@ -2743,5 +2742,5 @@ data:
       "timezone": "",
       "title": "Image Builder Worker",
       "uid": "image-builder-worker",
-      "version": 4
+      "version": 5
     }


### PR DESCRIPTION
This pull request includes:

Worker dashboard:
- minor fix for the error rate display panel of the worker dashboard

Before:
![error_before](https://user-images.githubusercontent.com/20438192/158185524-68547534-cb7e-448a-bb6b-3841c8db13df.png)

After:
![error_after](https://user-images.githubusercontent.com/20438192/158185538-ea4e93a3-7242-4221-ae14-ef0a6b47d551.png)

Composer dashboard:
- formatting the queries of the composer dashboard to make them more readable in the grafana dashboard
- add fallback values for empty prometheus queries 




- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
