### PR TITLE
container: graceful shutdown

### DIFF
--- a/containers/osbuild-composer/entrypoint.py
+++ b/containers/osbuild-composer/entrypoint.py
@@ -9,6 +9,7 @@ a container.
 import argparse
 import contextlib
 import os
+import pathlib
 import socket
 import subprocess
 import sys
@@ -301,6 +302,10 @@ class Cli(contextlib.AbstractContextManager):
         res = 0
         sockets = self._prepare_sockets()
 
+        liveness = pathlib.Path('/run/live')
+
+        liveness.touch()
+
         try:
             if self.args.builtin_worker:
                 proc_worker = self._spawn_worker()
@@ -324,7 +329,6 @@ class Cli(contextlib.AbstractContextManager):
                     proc_dnf_json.terminate()
                 proc_dnf_json.wait()
 
-            return res
         except KeyboardInterrupt:
             if proc_worker:
                 proc_worker.terminate()
@@ -343,6 +347,8 @@ class Cli(contextlib.AbstractContextManager):
             if proc_composer:
                 proc_composer.kill()
             raise
+        finally:
+            liveness.unlink()
 
         return res
 

--- a/containers/osbuild-composer/entrypoint.py
+++ b/containers/osbuild-composer/entrypoint.py
@@ -10,6 +10,7 @@ import argparse
 import contextlib
 import os
 import pathlib
+import signal
 import socket
 import subprocess
 import sys
@@ -301,6 +302,13 @@ class Cli(contextlib.AbstractContextManager):
         proc_dnf_json = None
         res = 0
         sockets = self._prepare_sockets()
+
+        def handler(signum, frame):
+            proc_composer.terminate()
+            proc_worker.terminate()
+            proc_dnf_json.terminate()
+
+        signal.signal(signal.SIGTERM, handler)
 
         liveness = pathlib.Path('/run/live')
 

--- a/containers/osbuild-composer/entrypoint.py
+++ b/containers/osbuild-composer/entrypoint.py
@@ -330,15 +330,15 @@ class Cli(contextlib.AbstractContextManager):
                 proc_dnf_json.wait()
 
         except KeyboardInterrupt:
+            if proc_composer:
+                proc_composer.terminate()
+                res = proc_composer.wait()
             if proc_worker:
                 proc_worker.terminate()
                 proc_worker.wait()
             if proc_dnf_json:
                 proc_dnf_json.terminate()
                 proc_dnf_json.wait()
-            if proc_composer:
-                proc_composer.terminate()
-                res = proc_composer.wait()
         except:
             if proc_worker:
                 proc_worker.kill()

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -3,6 +3,7 @@ package weldr
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	errors_package "errors"
@@ -52,6 +53,7 @@ type API struct {
 
 	logger *log.Logger
 	router *httprouter.Router
+	server http.Server
 
 	compatOutputDir string
 
@@ -271,14 +273,18 @@ func setupRouter(api *API) *API {
 }
 
 func (api *API) Serve(listener net.Listener) error {
-	server := http.Server{Handler: api}
+	api.server = http.Server{Handler: api}
 
-	err := server.Serve(listener)
+	err := api.server.Serve(listener)
 	if err != nil && err != http.ErrServerClosed {
 		return err
 	}
 
 	return nil
+}
+
+func (api *API) Shutdown(ctx context.Context) error {
+	return api.server.Shutdown(ctx)
 }
 
 func (api *API) ServeHTTP(writer http.ResponseWriter, request *http.Request) {

--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -41,10 +41,10 @@ objects:
           name: composer
           livenessProbe:
             failureThreshold: 3
-            httpGet:
-              path: ${LIVENESS_URI}
-              port: ${{COMPOSER_API_PORT}}
-              scheme: HTTP
+            exec:
+              command:
+              - cat
+              - /tmp/live
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1


### PR DESCRIPTION
Support graceful shutdown of composer, making sure that any pending request are handled before the container is
terminated.

In the past we risked OpenShift thinking the container was dead (because we stopped answering to liveness probes) and
killing it before pending requests (in particular long-running depsolves) had been processed.