### PR TITLE
prometheus: measure pending rather than queued time

### DIFF
--- a/internal/kojiapi/server_test.go
+++ b/internal/kojiapi/server_test.go
@@ -529,8 +529,8 @@ func TestJobTypeValidation(t *testing.T) {
 		resp, _ := json.Marshal(map[string]string{"message": msg})
 		test.TestRoute(t, handler, false, "GET", fmt.Sprintf("/api/composer-koji/v1/compose/%s%s", initID, path), ``, http.StatusNotFound, string(resp))
 
-		for idx, buildID := range buildJobIDs {
-			msg := fmt.Sprintf("Job %s not found: expected \"koji-finalize\", found \"osbuild-koji:fake-arch-%d\" job instead", buildID, idx)
+		for _, buildID := range buildJobIDs {
+			msg := fmt.Sprintf("Job %s not found: expected \"koji-finalize\", found \"osbuild-koji\" job instead", buildID)
 			resp, _ := json.Marshal(map[string]string{"message": msg})
 			test.TestRoute(t, handler, false, "GET", fmt.Sprintf("/api/composer-koji/v1/compose/%s%s", buildID, path), ``, http.StatusNotFound, string(resp))
 		}

--- a/internal/prometheus/job_metrics.go
+++ b/internal/prometheus/job_metrics.go
@@ -61,9 +61,9 @@ func EnqueueJobMetrics(jobType string) {
 	PendingJobs.WithLabelValues(jobType).Inc()
 }
 
-func DequeueJobMetrics(queued time.Time, started time.Time, jobType string) {
-	if !started.IsZero() && !queued.IsZero() {
-		diff := started.Sub(queued).Seconds()
+func DequeueJobMetrics(pending time.Time, started time.Time, jobType string) {
+	if !started.IsZero() && !pending.IsZero() {
+		diff := started.Sub(pending).Seconds()
 		JobWaitDuration.WithLabelValues(jobType).Observe(diff)
 		PendingJobs.WithLabelValues(jobType).Dec()
 		RunningJobs.WithLabelValues(jobType).Inc()

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -461,12 +461,22 @@ func (s *Server) requestJob(ctx context.Context, arch string, jobTypes []string,
 		return
 	}
 
+	// Record how long the job has been pending for, that is either how
+	// long it has been queued for, in case it has no dependencies, or
+	// how long it has been since all its dependencies finished, if it
+	// has any.
+	pending := status.Queued
+
 	for _, depID := range depIDs {
 		// TODO: include type of arguments
 		var result json.RawMessage
-		_, result, _, _, _, _, _, err = s.jobs.JobStatus(depID)
+		var finished time.Time
+		_, result, _, _, finished, _, _, err = s.jobs.JobStatus(depID)
 		if err != nil {
 			return
+		}
+		if finished.After(pending) {
+			pending = finished
 		}
 		dynamicArgs = append(dynamicArgs, result)
 	}
@@ -478,7 +488,7 @@ func (s *Server) requestJob(ctx context.Context, arch string, jobTypes []string,
 		}
 	}
 
-	prometheus.DequeueJobMetrics(status.Queued, status.Started, jobType)
+	prometheus.DequeueJobMetrics(pending, status.Started, jobType)
 
 	return
 }

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -452,13 +452,18 @@ func (s *Server) requestJob(ctx context.Context, arch string, jobTypes []string,
 	jobType, status, _, err := s.jobStatus(jobId, nil)
 	if err != nil {
 		logrus.Errorf("error retrieving job status: %v", err)
+		return
 	} else {
 		prometheus.DequeueJobMetrics(status.Queued, status.Started, jobType)
 	}
 
 	for _, depID := range depIDs {
 		// TODO: include type of arguments
-		_, result, _, _, _, _, _, _ := s.jobs.JobStatus(depID)
+		var result json.RawMessage
+		_, result, _, _, _, _, _, err = s.jobs.JobStatus(depID)
+		if err != nil {
+			return
+		}
 		dynamicArgs = append(dynamicArgs, result)
 	}
 

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -453,8 +453,6 @@ func (s *Server) requestJob(ctx context.Context, arch string, jobTypes []string,
 	if err != nil {
 		logrus.Errorf("error retrieving job status: %v", err)
 		return
-	} else {
-		prometheus.DequeueJobMetrics(status.Queued, status.Started, jobType)
 	}
 
 	for _, depID := range depIDs {
@@ -479,6 +477,8 @@ func (s *Server) requestJob(ctx context.Context, arch string, jobTypes []string,
 	} else if jobType == "osbuild-koji:"+arch {
 		jobType = "osbuild-koji"
 	}
+
+	prometheus.DequeueJobMetrics(status.Queued, status.Started, jobType)
 
 	return
 }


### PR DESCRIPTION
Measure the time a job has been pending on the queue (ready to be dequeued), rather than
how long it has been on the queue altogether. This will give us a measure for when we need
more workers.

Also record job types as `osbuild` rather than `osbuild:x86_64`.