### PR TITLE
test: add image types test

### DIFF
--- a/cmd/osbuild-composer-image-types-tests/main_test.go
+++ b/cmd/osbuild-composer-image-types-tests/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+    "fmt"
+    "os/exec"
+    "testing"
+)
+
+func TestImageTypes(t *testing.T) {
+        cmd := exec.Command("composer-cli", "compose", "types")
+        stdout, err := cmd.Output()
+
+        if err != nil {                                                                                                               fmt.Println(err.Error())
+                return
+        }
+
+        // Print the output
+        fmt.Println(string(stdout))                                                                                   
+
+	t.Errorf(string(stdout))
+}

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -144,6 +144,7 @@ export GOPATH=%{gobuilddir}:%{gopath}
 TEST_LDFLAGS="${LDFLAGS:-} -B 0x$(od -N 20 -An -tx1 -w100 /dev/urandom | tr -d ' ')"
 
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-composer-cli-tests %{goipath}/cmd/osbuild-composer-cli-tests
+go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-composer-image-types-tests %{goipath}/cmd/osbuild-composer-image-types-tests
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-dnf-json-tests %{goipath}/cmd/osbuild-dnf-json-tests
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-weldr-tests %{goipath}/internal/client/
 go test -c -tags=integration -ldflags="${TEST_LDFLAGS}" -o _bin/osbuild-image-tests %{goipath}/cmd/osbuild-image-tests
@@ -210,6 +211,7 @@ install -m 0644 -vp docs/*.7                                       %{buildroot}%
 
 install -m 0755 -vd                                                %{buildroot}%{_libexecdir}/osbuild-composer-test
 install -m 0755 -vp _bin/osbuild-composer-cli-tests                %{buildroot}%{_libexecdir}/osbuild-composer-test/
+install -m 0755 -vp _bin/osbuild-composer-image-types-tests        %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp _bin/osbuild-weldr-tests                       %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp _bin/osbuild-dnf-json-tests                    %{buildroot}%{_libexecdir}/osbuild-composer-test/
 install -m 0755 -vp _bin/osbuild-image-tests                       %{buildroot}%{_libexecdir}/osbuild-composer-test/

--- a/test/cases/base_tests.sh
+++ b/test/cases/base_tests.sh
@@ -19,6 +19,7 @@ TEST_CASES=(
   "osbuild-composer-cli-tests"
   "osbuild-auth-tests"
   "osbuild-composer-dbjobqueue-tests"
+  "osbuild-composer-image-types-tests"
 )
 
 # Print out a nice test divider so we know when tests stop and start.


### PR DESCRIPTION
test: related to bz 2018419. We need a test to make sure every OS+arch
variant has the expected image types.