### PR TITLE
`test/api.sh` cleanup

### DIFF
--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -503,7 +503,7 @@ else
 fi
 
 # generate a temp key for user tests
-ssh-keygen -t rsa-sha2-512 -f /tmp/usertest -C "usertest" -N ""
+ssh-keygen -t rsa-sha2-512 -f "${WORKDIR}/usertest" -C "usertest" -N ""
 
 function createReqFileAWS() {
   AWS_SNAPSHOT_NAME=${TEST_ID}
@@ -531,11 +531,11 @@ function createReqFileAWS() {
       {
         "name": "user1",
         "groups": ["wheel"],
-        "key": "$(cat /tmp/usertest.pub)"
+        "key": "$(cat "${WORKDIR}/usertest.pub")"
       },
       {
         "name": "user2",
-        "key": "$(cat /tmp/usertest.pub)"
+        "key": "$(cat "${WORKDIR}/usertest.pub")"
       }
     ]
   },
@@ -576,11 +576,11 @@ function createReqFileAWSS3() {
       {
         "name": "user1",
         "groups": ["wheel"],
-        "key": "$(cat /tmp/usertest.pub)"
+        "key": "$(cat "${WORKDIR}/usertest.pub")"
       },
       {
         "name": "user2",
-        "key": "$(cat /tmp/usertest.pub)"
+        "key": "$(cat "${WORKDIR}/usertest.pub")"
       }
     ]
   },
@@ -977,14 +977,14 @@ function verifyInAWS() {
   _instanceCheck "$_ssh"
 
   # Check access to user1 and user2
-  check_groups=$(ssh -oStrictHostKeyChecking=no -i /tmp/usertest "user1@$HOST" -t 'groups')
+  check_groups=$(ssh -oStrictHostKeyChecking=no -i "${WORKDIR}/usertest" "user1@$HOST" -t 'groups')
   if [[ $check_groups =~ "wheel" ]]; then
    echo "✔️  user1 has the group wheel"
   else
     echo 'user1 should have the group wheel 😢'
     exit 1
   fi
-  check_groups=$(ssh -oStrictHostKeyChecking=no -i /tmp/usertest "user2@$HOST" -t 'groups')
+  check_groups=$(ssh -oStrictHostKeyChecking=no -i "${WORKDIR}/usertest" "user2@$HOST" -t 'groups')
   if [[ $check_groups =~ "wheel" ]]; then
     echo 'user2 should not have group wheel 😢'
     exit 1


### PR DESCRIPTION
- Do not create files in directories which don't get cleaned up.
- Make sure that the DB is dumped even if the test case fails.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
