### PR TITLE
Add `cloud-init` to VMDK image and test it in VSphere

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -387,6 +387,7 @@ cross-distro.sh:
     - azure
     - edge-commit
     - gcp
+    - vsphere
 
 API:
   stage: test

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -209,6 +209,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 		if err != nil {
 			return err
 		}
+		f.Close()
 	}
 
 	if len(args.Targets) == 0 {

--- a/internal/cloudapi/v2/v2.go
+++ b/internal/cloudapi/v2/v2.go
@@ -532,8 +532,9 @@ func enqueueCompose(workers *worker.Server, distribution distro.Distro, bp bluep
 	}
 
 	id, err = workers.EnqueueOSBuildAsDependency(ir.arch.Name(), &worker.OSBuildJob{
-		Targets: []*target.Target{ir.target},
-		Exports: ir.imageType.Exports(),
+		Targets:         []*target.Target{ir.target},
+		Exports:         ir.imageType.Exports(),
+		StreamOptimized: ir.imageType.Name() == "vmdk", // https://github.com/osbuild/osbuild/issues/528,
 		PipelineNames: &worker.PipelineNames{
 			Build:   ir.imageType.BuildPipelines(),
 			Payload: ir.imageType.PayloadPipelines(),

--- a/internal/distro/rhel85/package_sets.go
+++ b/internal/distro/rhel85/package_sets.go
@@ -304,11 +304,17 @@ func vhdCommonPackageSet(t *imageType) rpmmd.PackageSet {
 func vmdkCommonPackageSet(t *imageType) rpmmd.PackageSet {
 	return rpmmd.PackageSet{
 		Include: []string{
-			"@core", "chrony", "firewalld", "langpacks-en", "open-vm-tools",
+			"@core",
+			"chrony",
+			"cloud-init",
+			"firewalld",
+			"langpacks-en",
+			"open-vm-tools",
 			"selinux-policy-targeted",
 		},
 		Exclude: []string{
-			"dracut-config-rescue", "rng-tools",
+			"dracut-config-rescue",
+			"rng-tools",
 		},
 	}.Append(bootPackageSet(t))
 

--- a/internal/distro/rhel86/package_sets.go
+++ b/internal/distro/rhel86/package_sets.go
@@ -427,11 +427,17 @@ func azureRhuiCommonPackageSet(t *imageType) rpmmd.PackageSet {
 func vmdkCommonPackageSet(t *imageType) rpmmd.PackageSet {
 	return rpmmd.PackageSet{
 		Include: []string{
-			"@core", "chrony", "firewalld", "langpacks-en", "open-vm-tools",
+			"@core",
+			"chrony",
+			"cloud-init",
+			"firewalld",
+			"langpacks-en",
+			"open-vm-tools",
 			"selinux-policy-targeted",
 		},
 		Exclude: []string{
-			"dracut-config-rescue", "rng-tools",
+			"dracut-config-rescue",
+			"rng-tools",
 		},
 	}.Append(bootPackageSet(t))
 

--- a/internal/distro/rhel90/package_sets.go
+++ b/internal/distro/rhel90/package_sets.go
@@ -520,6 +520,7 @@ func vmdkCommonPackageSet(t *imageType) rpmmd.PackageSet {
 	ps := rpmmd.PackageSet{
 		Include: []string{
 			"chrony",
+			"cloud-init",
 			"firewalld",
 			"langpacks-en",
 			"open-vm-tools",

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -11,11 +11,11 @@ import (
 
 type Target struct {
 	Uuid      uuid.UUID              `json:"uuid"`
-	ImageName string                 `json:"image_name"`
-	Name      string                 `json:"name"`
+	ImageName string                 `json:"image_name"` // Desired name of the image in the target environment
+	Name      string                 `json:"name"`       // Name of the specific target type
 	Created   time.Time              `json:"created"`
 	Status    common.ImageBuildState `json:"status"`
-	Options   TargetOptions          `json:"options"`
+	Options   TargetOptions          `json:"options"` // Target type specific options
 }
 
 func newTarget(name string, options TargetOptions) *Target {

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -1231,12 +1231,11 @@ function verifyInVSphere() {
     _ci_iso_path="$(_createCIUserdataISO "${_ci_userdata_path}" "${_ci_metadata_path}")"
 
     VSPHERE_IMAGE_NAME="${VSPHERE_VM_NAME}.vmdk"
+    mv "${_filename}" "${WORKDIR}/${VSPHERE_IMAGE_NAME}"
 
     # import the built VMDK image to VSphere
     # import.vmdk seems to be creating the provided directory and
     # if one with this name exists, it appends "_<number>" to the name
-    greenprint "🚧 Converting the downloaded VMDK image to be streamOptimized"
-    qemu-img convert -O vmdk -o subformat=streamOptimized "${_filename}" "${WORKDIR}/${VSPHERE_IMAGE_NAME}"
     greenprint "💿 ⬆️ Importing the converted VMDK image to VSphere"
     $GOVC_CMD import.vmdk \
         -u "${GOVMOMI_USERNAME}:${GOVMOMI_PASSWORD}@${GOVMOMI_URL}" \

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -312,7 +312,7 @@ function dump_db() {
   set +x
 
   # Make sure we get 3 job entries in the db per compose (depsolve + manifest + build)
-  sudo ${CONTAINER_RUNTIME} exec "${DB_CONTAINER_NAME}" psql -U postgres -d osbuildcomposer -c "SELECT * FROM jobs;" | grep "9 rows"
+  sudo ${CONTAINER_RUNTIME} exec "${DB_CONTAINER_NAME}" psql -U postgres -d osbuildcomposer -c "SELECT * FROM jobs;" | grep "9 rows" > /dev/null
 
   # Save the result, including the manifest, for the job, straight from the db
   sudo ${CONTAINER_RUNTIME} exec "${DB_CONTAINER_NAME}" psql -U postgres -d osbuildcomposer -c "SELECT result FROM jobs WHERE type='manifest-id-only'" \

--- a/test/data/manifests/centos_8-x86_64-vmdk-boot.json
+++ b/test/data/manifests/centos_8-x86_64-vmdk-boot.json
@@ -1321,6 +1321,11 @@
                 "type": "org.osbuild.files",
                 "origin": "org.osbuild.source",
                 "references": {
+                  "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:0064a3aeff41fb7345c061956c35e4b9d0b8802954e717491fb6eb51028d22fd": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -1361,12 +1366,22 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:031477484f48d6dac475ab735855a6d9c29e8f855c53cbb628def8c195d4bf5e": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:0337020f46cba670130c8bf50d3d88b90bc5b76e65f9326cc2806c66c49bbf5a": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
                   },
                   "sha256:03b50a4ea5cf5655c67e2358fabb6e563eec4e7929e7fc6c4e92c92694f60fa0": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:03ba0d5899e28527a3988b705b959f32de1b753f090e6c529e8c8cba1a200967": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -1387,6 +1402,11 @@
                     }
                   },
                   "sha256:06e3b40456f9be68076d03cf7181cbe0d73bf0a9424ab9e3abb7abf634ad3c47": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:07ed1209e898552e6aeac0e6d148271d562c576f7d903cb7a99a697643068f58": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -1456,6 +1476,16 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:0edde19e0c027c8cff31b82e1f4b0b198c00bf924047fcf4dd610a7d4965ab52": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:0feac495306bbe6e3149a352025bea8d23cda512859a230cbd3f510cf48caaf7": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:0ff9e879fc05de4714ff375ae810ccd0a86f23a18459a7fa8af4b365c3ccae6c": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -1506,6 +1536,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:17cebd5c2e6ad0cf05850096d2d54d667c0d2af7407dad68e35b4745abd1d4bc": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -1531,12 +1566,27 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:19ca7ab9cb2e39ec452ed1424f828ec464266094e31903301680d5a5d0e2ac2c": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:19d66d152b745dbd49cea9d21c52aec0ec4d4321edef97a342acd3542404fa31": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
                   },
                   "sha256:1a2f8df76e32a471249d5fd3e8d9ec6de5c5cc66354307dab42d81e6b2130bf3": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:1b53c868277dec628058b31b1a8a8a2ccd8efe832ce9694805b5f82564136eb3": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -1562,6 +1612,11 @@
                     }
                   },
                   "sha256:1fad1d1f8b56e6967863aeb60f5fa3615e6a35b0f6532d8a23066e6823b50860": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:20874a9d40b12125c9e5b97fe4ccda3f94acbc03da1dec7299123901f5b56631": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -1816,6 +1871,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:451d0cb6e2284578e3279b4cbb5ec98e9d98a687556c6b424adf8f1282d4ef58": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:4543844c3ebdc85d8c0facaeb9de9e0cda324995fd62e084ffdbf238204fa529": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -1886,6 +1946,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:4b878cfede2b1aa4458e6247464232ae78e4a9f39c6427b8219875c7362d5273": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:4be9a0c15cfe09f0451f5092ce0e7fc58770461247608125dbaf7558379f235a": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -1952,6 +2017,11 @@
                     }
                   },
                   "sha256:524d7475ccaead0c9b353535a1ca441a73ee465e35ea6f1c8833292af1967fc0": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:525393e4d658e395c6280bd2ff4afe54999796c4722986325297ba4bfade3ea5": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -2071,6 +2141,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:60b0cbc5e435be346bb06f45f3336f8936d7362022d8bceda80ff16bc3fb7dd2": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:61501f6b349afe8355f7ad032e1f6443976f2631b0d8960d900b8671978c2f16": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -2112,6 +2187,11 @@
                     }
                   },
                   "sha256:65ecf1e479dc2b2f7f09c2e86d7457043b3470b3eab3c4ee8909b50b0a669fc2": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:67419432fe7d373f8e5ddaa7b0dd1c25389608bf2f4ee76dbabcc2d96eb8c9d0": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -2251,6 +2331,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:7927147168e4f74efd126d2156bfcb841e251b4f960726476feecd17e1710fbe": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -2326,6 +2411,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:80ffd3c1ca47e469c9d69b9e88d5b385ba081e55412238ced56fecd996afdf8e": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -2347,6 +2437,11 @@
                     }
                   },
                   "sha256:829c842bbd79dca18d37198414626894c44e5b8faf0cce0054ca0ba6623ae136": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:82ce159a9e4e4b6b4fdce9ad954aa507f67108430bd261a4dcd826e44d0152a4": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -2376,6 +2471,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:85eb614fc608f3b3f4bbd08d4a3b0ff6af188677ea4e009be021680c521cedae": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:861c24f03117c7597167c5e8e3a9a920a3fffd5de346deec2a1bd6172a187120": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -2397,6 +2497,11 @@
                     }
                   },
                   "sha256:87f2a4d80cf4f6a958f3662c6a382edefc32a5ad2c364a7f3c40337cf2b1e8ba": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:8891a9a4707611c13a5693b195201dd940254ffdb03cf5742952329282bb8cb7": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -2461,6 +2566,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:92af3ab99545b691391158526294da044ff7dd51460db6ec8de81f99fc329375": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:93f86f6a4cd01bfb0d808801cb21b1eb25db351e6655d5bc804f631474010197": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -2472,6 +2582,11 @@
                     }
                   },
                   "sha256:940494444260f8437c62cfbe386666ab09ce6ed9fe898054e4917a792152e34f": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:9423e73b59c427ec6258be16d7c4e2014187ee81539652dc8bee95677d5e3f6e": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -2506,6 +2621,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:95cb9c201ee3b54fe6331bd7e74f43485632e95448d31fd340ffaa84a32b41ab": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:95e2fded4a5ff4b8807e71a35a0a781d52846cf00dd7ee4692d7932ac197ee39": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -2526,6 +2646,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:9851a70ab1371b4e86cdd268d36a7a87266c915fe7cb8a59ea8d422df320febf": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:98a6386df94fc9595365c3ecbc630708420fa68d1774614a723dec4a55e84b9c": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -2537,6 +2662,11 @@
                     }
                   },
                   "sha256:9a6e8072669988348eb5bc011ea2173a5d5fb2b2247f5889bd610d20f1bf8d29": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:9c7a5a6f73c8e32559226c54d229cb25304a81a853af22d9f829b9bb09b21f53": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -2662,6 +2792,11 @@
                     }
                   },
                   "sha256:aa0007192287faeaecc72d9fa48efdb3108c764d450dc8fea65474476da32c45": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -2816,6 +2951,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:bdc472abbb50eb652e78290b26756ad06ac2ea52e36f8acb3c4fc09bc7a58067": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:be2a5b35e9079d05d2e258e021ea3aefff973cdca931035465bab268a7a3e5ad": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -2857,6 +2997,11 @@
                     }
                   },
                   "sha256:c421b9c029abac796ade606f96d638e06a6d4ce5c2d499abd05812c306d25143": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:c45eaea64b54b27bcacb6d8e542c72ddbed5fafcd5e2facb08f7c04775e4f381": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -2907,6 +3052,11 @@
                     }
                   },
                   "sha256:ca1217252fae51339f8f30f753763332aaae528cd719484921d21130274b6fa6": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:cad86777bcb265db0da766952ff63e8d33f0fd4f3b90b22d0a1da587a785db44": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -3001,12 +3151,27 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:d1e8c7a00924d1a6dee44ade189025853a501d4f77c73f3bfc006aa907d97daf": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:d218619a4859e002fe677703bc1767986314cd196ae2ac397ed057f3bec36516": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:d2748115958b57c9c5125e23bad9462edbabb33c81197424a33d8060745ff646": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:d545ada129d3984d85f5049d88fc7b6a6c5653775062138349df7ec29a8cbee6": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:d5c283da0d2666742635754626263f6f78e273cd46d83d2d66ed43730a731685": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -3046,6 +3211,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:db2adf35874e77b875de93df9b5ac17d9c93f17248c77b4be6a22a50cb51a0f2": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:dbbc9e20caabc30070354d91f61f383081f6d658e09d3c09e6df8764559e5aca": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -3057,6 +3227,11 @@
                     }
                   },
                   "sha256:dcf21d0e24cc9ca00052bcbff40da076003fa4f8bd4a96fa99e43d7375f62a02": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:dea18976861575d40ffca814dee08a225376c7828a5afc9e5d0a383edd3d8907": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -3187,6 +3362,11 @@
                     }
                   },
                   "sha256:ea6321a3a85f3b8100709813acb21c4ef09796d234fe49079a6b7626f835e483": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:ebeb05a4a9cdd5d060859eabac1349029c0120615c98fc939e26664c030655c1": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -3347,6 +3527,11 @@
                     }
                   },
                   "sha256:fd7729725f0ee45728c665e078614a04eeb476966afa91a6294c53ccafb529ad": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:fdbfcb0183272d9c7f898ae529ea92b69b4fb0c16c20446a3c973bcbe1e5abef": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -3674,11 +3859,17 @@
           "sha256:02f10beaf61212427e0cd57140d050948eea0b533cf432d7bc4c10266c8b33db": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/xz-5.2.4-3.el8.x86_64.rpm"
           },
+          "sha256:031477484f48d6dac475ab735855a6d9c29e8f855c53cbb628def8c195d4bf5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm"
+          },
           "sha256:0337020f46cba670130c8bf50d3d88b90bc5b76e65f9326cc2806c66c49bbf5a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/glibc-2.28-189.el8.x86_64.rpm"
           },
           "sha256:03b50a4ea5cf5655c67e2358fabb6e563eec4e7929e7fc6c4e92c92694f60fa0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/mozjs60-60.9.0-4.el8.x86_64.rpm"
+          },
+          "sha256:03ba0d5899e28527a3988b705b959f32de1b753f090e6c529e8c8cba1a200967": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/cloud-init-21.1-13.el8.noarch.rpm"
           },
           "sha256:03e8d06d84b6c983524bb4e2c83559f7a28f13a668a3ff97782015a3c2ad36e5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/centos-gpg-keys-8-4.el8.noarch.rpm"
@@ -3691,6 +3882,9 @@
           },
           "sha256:06e3b40456f9be68076d03cf7181cbe0d73bf0a9424ab9e3abb7abf634ad3c47": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/kbd-2.0.4-10.el8.x86_64.rpm"
+          },
+          "sha256:07ed1209e898552e6aeac0e6d148271d562c576f7d903cb7a99a697643068f58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-cffi-1.11.5-5.el8.x86_64.rpm"
           },
           "sha256:08b76b0af07db4d3b27776a96bb7d0dc0f02b7219569676ac79036190d731d5b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libedit-3.1-23.20170329cvs.el8.x86_64.rpm"
@@ -3739,6 +3933,12 @@
           },
           "sha256:0e9a8a0f823bf0ef948862f0ccb62353460bd07931e756c98f23908c1c526578": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-decorator-4.2.1-2.el8.noarch.rpm"
+          },
+          "sha256:0edde19e0c027c8cff31b82e1f4b0b198c00bf924047fcf4dd610a7d4965ab52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-pytz-2017.2-9.el8.noarch.rpm"
+          },
+          "sha256:0feac495306bbe6e3149a352025bea8d23cda512859a230cbd3f510cf48caaf7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-jsonschema-2.6.0-4.el8.noarch.rpm"
           },
           "sha256:0ff9e879fc05de4714ff375ae810ccd0a86f23a18459a7fa8af4b365c3ccae6c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/e2fsprogs-libs-1.45.6-3.el8.x86_64.rpm"
@@ -3791,6 +3991,9 @@
           "sha256:18df4898df9e64a144245c9a180fecf5f87e378afffe90d9488758e1263b2e7b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/audit-libs-3.0.7-1.el8.x86_64.rpm"
           },
+          "sha256:19ca7ab9cb2e39ec452ed1424f828ec464266094e31903301680d5a5d0e2ac2c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libmaxminddb-1.2.0-10.el8.x86_64.rpm"
+          },
           "sha256:19d66d152b745dbd49cea9d21c52aec0ec4d4321edef97a342acd3542404fa31": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/bzip2-libs-1.0.6-26.el8.x86_64.rpm"
           },
@@ -3799,6 +4002,12 @@
           },
           "sha256:1b18f8d64433a5e74f3c0c0a962737833826527dfa6b9a26942506f7990885af": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-librepo-1.14.2-1.el8.x86_64.rpm"
+          },
+          "sha256:1b53c868277dec628058b31b1a8a8a2ccd8efe832ce9694805b5f82564136eb3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-prettytable-0.7.2-14.el8.noarch.rpm"
+          },
+          "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm"
           },
           "sha256:1c4b186665558747023a60d0d662d3780a1bc49e578062f4b70100c71ab2220c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/mokutil-0.3.0-11.el8.x86_64.rpm"
@@ -3814,6 +4023,9 @@
           },
           "sha256:1fad1d1f8b56e6967863aeb60f5fa3615e6a35b0f6532d8a23066e6823b50860": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/ca-certificates-2021.2.50-82.el8.noarch.rpm"
+          },
+          "sha256:20874a9d40b12125c9e5b97fe4ccda3f94acbc03da1dec7299123901f5b56631": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-oauthlib-2.1.0-1.el8.noarch.rpm"
           },
           "sha256:20bb189228afa589141d9c9d4ed457729d13c11608305387602d0b00ed0a3093": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libunistring-0.9.9-3.el8.x86_64.rpm"
@@ -3977,6 +4189,9 @@
           "sha256:42f48b1707318215f904134e014d00fac2d811ccc01943abc718b31ef05c0f34": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libkcapi-1.2.0-2.el8.x86_64.rpm"
           },
+          "sha256:451d0cb6e2284578e3279b4cbb5ec98e9d98a687556c6b424adf8f1282d4ef58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-libsemanage-2.9-6.el8.x86_64.rpm"
+          },
           "sha256:4543844c3ebdc85d8c0facaeb9de9e0cda324995fd62e084ffdbf238204fa529": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/glib2-2.56.4-158.el8.x86_64.rpm"
           },
@@ -4022,6 +4237,9 @@
           "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm"
           },
+          "sha256:4b878cfede2b1aa4458e6247464232ae78e4a9f39c6427b8219875c7362d5273": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-audit-3.0.7-1.el8.x86_64.rpm"
+          },
           "sha256:4be9a0c15cfe09f0451f5092ce0e7fc58770461247608125dbaf7558379f235a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/iwl5150-firmware-8.24.2.2-105.el8.1.noarch.rpm"
           },
@@ -4066,6 +4284,9 @@
           },
           "sha256:524d7475ccaead0c9b353535a1ca441a73ee465e35ea6f1c8833292af1967fc0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/trousers-0.3.15-1.el8.x86_64.rpm"
+          },
+          "sha256:525393e4d658e395c6280bd2ff4afe54999796c4722986325297ba4bfade3ea5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-pyyaml-3.12-12.el8.x86_64.rpm"
           },
           "sha256:5452b96e4b57c275dd41e48d55af1ca4f77ccfb3ae403796e599a039d7382b91": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libbasicobjects-0.1.1-39.el8.x86_64.rpm"
@@ -4139,6 +4360,9 @@
           "sha256:60927fc50f4b00fa6caa99fbb1867c96bd3fbfa40e52b6711729f51ffd078da4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/nss-softokn-freebl-3.67.0-7.el8_5.x86_64.rpm"
           },
+          "sha256:60b0cbc5e435be346bb06f45f3336f8936d7362022d8bceda80ff16bc3fb7dd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-jsonpointer-1.10-11.el8.noarch.rpm"
+          },
           "sha256:61501f6b349afe8355f7ad032e1f6443976f2631b0d8960d900b8671978c2f16": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libdrm-2.4.108-1.el8.x86_64.rpm"
           },
@@ -4165,6 +4389,9 @@
           },
           "sha256:65ecf1e479dc2b2f7f09c2e86d7457043b3470b3eab3c4ee8909b50b0a669fc2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/publicsuffix-list-dafsa-20180723-1.el8.noarch.rpm"
+          },
+          "sha256:67419432fe7d373f8e5ddaa7b0dd1c25389608bf2f4ee76dbabcc2d96eb8c9d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/geolite2-country-20180605-1.el8.noarch.rpm"
           },
           "sha256:67667524adbae5df6a49b188a28073ef66b090a47c166ab0ddbcbe830b584f6f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/dracut-network-049-201.git20220131.el8.x86_64.rpm"
@@ -4316,6 +4543,9 @@
           "sha256:829c842bbd79dca18d37198414626894c44e5b8faf0cce0054ca0ba6623ae136": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/gettext-0.19.8.1-17.el8.x86_64.rpm"
           },
+          "sha256:82ce159a9e4e4b6b4fdce9ad954aa507f67108430bd261a4dcd826e44d0152a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-pyserial-3.1.1-8.el8.noarch.rpm"
+          },
           "sha256:82e27237686171b812aee7903c11ec4f8dbdb6544e419758fb0fbd61731044b0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/ipset-7.1-1.el8.x86_64.rpm"
           },
@@ -4331,6 +4561,9 @@
           "sha256:84cef50494317f6e968c8a27134e6f442a1898b137715bd69573d6d72e7b6fb1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/iptables-libs-1.8.4-22.el8.x86_64.rpm"
           },
+          "sha256:85eb614fc608f3b3f4bbd08d4a3b0ff6af188677ea4e009be021680c521cedae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-jsonpatch-1.21-2.el8.noarch.rpm"
+          },
           "sha256:861c24f03117c7597167c5e8e3a9a920a3fffd5de346deec2a1bd6172a187120": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-unbound-1.7.3-17.el8.x86_64.rpm"
           },
@@ -4345,6 +4578,9 @@
           },
           "sha256:87f2a4d80cf4f6a958f3662c6a382edefc32a5ad2c364a7f3c40337cf2b1e8ba": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libcroco-0.6.12-4.el8_2.1.x86_64.rpm"
+          },
+          "sha256:8891a9a4707611c13a5693b195201dd940254ffdb03cf5742952329282bb8cb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-pycparser-2.14-14.el8.noarch.rpm"
           },
           "sha256:893119e9cc3b3ca13f8e55bfd5705f69973bafcdd2aba7b28c44c354628de3c5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libsss_nss_idmap-2.6.1-2.el8.x86_64.rpm"
@@ -4385,6 +4621,9 @@
           "sha256:910e67c097669fc195fe93bc04e03fe06802a69a7c11f0998d3523f5cc207605": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/open-vm-tools-11.3.5-1.el8.x86_64.rpm"
           },
+          "sha256:92af3ab99545b691391158526294da044ff7dd51460db6ec8de81f99fc329375": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/dhcp-common-4.3.6-47.el8.0.1.noarch.rpm"
+          },
           "sha256:93f86f6a4cd01bfb0d808801cb21b1eb25db351e6655d5bc804f631474010197": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/iputils-20180629-8.el8.x86_64.rpm"
           },
@@ -4393,6 +4632,9 @@
           },
           "sha256:940494444260f8437c62cfbe386666ab09ce6ed9fe898054e4917a792152e34f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/nss-softokn-3.67.0-7.el8_5.x86_64.rpm"
+          },
+          "sha256:9423e73b59c427ec6258be16d7c4e2014187ee81539652dc8bee95677d5e3f6e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/dhcp-client-4.3.6-47.el8.0.1.x86_64.rpm"
           },
           "sha256:946ba273a3a3b6fdf140f3c03112918c0a556a5871c477f5dbbb98600e6ca557": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/platform-python-setuptools-39.2.0-6.el8.noarch.rpm"
@@ -4412,6 +4654,9 @@
           "sha256:956da9a94f3f2331df649b8351ebeb0c102702486ff447e8252e7af3b96ab414": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/squashfs-tools-4.3-20.el8.x86_64.rpm"
           },
+          "sha256:95cb9c201ee3b54fe6331bd7e74f43485632e95448d31fd340ffaa84a32b41ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm"
+          },
           "sha256:95e2fded4a5ff4b8807e71a35a0a781d52846cf00dd7ee4692d7932ac197ee39": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/grub2-common-2.02-106.el8.noarch.rpm"
           },
@@ -4423,6 +4668,9 @@
           },
           "sha256:9729d5fd2ecbf6902329585a4acdd09f2f591673802ca89dd575ba8351991814": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/file-5.33-20.el8.x86_64.rpm"
+          },
+          "sha256:9851a70ab1371b4e86cdd268d36a7a87266c915fe7cb8a59ea8d422df320febf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-setools-4.3.0-3.el8.x86_64.rpm"
           },
           "sha256:98a6386df94fc9595365c3ecbc630708420fa68d1774614a723dec4a55e84b9c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/json-glib-1.4.4-1.el8.x86_64.rpm"
@@ -4616,6 +4864,9 @@
           "sha256:bd591ce02aca250a87f879e3f220632589218f384ac968e46c558cd7468fddbb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/glibc-gconv-extra-2.28-189.el8.x86_64.rpm"
           },
+          "sha256:bdc472abbb50eb652e78290b26756ad06ac2ea52e36f8acb3c4fc09bc7a58067": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/bind-export-libs-9.11.36-2.el8.x86_64.rpm"
+          },
           "sha256:be2a5b35e9079d05d2e258e021ea3aefff973cdca931035465bab268a7a3e5ad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libblockdev-crypto-2.24-8.el8.x86_64.rpm"
           },
@@ -4642,6 +4893,9 @@
           },
           "sha256:c421b9c029abac796ade606f96d638e06a6d4ce5c2d499abd05812c306d25143": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/cyrus-sasl-lib-2.1.27-5.el8.x86_64.rpm"
+          },
+          "sha256:c45eaea64b54b27bcacb6d8e542c72ddbed5fafcd5e2facb08f7c04775e4f381": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-netifaces-0.10.6-4.el8.x86_64.rpm"
           },
           "sha256:c515d78c64a93d8b469593bff5800eccd50f24b16697ab13bdce81238c38eb77": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/diffutils-3.6-6.el8.x86_64.rpm"
@@ -4675,6 +4929,9 @@
           },
           "sha256:ca1217252fae51339f8f30f753763332aaae528cd719484921d21130274b6fa6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/dbus-daemon-1.12.8-18.el8.x86_64.rpm"
+          },
+          "sha256:cad86777bcb265db0da766952ff63e8d33f0fd4f3b90b22d0a1da587a785db44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/geolite2-city-20180605-1.el8.noarch.rpm"
           },
           "sha256:cb17e2ad56305c99d1589a9965e34b62e342f7ee0348cdb17c852f65db24221e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/rpm-libs-4.14.3-21.el8.x86_64.rpm"
@@ -4730,11 +4987,20 @@
           "sha256:d1cc79976965be3fe769cb8c23a281064816eaa195caf6057b8d1da0e9ff7ae5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libbytesize-1.4-3.el8.x86_64.rpm"
           },
+          "sha256:d1e8c7a00924d1a6dee44ade189025853a501d4f77c73f3bfc006aa907d97daf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-ply-3.9-9.el8.noarch.rpm"
+          },
           "sha256:d218619a4859e002fe677703bc1767986314cd196ae2ac397ed057f3bec36516": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/p11-kit-trust-0.23.22-1.el8.x86_64.rpm"
           },
+          "sha256:d2748115958b57c9c5125e23bad9462edbabb33c81197424a33d8060745ff646": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-babel-2.5.1-7.el8.noarch.rpm"
+          },
           "sha256:d545ada129d3984d85f5049d88fc7b6a6c5653775062138349df7ec29a8cbee6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/tpm2-tss-2.3.2-4.el8.x86_64.rpm"
+          },
+          "sha256:d5c283da0d2666742635754626263f6f78e273cd46d83d2d66ed43730a731685": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/checkpolicy-2.9-1.el8.x86_64.rpm"
           },
           "sha256:d654a9cff90f93c970d81afe543d33c1c4ae28cc529b023fd9d6e257aad32bc3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/linux-firmware-20211119-105.gitf5d51956.el8.noarch.rpm"
@@ -4757,6 +5023,9 @@
           "sha256:dae52ddd215b506d1805b66873194df5043fd758d42960dee68f029eab329b42": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libdaemon-0.14-15.el8.x86_64.rpm"
           },
+          "sha256:db2adf35874e77b875de93df9b5ac17d9c93f17248c77b4be6a22a50cb51a0f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-cryptography-3.2.1-5.el8.x86_64.rpm"
+          },
           "sha256:dbbc9e20caabc30070354d91f61f383081f6d658e09d3c09e6df8764559e5aca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/cracklib-2.9.6-15.el8.x86_64.rpm"
           },
@@ -4765,6 +5034,9 @@
           },
           "sha256:dcf21d0e24cc9ca00052bcbff40da076003fa4f8bd4a96fa99e43d7375f62a02": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/microcode_ctl-20210608-1.el8.x86_64.rpm"
+          },
+          "sha256:dea18976861575d40ffca814dee08a225376c7828a5afc9e5d0a383edd3d8907": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/ipcalc-0.2.4-4.el8.x86_64.rpm"
           },
           "sha256:deb19644235b9703eb68b210e2b1bc599c475adb44298bae8131abeeef88c8a7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libtalloc-2.3.3-1.el8.x86_64.rpm"
@@ -4846,6 +5118,9 @@
           },
           "sha256:ea6321a3a85f3b8100709813acb21c4ef09796d234fe49079a6b7626f835e483": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libuser-0.62-24.el8.x86_64.rpm"
+          },
+          "sha256:ebeb05a4a9cdd5d060859eabac1349029c0120615c98fc939e26664c030655c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-jwt-1.6.1-2.el8.noarch.rpm"
           },
           "sha256:ed1f7ab0225df75734034cb2aea426c48c089f2bd476ec66b66af879437c5393": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/tar-1.30-5.el8.x86_64.rpm"
@@ -4954,6 +5229,9 @@
           },
           "sha256:fd888e489ae944e957265393f6b2ada131569459e13f30a48528a2bbb4054e58": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-kickstart-3.16.14-1.el8.noarch.rpm"
+          },
+          "sha256:fdbfcb0183272d9c7f898ae529ea92b69b4fb0c16c20446a3c973bcbe1e5abef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/dhcp-libs-4.3.6-47.el8.0.1.x86_64.rpm"
           },
           "sha256:fe9a848502c595e0b7acc699d69c24b9c5ad0ac58a0b3933cd228f3633de31cb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/nettle-3.4.1-7.el8.x86_64.rpm"
@@ -9215,6 +9493,16 @@
         "check_gpg": true
       },
       {
+        "name": "bind-export-libs",
+        "epoch": 32,
+        "version": "9.11.36",
+        "release": "2.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/bind-export-libs-9.11.36-2.el8.x86_64.rpm",
+        "checksum": "sha256:bdc472abbb50eb652e78290b26756ad06ac2ea52e36f8acb3c4fc09bc7a58067",
+        "check_gpg": true
+      },
+      {
         "name": "biosdevname",
         "epoch": 0,
         "version": "0.7.3",
@@ -9302,6 +9590,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/centos-stream-repos-8-4.el8.noarch.rpm",
         "checksum": "sha256:6421059eda903b4494c4b01689193d81a3161b5e7f04697f810e96cb901b970e",
+        "check_gpg": true
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "1.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/checkpolicy-2.9-1.el8.x86_64.rpm",
+        "checksum": "sha256:d5c283da0d2666742635754626263f6f78e273cd46d83d2d66ed43730a731685",
         "check_gpg": true
       },
       {
@@ -9532,6 +9830,36 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.3.6",
+        "release": "47.el8.0.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/dhcp-client-4.3.6-47.el8.0.1.x86_64.rpm",
+        "checksum": "sha256:9423e73b59c427ec6258be16d7c4e2014187ee81539652dc8bee95677d5e3f6e",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.3.6",
+        "release": "47.el8.0.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/dhcp-common-4.3.6-47.el8.0.1.noarch.rpm",
+        "checksum": "sha256:92af3ab99545b691391158526294da044ff7dd51460db6ec8de81f99fc329375",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-libs",
+        "epoch": 12,
+        "version": "4.3.6",
+        "release": "47.el8.0.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/dhcp-libs-4.3.6-47.el8.0.1.x86_64.rpm",
+        "checksum": "sha256:fdbfcb0183272d9c7f898ae529ea92b69b4fb0c16c20446a3c973bcbe1e5abef",
         "check_gpg": true
       },
       {
@@ -10192,6 +10520,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/initscripts-10.00.17-1.el8.x86_64.rpm",
         "checksum": "sha256:7875ef88b689e6249a87ebbbed865b31fe78f31091de39e89869ff369e61bb38",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "4.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/ipcalc-0.2.4-4.el8.x86_64.rpm",
+        "checksum": "sha256:dea18976861575d40ffca814dee08a225376c7828a5afc9e5d0a383edd3d8907",
         "check_gpg": true
       },
       {
@@ -12115,6 +12453,56 @@
         "check_gpg": true
       },
       {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0.7",
+        "release": "1.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-audit-3.0.7-1.el8.x86_64.rpm",
+        "checksum": "sha256:4b878cfede2b1aa4458e6247464232ae78e4a9f39c6427b8219875c7362d5273",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cffi",
+        "epoch": 0,
+        "version": "1.11.5",
+        "release": "5.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-cffi-1.11.5-5.el8.x86_64.rpm",
+        "checksum": "sha256:07ed1209e898552e6aeac0e6d148271d562c576f7d903cb7a99a697643068f58",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "3.0.4",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm",
+        "checksum": "sha256:176ffcb2cf0fdcbdd2d8119cbd98eef60a30fdb0fb065a9382d2c95e90c79652",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-configobj",
+        "epoch": 0,
+        "version": "5.0.6",
+        "release": "11.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm",
+        "checksum": "sha256:1bd969e0521820374122f5132e5998d9bd2ab185be66565a7266096297419c8e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-cryptography",
+        "epoch": 0,
+        "version": "3.2.1",
+        "release": "5.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-cryptography-3.2.1-5.el8.x86_64.rpm",
+        "checksum": "sha256:db2adf35874e77b875de93df9b5ac17d9c93f17248c77b4be6a22a50cb51a0f2",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dateutil",
         "epoch": 1,
         "version": "2.6.1",
@@ -12205,6 +12593,26 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-idna-2.5-5.el8.noarch.rpm",
+        "checksum": "sha256:78c43d8a15ca018de1803e4baac5819e1baab1963fd31f1e44e54e8a573acbfc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jwt",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-jwt-1.6.1-2.el8.noarch.rpm",
+        "checksum": "sha256:ebeb05a4a9cdd5d060859eabac1349029c0120615c98fc939e26664c030655c1",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.18",
@@ -12245,6 +12653,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-libsemanage-2.9-6.el8.x86_64.rpm",
+        "checksum": "sha256:451d0cb6e2284578e3279b4cbb5ec98e9d98a687556c6b424adf8f1282d4ef58",
+        "check_gpg": true
+      },
+      {
         "name": "python3-linux-procfs",
         "epoch": 0,
         "version": "0.7.0",
@@ -12262,6 +12680,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-nftables-0.9.3-24.el8.x86_64.rpm",
         "checksum": "sha256:56e3aaed4790949f4ae57e61b02f97f2e8d9da24eb75b847c1609ceab18efe1f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-oauthlib-2.1.0-1.el8.noarch.rpm",
+        "checksum": "sha256:20874a9d40b12125c9e5b97fe4ccda3f94acbc03da1dec7299123901f5b56631",
         "check_gpg": true
       },
       {
@@ -12285,6 +12713,46 @@
         "check_gpg": true
       },
       {
+        "name": "python3-ply",
+        "epoch": 0,
+        "version": "3.9",
+        "release": "9.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-ply-3.9-9.el8.noarch.rpm",
+        "checksum": "sha256:d1e8c7a00924d1a6dee44ade189025853a501d4f77c73f3bfc006aa907d97daf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "18.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm",
+        "checksum": "sha256:031477484f48d6dac475ab735855a6d9c29e8f855c53cbb628def8c195d4bf5e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pycparser",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-pycparser-2.14-14.el8.noarch.rpm",
+        "checksum": "sha256:8891a9a4707611c13a5693b195201dd940254ffdb03cf5742952329282bb8cb7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.6.8",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm",
+        "checksum": "sha256:7f506879c64e0bb4d98782d025f46fb9a07517487ae4cbebbb3985a98f4e2154",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pyudev",
         "epoch": 0,
         "version": "0.21.0",
@@ -12295,6 +12763,26 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "3.12",
+        "release": "12.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-pyyaml-3.12-12.el8.x86_64.rpm",
+        "checksum": "sha256:525393e4d658e395c6280bd2ff4afe54999796c4722986325297ba4bfade3ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.20.0",
+        "release": "2.1.el8_1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm",
+        "checksum": "sha256:003ee19ec5b88de212c3246bdfdb3e97a9910a25a219fd7cf5030b7bc666fea9",
+        "check_gpg": true
+      },
+      {
         "name": "python3-rpm",
         "epoch": 0,
         "version": "4.14.3",
@@ -12302,6 +12790,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-rpm-4.14.3-21.el8.x86_64.rpm",
         "checksum": "sha256:3c1def0d7e748535e2562afbace25daccf2b42fd52696af72a018b00e7adb911",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.3.0",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-setools-4.3.0-3.el8.x86_64.rpm",
+        "checksum": "sha256:9851a70ab1371b4e86cdd268d36a7a87266c915fe7cb8a59ea8d422df320febf",
         "check_gpg": true
       },
       {
@@ -12352,6 +12850,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-syspurpose-1.28.25-1.el8.x86_64.rpm",
         "checksum": "sha256:948751f111ab8d2a6950f6eabbacc2aef2eaa6f9f7ae3d2667d3716a226b30d9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.24.2",
+        "release": "5.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/python3-urllib3-1.24.2-5.el8.noarch.rpm",
+        "checksum": "sha256:aa1835fd302a37b84ac256db5dd0de09bd9883a5a07775aedb491faf46b18ee0",
         "check_gpg": true
       },
       {
@@ -12815,6 +13323,36 @@
         "check_gpg": true
       },
       {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "21.1",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/cloud-init-21.1-13.el8.noarch.rpm",
+        "checksum": "sha256:03ba0d5899e28527a3988b705b959f32de1b753f090e6c529e8c8cba1a200967",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20180605",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/geolite2-city-20180605-1.el8.noarch.rpm",
+        "checksum": "sha256:cad86777bcb265db0da766952ff63e8d33f0fd4f3b90b22d0a1da587a785db44",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20180605",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/geolite2-country-20180605-1.el8.noarch.rpm",
+        "checksum": "sha256:67419432fe7d373f8e5ddaa7b0dd1c25389608bf2f4ee76dbabcc2d96eb8c9d0",
+        "check_gpg": true
+      },
+      {
         "name": "glibc-gconv-extra",
         "epoch": 0,
         "version": "2.28",
@@ -12965,6 +13503,16 @@
         "check_gpg": true
       },
       {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "10.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/libmaxminddb-1.2.0-10.el8.x86_64.rpm",
+        "checksum": "sha256:19ca7ab9cb2e39ec452ed1424f828ec464266094e31903301680d5a5d0e2ac2c",
+        "check_gpg": true
+      },
+      {
         "name": "libmspack",
         "epoch": 0,
         "version": "0.7",
@@ -13105,6 +13653,106 @@
         "check_gpg": true
       },
       {
+        "name": "python3-babel",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-babel-2.5.1-7.el8.noarch.rpm",
+        "checksum": "sha256:d2748115958b57c9c5125e23bad9462edbabb33c81197424a33d8060745ff646",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jinja2",
+        "epoch": 0,
+        "version": "2.10.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm",
+        "checksum": "sha256:95cb9c201ee3b54fe6331bd7e74f43485632e95448d31fd340ffaa84a32b41ab",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpatch",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-jsonpatch-1.21-2.el8.noarch.rpm",
+        "checksum": "sha256:85eb614fc608f3b3f4bbd08d4a3b0ff6af188677ea4e009be021680c521cedae",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpointer",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "11.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-jsonpointer-1.10-11.el8.noarch.rpm",
+        "checksum": "sha256:60b0cbc5e435be346bb06f45f3336f8936d7362022d8bceda80ff16bc3fb7dd2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonschema",
+        "epoch": 0,
+        "version": "2.6.0",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-jsonschema-2.6.0-4.el8.noarch.rpm",
+        "checksum": "sha256:0feac495306bbe6e3149a352025bea8d23cda512859a230cbd3f510cf48caaf7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "0.23",
+        "release": "19.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-markupsafe-0.23-19.el8.x86_64.rpm",
+        "checksum": "sha256:9c7a5a6f73c8e32559226c54d229cb25304a81a853af22d9f829b9bb09b21f53",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-netifaces",
+        "epoch": 0,
+        "version": "0.10.6",
+        "release": "4.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-netifaces-0.10.6-4.el8.x86_64.rpm",
+        "checksum": "sha256:c45eaea64b54b27bcacb6d8e542c72ddbed5fafcd5e2facb08f7c04775e4f381",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-prettytable-0.7.2-14.el8.noarch.rpm",
+        "checksum": "sha256:1b53c868277dec628058b31b1a8a8a2ccd8efe832ce9694805b5f82564136eb3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyserial",
+        "epoch": 0,
+        "version": "3.1.1",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-pyserial-3.1.1-8.el8.noarch.rpm",
+        "checksum": "sha256:82ce159a9e4e4b6b4fdce9ad954aa507f67108430bd261a4dcd826e44d0152a4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pytz",
+        "epoch": 0,
+        "version": "2017.2",
+        "release": "9.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/python3-pytz-2017.2-9.el8.noarch.rpm",
+        "checksum": "sha256:0edde19e0c027c8cff31b82e1f4b0b198c00bf924047fcf4dd610a7d4965ab52",
+        "check_gpg": true
+      },
+      {
         "name": "python3-unbound",
         "epoch": 0,
         "version": "1.7.3",
@@ -13213,6 +13861,114 @@
       "pool": [
         "2.centos.pool.ntp.org iburst"
       ]
+    },
+    "cloud-init": {
+      "/etc/cloud": {
+        "cloud.cfg": {
+          "cloud_config_modules": [
+            "mounts",
+            "locale",
+            "set-passwords",
+            "rh_subscription",
+            "yum-add-repo",
+            "package-update-upgrade-install",
+            "timezone",
+            "puppet",
+            "chef",
+            "salt-minion",
+            "mcollective",
+            "disable-ec2-metadata",
+            "runcmd"
+          ],
+          "cloud_final_modules": [
+            "rightscale_userdata",
+            "scripts-per-once",
+            "scripts-per-boot",
+            "scripts-per-instance",
+            "scripts-user",
+            "ssh-authkey-fingerprints",
+            "keys-to-console",
+            "phone-home",
+            "final-message",
+            "power-state-change"
+          ],
+          "cloud_init_modules": [
+            "disk_setup",
+            "migrator",
+            "bootcmd",
+            "write-files",
+            "growpart",
+            "resizefs",
+            "set_hostname",
+            "update_hostname",
+            "update_etc_hosts",
+            "rsyslog",
+            "users-groups",
+            "ssh"
+          ],
+          "disable_root": 1,
+          "disable_vmware_customization": false,
+          "mount_default_fields": [
+            null,
+            null,
+            "auto",
+            "defaults,nofail,x-systemd.requires=cloud-init.service",
+            "0",
+            "2"
+          ],
+          "resize_rootfs_tmp": "/dev",
+          "ssh_deletekeys": 1,
+          "ssh_genkeytypes": [
+            "rsa",
+            "ecdsa",
+            "ed25519"
+          ],
+          "ssh_pwauth": 0,
+          "syslog_fix_perms": null,
+          "system_info": {
+            "default_user": {
+              "gecos": "Cloud User",
+              "groups": [
+                "adm",
+                "systemd-journal"
+              ],
+              "lock_passwd": true,
+              "name": "cloud-user",
+              "shell": "/bin/bash",
+              "sudo": [
+                "ALL=(ALL) NOPASSWD:ALL"
+              ]
+            },
+            "distro": "rhel",
+            "paths": {
+              "cloud_dir": "/var/lib/cloud",
+              "templates_dir": "/etc/cloud/templates"
+            },
+            "ssh_svcname": "sshd"
+          },
+          "users": [
+            "default"
+          ]
+        }
+      },
+      "/etc/cloud/cloud.cfg.d": {
+        "05_logging.cfg": {
+          "_log": [
+            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
+            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
+          ],
+          "log_cfgs": [
+            [
+              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
+            ]
+          ],
+          "output": {
+            "all": "| tee -a /var/log/cloud-init-output.log"
+          }
+        }
+      }
     },
     "default-target": "graphical.target",
     "dnf": {
@@ -13374,6 +14130,7 @@
       "authselect-libs-1.2.2-3.el8.x86_64",
       "basesystem-11-5.el8.noarch",
       "bash-4.4.20-3.el8.x86_64",
+      "bind-export-libs-9.11.36-2.el8.x86_64",
       "biosdevname-0.7.3-2.el8.x86_64",
       "brotli-1.0.6-3.el8.x86_64",
       "bubblewrap-0.4.0-1.el8.x86_64",
@@ -13383,8 +14140,10 @@
       "centos-gpg-keys-8-4.el8.noarch",
       "centos-stream-release-8.6-1.el8.noarch",
       "centos-stream-repos-8-4.el8.noarch",
+      "checkpolicy-2.9-1.el8.x86_64",
       "chkconfig-1.19.1-1.el8.x86_64",
       "chrony-4.1-1.el8.x86_64",
+      "cloud-init-21.1-13.el8.noarch",
       "coreutils-8.30-12.el8.x86_64",
       "coreutils-common-8.30-12.el8.x86_64",
       "cpio-2.12-11.el8.x86_64",
@@ -13406,6 +14165,9 @@
       "dbus-tools-1.12.8-18.el8.x86_64",
       "device-mapper-1.02.181-3.el8.x86_64",
       "device-mapper-libs-1.02.181-3.el8.x86_64",
+      "dhcp-client-4.3.6-47.el8.0.1.x86_64",
+      "dhcp-common-4.3.6-47.el8.0.1.noarch",
+      "dhcp-libs-4.3.6-47.el8.0.1.x86_64",
       "diffutils-3.6-6.el8.x86_64",
       "dmidecode-3.3-1.el8.x86_64",
       "dnf-4.7.0-7.el8.noarch",
@@ -13442,6 +14204,8 @@
       "gdbm-1.18-1.el8.x86_64",
       "gdbm-libs-1.18-1.el8.x86_64",
       "gdisk-1.0.3-8.el8.x86_64",
+      "geolite2-city-20180605-1.el8.noarch",
+      "geolite2-country-20180605-1.el8.noarch",
       "gettext-0.19.8.1-17.el8.x86_64",
       "gettext-libs-0.19.8.1-17.el8.x86_64",
       "glib2-2.56.4-158.el8.x86_64",
@@ -13475,6 +14239,7 @@
       "ima-evm-utils-1.3.2-12.el8.x86_64",
       "info-6.5-7.el8_5.x86_64",
       "initscripts-10.00.17-1.el8.x86_64",
+      "ipcalc-0.2.4-4.el8.x86_64",
       "iproute-5.15.0-2.el8.x86_64",
       "iprutils-2.4.19-1.el8.x86_64",
       "ipset-7.1-1.el8.x86_64",
@@ -13566,6 +14331,7 @@
       "libkcapi-hmaccalc-1.2.0-2.el8.x86_64",
       "libksba-1.3.5-7.el8.x86_64",
       "libldb-2.4.1-1.el8.x86_64",
+      "libmaxminddb-1.2.0-10.el8.x86_64",
       "libmnl-1.0.4-6.el8.x86_64",
       "libmodulemd-2.13.0-1.el8.x86_64",
       "libmount-2.32.1-32.el8.x86_64",
@@ -13695,6 +14461,12 @@
       "protobuf-c-1.3.0-6.el8.x86_64",
       "psmisc-23.1-5.el8.x86_64",
       "publicsuffix-list-dafsa-20180723-1.el8.noarch",
+      "python3-audit-3.0.7-1.el8.x86_64",
+      "python3-babel-2.5.1-7.el8.noarch",
+      "python3-cffi-1.11.5-5.el8.x86_64",
+      "python3-chardet-3.0.4-7.el8.noarch",
+      "python3-configobj-5.0.6-11.el8.noarch",
+      "python3-cryptography-3.2.1-5.el8.x86_64",
       "python3-dateutil-2.6.1-6.el8.noarch",
       "python3-dbus-1.2.4-15.el8.x86_64",
       "python3-decorator-4.2.1-2.el8.noarch",
@@ -13704,22 +14476,43 @@
       "python3-gobject-base-3.28.3-2.el8.x86_64",
       "python3-gpg-1.13.1-9.el8.x86_64",
       "python3-hawkey-0.63.0-7.el8.x86_64",
+      "python3-idna-2.5-5.el8.noarch",
+      "python3-jinja2-2.10.1-3.el8.noarch",
+      "python3-jsonpatch-1.21-2.el8.noarch",
+      "python3-jsonpointer-1.10-11.el8.noarch",
+      "python3-jsonschema-2.6.0-4.el8.noarch",
+      "python3-jwt-1.6.1-2.el8.noarch",
       "python3-libcomps-0.1.18-1.el8.x86_64",
       "python3-libdnf-0.63.0-7.el8.x86_64",
       "python3-libs-3.6.8-45.el8.x86_64",
       "python3-libselinux-2.9-5.el8.x86_64",
+      "python3-libsemanage-2.9-6.el8.x86_64",
       "python3-linux-procfs-0.7.0-1.el8.noarch",
+      "python3-markupsafe-0.23-19.el8.x86_64",
+      "python3-netifaces-0.10.6-4.el8.x86_64",
       "python3-nftables-0.9.3-24.el8.x86_64",
+      "python3-oauthlib-2.1.0-1.el8.noarch",
       "python3-perf-4.18.0-358.el8.x86_64",
       "python3-pip-wheel-9.0.3-22.el8.noarch",
+      "python3-ply-3.9-9.el8.noarch",
+      "python3-policycoreutils-2.9-18.el8.noarch",
+      "python3-prettytable-0.7.2-14.el8.noarch",
+      "python3-pycparser-2.14-14.el8.noarch",
+      "python3-pyserial-3.1.1-8.el8.noarch",
+      "python3-pysocks-1.6.8-3.el8.noarch",
+      "python3-pytz-2017.2-9.el8.noarch",
       "python3-pyudev-0.21.0-7.el8.noarch",
+      "python3-pyyaml-3.12-12.el8.x86_64",
+      "python3-requests-2.20.0-2.1.el8_1.noarch",
       "python3-rpm-4.14.3-21.el8.x86_64",
+      "python3-setools-4.3.0-3.el8.x86_64",
       "python3-setuptools-wheel-39.2.0-6.el8.noarch",
       "python3-six-1.11.0-8.el8.noarch",
       "python3-slip-0.6.4-11.el8.noarch",
       "python3-slip-dbus-0.6.4-11.el8.noarch",
       "python3-syspurpose-1.28.25-1.el8.x86_64",
       "python3-unbound-1.7.3-17.el8.x86_64",
+      "python3-urllib3-1.24.2-5.el8.noarch",
       "readline-7.0-10.el8.x86_64",
       "rootfiles-8.1-22.el8.noarch",
       "rpm-4.14.3-21.el8.x86_64",
@@ -13899,6 +14692,10 @@
       "auditd.service",
       "autovt@.service",
       "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
       "crond.service",
       "ctrl-alt-del.target",
       "dbus-org.fedoraproject.FirewallD1.service",
@@ -14041,6 +14838,9 @@
     "timezone": "New_York",
     "tmpfiles.d": {
       "/usr/lib/tmpfiles.d": {
+        "cloud-init.conf": [
+          "d /run/cloud-init 0700 root root - -"
+        ],
         "cryptsetup.conf": [
           "d /run/cryptsetup 0700 root root -"
         ],

--- a/test/data/manifests/centos_9-x86_64-vmdk-boot.json
+++ b/test/data/manifests/centos_9-x86_64-vmdk-boot.json
@@ -1315,6 +1315,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:0a8e44906d718132a13d6de94fbd9fe99a2e2c516e54607917a81dd9ece06d6e": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:0afe6e35348485ae2696e6170dcf34370f33fcf42a357fc815e332d939dd1025": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -1455,6 +1460,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:194acd1a65f4fcb3e3f2c2ff694646cf6a814ff881f867c6f65547258fd1b741": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:194eca101ef8d9c40a427f67ca8ad076dd667ff75a7beb0c093ba5093515cd35": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -1486,6 +1496,11 @@
                     }
                   },
                   "sha256:1b712e683fd47b48b01a8a114ffbc50a7f541b26a0c5f43e07f507a60e601161": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:1c47e46d8d95ee63d01aa7b618b1e883705a9e1b4e48239684bda7e308f780f9": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -1550,6 +1565,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:2420bc9d6d1549f7a0625305b8d7aa3e2d797d65ee6384eec4c6139028ccd216": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:26191af0cc7acf9bb335ebd8b4ed357582165ee3be78fce9f4395f84ad2805ce": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -1561,6 +1581,11 @@
                     }
                   },
                   "sha256:2629a79d1b680eab75cce332e1a47234f68f0fe12f29cb81d5c31a9afb8e0cad": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:2657c134fdbef4f7ce1194fd1f6c454e9069b2364c58c4be5a337e44da40a419": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -1676,6 +1701,11 @@
                     }
                   },
                   "sha256:35d2595455e930ac9a1cb2dfeaa2cfe6f126c651110d4d468b9b1f554667c0a8": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:370ab59bdcfc5657002bb12c6344a90338e4ccc735de9967575f06c5cf3c65a7": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -1806,6 +1836,11 @@
                     }
                   },
                   "sha256:47e168e6436a246270d3704bcec485d1990fdc327e16fef145bb3acc464d2dca": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:4814e7fd9810db89815950cb94dd4f860432ecb473b35a885296ad611e87fba6": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -2020,6 +2055,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:6471d1e5a24b0c084f5d5a45ad7e0d6f4264f1b33ecdb5d7825f7d3e9fca3a5b": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:647a3b9a52df25cb2aaf7f3715b219839b4cf71913638c88172d925173280812": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -2035,7 +2075,17 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:651de672518dbc791dd9f40881d43d2fe67dd7c5aa2568e8ec39c7d2336561b4": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:656031558c53da4a5b3ccfd883bd6d55996037891323152b1f07e8d1d5377406": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:66105c0910b86fde1607dff6bf2e47f3f91e9f7ce0b51311cd21d77aa1be1c86": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -2106,6 +2156,11 @@
                     }
                   },
                   "sha256:708fbc3c7fd77a21e0b391e2a80d5c344962de9865e79514b2c89210ef06ba39": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:70b97ef7a9647cc09a85ece81f480ae0fe41220f2e4d7399e4df0347f59b0910": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -2205,12 +2260,22 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:7d85a2bb6c382288e1be0f338f80d7d96de345efebb4cc38c7028b3f630cfbc5": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:7e48569645eea550de033eef433ef742278933429cc5a4180ea08842e54a5c6f": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
                   },
                   "sha256:7e62a0ed0a508486b565e48794a146022f344aeb6801834ad7c5afe6a97ef065": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:7e6e354e0503b143139e8188aa0f8a1a01dc9ef1781f1392d34be9c68a53837b": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -2280,6 +2345,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:87671b5b055867093fe2349a299ec93daaeb94e86b0e12e44372433b27084818": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:879771cd51bb4ef2afd2e4a8d29b4f66040ec7f0f47d647f2c00ab0122bdf8e0": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -2301,6 +2371,11 @@
                     }
                   },
                   "sha256:8cd5a78cab8783dd241c52c4fcda28fb111c443887dd6d0fe38385e8383c98b3": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:8cde6a3234941c997cefcc3d3bb8e2fcca07d1b00261ca452d74c0575430a718": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -2365,6 +2440,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:94c2a965d1482da0fcf2875571950e137506ae298eaaafffacf9b1d292d28d75": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:95969ee44acac70d3154f61235eeaf855f1758fc6f1d2005185286ff4307b320": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -2416,6 +2496,11 @@
                     }
                   },
                   "sha256:999ae1e39f1011d1176b764839830d79dc54117834f068bd96276a09752c4cdc": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:99b3e44165b1daa21d0de8deb1c64ea66457bc3335d7c19c6453858a984f9640": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -2570,6 +2655,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:aabc3c95ce10dc4bd4b495d307f0dbacb569150f5288c6e1a79aa6360401ca1d": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:aaff108008e6ba95800e40a53f81c7c3ba7d346325e602db187884032848151e": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -2670,6 +2760,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:bb827877de1ef5ba03dbac3e8224ac6d0ec18b14fc622f1611acb29ac6332be5": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:bb85bd28cc162e98da53b756b988ffd9350f4dbcc186f4c6962ae047e27f83d3": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -2740,6 +2835,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:c41be5244a320291dd66d0eef940f9916e5e327c0fdf3e3f5f9c529d0960edca": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:c41f91075ee8ca480c2631a485bcc74876b9317b4dc9bd66566da32313621bd7": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -2800,12 +2900,22 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:cc8a07a239821d42804b255a5c3c894313abc77179eae6601f7ed7af2a7ecdb3": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:cd7b26033826d303e834dca8ce4b316ff0748afc573b2ce67cf83558f6940c9a": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
                   },
                   "sha256:ce4982f35c3e9beda6958e5a33c42acb5ad120e54edddbf44d8ee1f03fb26d4f": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:cedb91383bf34f55948f743a592a0665643cb55b60a85b02332be18c25fc809b": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -2950,6 +3060,16 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:e0a4c7a13befc85ea43686ba1591f461db128c58dadbbef2c1305afa2b2e11de": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:e29e50c96c36586e2adb3e2d7a2ac5bbd66a376d48fbf899638ae76357057b7d": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:e2c4a474b07b0db8e4ab2421187964a2cd37155f6595e13895486054e27875fa": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -2985,12 +3105,22 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:e72d98643336f4d3917235645333041daee4bf1e89992a680d80c4760fb07797": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:e7754468d6d2cd13aaf42fd5122745fe18e5063b2238a34cedb77444d798c9f2": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
                   },
                   "sha256:e7c0fe7ef552f6c931de1591a18d80e4310b34c5bb75801305372b42cb4caa2d": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:e810f64a80486f8300980ffd2bf3bad6842bc1580c6d8cea9b01416741b1b065": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -3015,6 +3145,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:ea14084371ab1d4872a7fa8cd304e640af2f196bf6a8254766eded76172700a7": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:eaa6b1a04ed162da5e5b1fcfe4e2618d2227fa980075e74ae15f11a38d939570": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -3031,6 +3166,11 @@
                     }
                   },
                   "sha256:eb7af981fb95425c68ccb0e4b95688672afd3032b57002e65fda8f734a089556": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:ebb0fd47e97395103e4233eb635b1751b7ac62c5ec98ed5c7335b24da97440f8": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -3080,6 +3220,11 @@
                       "rpm.check_gpg": true
                     }
                   },
+                  "sha256:f3b156f924bd0a586261f785a08029bf148eddf8deac915dcf51cfb012e5169e": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
                   "sha256:f3c78d40b23b255b5885d62557ab3db66bc30e079195dfd37a0819c18b0e147c": {
                     "metadata": {
                       "rpm.check_gpg": true
@@ -3091,6 +3236,11 @@
                     }
                   },
                   "sha256:f5cf36e8081c2d72e9dd64dd1614155857dd6e71ebb2237e5b0e11ace5481bac": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:f5ec1b86adb19cbf5be0e9be0f28b4c9a6c9abe9176e7b087b7f90ec3db5deb9": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -3176,6 +3326,11 @@
                     }
                   },
                   "sha256:fdebefc46badf2e700e00582041a0e5f5183dd4fdc04badfe47c91f030cea0ce": {
+                    "metadata": {
+                      "rpm.check_gpg": true
+                    }
+                  },
+                  "sha256:fe11c36d9f94ae4fb71824f6db8931e191a767be0de28523f3132decddac27fa": {
                     "metadata": {
                       "rpm.check_gpg": true
                     }
@@ -3568,6 +3723,9 @@
           "sha256:0914a0cbe0304289e224789f8e50e3e48a2525eba742ad764a1901e8c1351fb5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/kernel-modules-5.14.0-55.el9.x86_64.rpm"
           },
+          "sha256:0a8e44906d718132a13d6de94fbd9fe99a2e2c516e54607917a81dd9ece06d6e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-babel-2.9.1-2.el9.noarch.rpm"
+          },
           "sha256:0afe6e35348485ae2696e6170dcf34370f33fcf42a357fc815e332d939dd1025": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/kernel-core-5.14.0-55.el9.x86_64.rpm"
           },
@@ -3679,6 +3837,9 @@
           "sha256:1b712e683fd47b48b01a8a114ffbc50a7f541b26a0c5f43e07f507a60e601161": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/chrony-4.1-3.el9.x86_64.rpm"
           },
+          "sha256:1c47e46d8d95ee63d01aa7b618b1e883705a9e1b4e48239684bda7e308f780f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-jsonpointer-2.0-4.el9.noarch.rpm"
+          },
           "sha256:1c59b113fda8863e9066cc5d01c6d00bd9c50c4650e1c5b932082c8886e185d1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/zlib-1.2.11-31.el9.x86_64.rpm"
           },
@@ -3721,6 +3882,9 @@
           "sha256:23fd0185b511665ee4d036752f1f819e8db9c92c438c36bcbb8a8cd52b4eb47f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el9.x86_64.rpm"
           },
+          "sha256:2420bc9d6d1549f7a0625305b8d7aa3e2d797d65ee6384eec4c6139028ccd216": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/geolite2-city-20191217-6.el9.noarch.rpm"
+          },
           "sha256:26191af0cc7acf9bb335ebd8b4ed357582165ee3be78fce9f4395f84ad2805ce": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/libmount-2.37.2-1.el9.x86_64.rpm"
           },
@@ -3729,6 +3893,9 @@
           },
           "sha256:2629a79d1b680eab75cce332e1a47234f68f0fe12f29cb81d5c31a9afb8e0cad": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/libsss_nss_idmap-2.6.2-2.el9.x86_64.rpm"
+          },
+          "sha256:2657c134fdbef4f7ce1194fd1f6c454e9069b2364c58c4be5a337e44da40a419": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/libmaxminddb-1.5.2-3.el9.x86_64.rpm"
           },
           "sha256:276ea59394e1bc5ad4b4e2fbac6fdc2d0e22a8a2eb70373804ded801d9e0966c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/sudo-1.9.5p2-7.el9.x86_64.rpm"
@@ -3804,6 +3971,9 @@
           },
           "sha256:35d2595455e930ac9a1cb2dfeaa2cfe6f126c651110d4d468b9b1f554667c0a8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/libselinux-utils-3.3-2.el9.x86_64.rpm"
+          },
+          "sha256:370ab59bdcfc5657002bb12c6344a90338e4ccc735de9967575f06c5cf3c65a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-distro-1.5.0-7.el9.noarch.rpm"
           },
           "sha256:3795adffd49869ba9c4a5809387089ba14c99a52fccec01d815383f5f9cefab5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/publicsuffix-list-dafsa-20210518-2.el9.noarch.rpm"
@@ -3888,6 +4058,9 @@
           },
           "sha256:47e168e6436a246270d3704bcec485d1990fdc327e16fef145bb3acc464d2dca": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/langpacks-en-3.0-16.el9.noarch.rpm"
+          },
+          "sha256:4814e7fd9810db89815950cb94dd4f860432ecb473b35a885296ad611e87fba6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-oauthlib-3.1.1-2.el9.noarch.rpm"
           },
           "sha256:496b68212d637810fab7321d7de729cd28cffa0093a69133dbf786c10f20b005": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/ethtool-5.10-4.el9.x86_64.rpm"
@@ -4021,6 +4194,9 @@
           "sha256:62758d5c6c2734afd7cc62dd19dc5ffbe499da3b0d6ec31b09d6ca8370d498b7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/libblockdev-part-2.25-11.el9.x86_64.rpm"
           },
+          "sha256:6471d1e5a24b0c084f5d5a45ad7e0d6f4264f1b33ecdb5d7825f7d3e9fca3a5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/ipcalc-1.0.0-5.el9.x86_64.rpm"
+          },
           "sha256:647a3b9a52df25cb2aaf7f3715b219839b4cf71913638c88172d925173280812": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/coreutils-8.32-31.el9.x86_64.rpm"
           },
@@ -4035,6 +4211,9 @@
           },
           "sha256:656031558c53da4a5b3ccfd883bd6d55996037891323152b1f07e8d1d5377406": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/libtasn1-4.16.0-7.el9.x86_64.rpm"
+          },
+          "sha256:66105c0910b86fde1607dff6bf2e47f3f91e9f7ce0b51311cd21d77aa1be1c86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-configobj-5.0.6-25.el9.noarch.rpm"
           },
           "sha256:664c687f13d9f9b8ea23b01d324db0c020182b98ed53b307f61f14f3482fa792": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/libusbx-1.0.24-4.el9.x86_64.rpm"
@@ -4083,6 +4262,9 @@
           },
           "sha256:708fbc3c7fd77a21e0b391e2a80d5c344962de9865e79514b2c89210ef06ba39": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/systemd-libs-249-9.el9.x86_64.rpm"
+          },
+          "sha256:70b97ef7a9647cc09a85ece81f480ae0fe41220f2e4d7399e4df0347f59b0910": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/python3-setools-4.4.0-4.el9.x86_64.rpm"
           },
           "sha256:7362b709114080b3d47494d891e380ba9c3155c2fd9b21e9399a04c76e7d7c86": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/libtdb-1.4.4-1.el9.x86_64.rpm"
@@ -4147,6 +4329,9 @@
           "sha256:7cac88d9d9aab97a341b1b80d32f22917e79babc600fbf895c65550be399d7d6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/python3-linux-procfs-0.7.0-1.el9.noarch.rpm"
           },
+          "sha256:7d85a2bb6c382288e1be0f338f80d7d96de345efebb4cc38c7028b3f630cfbc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-pyserial-3.4-12.el9.noarch.rpm"
+          },
           "sha256:7d9d4d37e86ba94bb941e2dad40c90a157aaa0602f02f3f90e76086515f439be": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/libaio-0.3.111-13.el9.x86_64.rpm"
           },
@@ -4155,6 +4340,9 @@
           },
           "sha256:7e62a0ed0a508486b565e48794a146022f344aeb6801834ad7c5afe6a97ef065": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/libsemanage-3.3-1.el9.x86_64.rpm"
+          },
+          "sha256:7e6e354e0503b143139e8188aa0f8a1a01dc9ef1781f1392d34be9c68a53837b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/python3-pyyaml-5.4.1-4.el9.x86_64.rpm"
           },
           "sha256:7ea2dd761b06f236e1c2854963e9c50eff7abeadc9a079305c61e1ead3b5bcc6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/firewalld-1.0.0-2.el9.noarch.rpm"
@@ -4198,6 +4386,9 @@
           "sha256:864b166ac6d55cad5010da369fd7ad4872f81c2c111867dfbf96ccf4c8273c7e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/coreutils-common-8.32-31.el9.x86_64.rpm"
           },
+          "sha256:87671b5b055867093fe2349a299ec93daaeb94e86b0e12e44372433b27084818": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-jinja2-2.11.3-4.el9.noarch.rpm"
+          },
           "sha256:879771cd51bb4ef2afd2e4a8d29b4f66040ec7f0f47d647f2c00ab0122bdf8e0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/openldap-2.4.59-3.el9.x86_64.rpm"
           },
@@ -4215,6 +4406,9 @@
           },
           "sha256:8cd5a78cab8783dd241c52c4fcda28fb111c443887dd6d0fe38385e8383c98b3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/gdbm-libs-1.19-4.el9.x86_64.rpm"
+          },
+          "sha256:8cde6a3234941c997cefcc3d3bb8e2fcca07d1b00261ca452d74c0575430a718": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/dhcp-client-4.4.2-15.b1.el9.x86_64.rpm"
           },
           "sha256:8db0425ae35988ceb831c3305edb668971249c916804c7aea4d1349dd9b189d5": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/rsyslog-logrotate-8.2102.0-101.el9.x86_64.rpm"
@@ -4287,6 +4481,9 @@
           },
           "sha256:999ae1e39f1011d1176b764839830d79dc54117834f068bd96276a09752c4cdc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/libibverbs-37.2-1.el9.x86_64.rpm"
+          },
+          "sha256:99b3e44165b1daa21d0de8deb1c64ea66457bc3335d7c19c6453858a984f9640": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-libsemanage-3.3-1.el9.x86_64.rpm"
           },
           "sha256:9a4290f7e31d11abc5ea0193cecc6bb05232996c6c2db7792bcbf411fbe23e26": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/libatasmart-0.19-22.el9.x86_64.rpm"
@@ -4384,6 +4581,9 @@
           "sha256:aa9ee73fe806ddeafab4a5b0e370256e6c61f67f67114101d0735aed3c9a5eda": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/openssl-3.0.1-5.el9.x86_64.rpm"
           },
+          "sha256:aabc3c95ce10dc4bd4b495d307f0dbacb569150f5288c6e1a79aa6360401ca1d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/cloud-init-21.1-16.el9.noarch.rpm"
+          },
           "sha256:aaff108008e6ba95800e40a53f81c7c3ba7d346325e602db187884032848151e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/dejavu-sans-fonts-2.37-18.el9.noarch.rpm"
           },
@@ -4449,6 +4649,9 @@
           },
           "sha256:bb0df17e75eb0cc5e5d207d3d9d579202e3510d9b15b053ac682dafbdda7e20c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/libsmbios-2.4.3-4.el9.x86_64.rpm"
+          },
+          "sha256:bb827877de1ef5ba03dbac3e8224ac6d0ec18b14fc622f1611acb29ac6332be5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-policycoreutils-3.3-2.el9.noarch.rpm"
           },
           "sha256:bb85bd28cc162e98da53b756b988ffd9350f4dbcc186f4c6962ae047e27f83d3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/dbus-1.12.20-5.el9.x86_64.rpm"
@@ -4540,6 +4743,9 @@
           "sha256:ce4982f35c3e9beda6958e5a33c42acb5ad120e54edddbf44d8ee1f03fb26d4f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/pigz-2.5-4.el9.x86_64.rpm"
           },
+          "sha256:cedb91383bf34f55948f743a592a0665643cb55b60a85b02332be18c25fc809b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-prettytable-0.7.2-27.el9.noarch.rpm"
+          },
           "sha256:cf389b227708f7037577f7cb418d203bdda3a20e942c92f4455edd2c74b9b450": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/sssd-client-2.6.2-2.el9.x86_64.rpm"
           },
@@ -4630,6 +4836,12 @@
           "sha256:e04e79a2e189f14a810deb8b92f6af24405a158bc5186c3f7433b13738b06673": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/sg3_utils-1.47-6.el9.x86_64.rpm"
           },
+          "sha256:e0a4c7a13befc85ea43686ba1591f461db128c58dadbbef2c1305afa2b2e11de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-jsonpatch-1.21-16.el9.noarch.rpm"
+          },
+          "sha256:e29e50c96c36586e2adb3e2d7a2ac5bbd66a376d48fbf899638ae76357057b7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-pytz-2021.1-4.el9.noarch.rpm"
+          },
           "sha256:e2c4a474b07b0db8e4ab2421187964a2cd37155f6595e13895486054e27875fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/iproute-5.13.0-5.el9.x86_64.rpm"
           },
@@ -4657,11 +4869,17 @@
           "sha256:e6c72b0ef52f005dd8dbf5b2573a2ee149e5a7124c566d36525d6dcbd113172a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/audit-3.0.7-100.el9.x86_64.rpm"
           },
+          "sha256:e72d98643336f4d3917235645333041daee4bf1e89992a680d80c4760fb07797": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/geolite2-country-20191217-6.el9.noarch.rpm"
+          },
           "sha256:e7754468d6d2cd13aaf42fd5122745fe18e5063b2238a34cedb77444d798c9f2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/file-5.39-8.el9.x86_64.rpm"
           },
           "sha256:e7c0fe7ef552f6c931de1591a18d80e4310b34c5bb75801305372b42cb4caa2d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/libndp-1.8-4.el9.x86_64.rpm"
+          },
+          "sha256:e810f64a80486f8300980ffd2bf3bad6842bc1580c6d8cea9b01416741b1b065": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-netifaces-0.10.6-15.el9.x86_64.rpm"
           },
           "sha256:e811ab263d16f112f8581259622e044cefcb801f6895e5f499e61c107e532c8e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/NetworkManager-team-1.36.0-0.7.el9.x86_64.rpm"
@@ -4690,6 +4908,9 @@
           "sha256:eb7af981fb95425c68ccb0e4b95688672afd3032b57002e65fda8f734a089556": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/systemd-pam-249-9.el9.x86_64.rpm"
           },
+          "sha256:ebb0fd47e97395103e4233eb635b1751b7ac62c5ec98ed5c7335b24da97440f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-audit-3.0.7-100.el9.x86_64.rpm"
+          },
           "sha256:ec7784303ac30b70348b742a8338ee283350006983cdcbb44e24d05a54facc8b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/iputils-20210202-7.el9.x86_64.rpm"
           },
@@ -4716,6 +4937,9 @@
           },
           "sha256:f322c4ae3e06acb22a94cd87be6b79d910039d7aed959644b0fdb26f54b12022": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/cronie-anacron-1.5.7-5.el9.x86_64.rpm"
+          },
+          "sha256:f3b156f924bd0a586261f785a08029bf148eddf8deac915dcf51cfb012e5169e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/dhcp-common-4.4.2-15.b1.el9.noarch.rpm"
           },
           "sha256:f3c78d40b23b255b5885d62557ab3db66bc30e079195dfd37a0819c18b0e147c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/python3-dateutil-2.8.1-6.el9.noarch.rpm"
@@ -4779,6 +5003,9 @@
           },
           "sha256:fdebefc46badf2e700e00582041a0e5f5183dd4fdc04badfe47c91f030cea0ce": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/diffutils-3.7-12.el9.x86_64.rpm"
+          },
+          "sha256:fe11c36d9f94ae4fb71824f6db8931e191a767be0de28523f3132decddac27fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/checkpolicy-3.3-1.el9.x86_64.rpm"
           },
           "sha256:ffb4cc04548f24cf7cd62da9747d3839af7676b29b60cfd3da59c6ec31ebdf99": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/polkit-pkla-compat-0.1-21.el9.x86_64.rpm"
@@ -8117,6 +8344,26 @@
     ],
     "packages": [
       {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/checkpolicy-3.3-1.el9.x86_64.rpm",
+        "checksum": "sha256:fe11c36d9f94ae4fb71824f6db8931e191a767be0de28523f3132decddac27fa",
+        "check_gpg": true
+      },
+      {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "21.1",
+        "release": "16.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/cloud-init-21.1-16.el9.noarch.rpm",
+        "checksum": "sha256:aabc3c95ce10dc4bd4b495d307f0dbacb569150f5288c6e1a79aa6360401ca1d",
+        "check_gpg": true
+      },
+      {
         "name": "flashrom",
         "epoch": 0,
         "version": "1.2",
@@ -8154,6 +8401,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/gdisk-1.0.7-5.el9.x86_64.rpm",
         "checksum": "sha256:5c573860eed39dba3f5e088715c26648805d807c6988123c3510189263b62f32",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/geolite2-city-20191217-6.el9.noarch.rpm",
+        "checksum": "sha256:2420bc9d6d1549f7a0625305b8d7aa3e2d797d65ee6384eec4c6139028ccd216",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/geolite2-country-20191217-6.el9.noarch.rpm",
+        "checksum": "sha256:e72d98643336f4d3917235645333041daee4bf1e89992a680d80c4760fb07797",
         "check_gpg": true
       },
       {
@@ -8327,6 +8594,16 @@
         "check_gpg": true
       },
       {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/libmaxminddb-1.5.2-3.el9.x86_64.rpm",
+        "checksum": "sha256:2657c134fdbef4f7ce1194fd1f6c454e9069b2364c58c4be5a337e44da40a419",
+        "check_gpg": true
+      },
+      {
         "name": "libmspack",
         "epoch": 0,
         "version": "0.10.1",
@@ -8477,6 +8754,76 @@
         "check_gpg": true
       },
       {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0.7",
+        "release": "100.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-audit-3.0.7-100.el9.x86_64.rpm",
+        "checksum": "sha256:ebb0fd47e97395103e4233eb635b1751b7ac62c5ec98ed5c7335b24da97440f8",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-babel",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-babel-2.9.1-2.el9.noarch.rpm",
+        "checksum": "sha256:0a8e44906d718132a13d6de94fbd9fe99a2e2c516e54607917a81dd9ece06d6e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-configobj",
+        "epoch": 0,
+        "version": "5.0.6",
+        "release": "25.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-configobj-5.0.6-25.el9.noarch.rpm",
+        "checksum": "sha256:66105c0910b86fde1607dff6bf2e47f3f91e9f7ce0b51311cd21d77aa1be1c86",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-distro-1.5.0-7.el9.noarch.rpm",
+        "checksum": "sha256:370ab59bdcfc5657002bb12c6344a90338e4ccc735de9967575f06c5cf3c65a7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jinja2",
+        "epoch": 0,
+        "version": "2.11.3",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-jinja2-2.11.3-4.el9.noarch.rpm",
+        "checksum": "sha256:87671b5b055867093fe2349a299ec93daaeb94e86b0e12e44372433b27084818",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpatch",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "16.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-jsonpatch-1.21-16.el9.noarch.rpm",
+        "checksum": "sha256:e0a4c7a13befc85ea43686ba1591f461db128c58dadbbef2c1305afa2b2e11de",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-jsonpointer",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-jsonpointer-2.0-4.el9.noarch.rpm",
+        "checksum": "sha256:1c47e46d8d95ee63d01aa7b618b1e883705a9e1b4e48239684bda7e308f780f9",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libselinux",
         "epoch": 0,
         "version": "3.3",
@@ -8484,6 +8831,86 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-libselinux-3.3-2.el9.x86_64.rpm",
         "checksum": "sha256:2bc4e5468961e9f8c4abed928ab036da9eed2cfaea725930ff9277e337984580",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-libsemanage-3.3-1.el9.x86_64.rpm",
+        "checksum": "sha256:99b3e44165b1daa21d0de8deb1c64ea66457bc3335d7c19c6453858a984f9640",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "12.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-markupsafe-1.1.1-12.el9.x86_64.rpm",
+        "checksum": "sha256:cc8a07a239821d42804b255a5c3c894313abc77179eae6601f7ed7af2a7ecdb3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-netifaces",
+        "epoch": 0,
+        "version": "0.10.6",
+        "release": "15.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-netifaces-0.10.6-15.el9.x86_64.rpm",
+        "checksum": "sha256:e810f64a80486f8300980ffd2bf3bad6842bc1580c6d8cea9b01416741b1b065",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-oauthlib",
+        "epoch": 0,
+        "version": "3.1.1",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-oauthlib-3.1.1-2.el9.noarch.rpm",
+        "checksum": "sha256:4814e7fd9810db89815950cb94dd4f860432ecb473b35a885296ad611e87fba6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-policycoreutils-3.3-2.el9.noarch.rpm",
+        "checksum": "sha256:bb827877de1ef5ba03dbac3e8224ac6d0ec18b14fc622f1611acb29ac6332be5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "27.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-prettytable-0.7.2-27.el9.noarch.rpm",
+        "checksum": "sha256:cedb91383bf34f55948f743a592a0665643cb55b60a85b02332be18c25fc809b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pyserial",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-pyserial-3.4-12.el9.noarch.rpm",
+        "checksum": "sha256:7d85a2bb6c382288e1be0f338f80d7d96de345efebb4cc38c7028b3f630cfbc5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-pytz",
+        "epoch": 0,
+        "version": "2021.1",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220208/Packages/python3-pytz-2021.1-4.el9.noarch.rpm",
+        "checksum": "sha256:e29e50c96c36586e2adb3e2d7a2ac5bbd66a376d48fbf899638ae76357057b7d",
         "check_gpg": true
       },
       {
@@ -8954,6 +9381,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el9.x86_64.rpm",
         "checksum": "sha256:a716ccca85fad2885af4d099f8c213eb4617d637d8ca6cf7d2b483b9de88a5d3",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "15.b1.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/dhcp-client-4.4.2-15.b1.el9.x86_64.rpm",
+        "checksum": "sha256:8cde6a3234941c997cefcc3d3bb8e2fcca07d1b00261ca452d74c0575430a718",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "15.b1.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/dhcp-common-4.4.2-15.b1.el9.noarch.rpm",
+        "checksum": "sha256:f3b156f924bd0a586261f785a08029bf148eddf8deac915dcf51cfb012e5169e",
         "check_gpg": true
       },
       {
@@ -9564,6 +10011,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/initscripts-service-10.11.1-1.el9.noarch.rpm",
         "checksum": "sha256:6f22d288de925cb964b24c6278930ce2a257f1d6ffd27a3456ce2e5f477b210f",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "5.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/ipcalc-1.0.0-5.el9.x86_64.rpm",
+        "checksum": "sha256:6471d1e5a24b0c084f5d5a45ad7e0d6f4264f1b33ecdb5d7825f7d3e9fca3a5b",
         "check_gpg": true
       },
       {
@@ -11367,6 +11824,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-chardet",
+        "epoch": 0,
+        "version": "4.0.0",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/python3-chardet-4.0.0-3.el9.noarch.rpm",
+        "checksum": "sha256:651de672518dbc791dd9f40881d43d2fe67dd7c5aa2568e8ec39c7d2336561b4",
+        "check_gpg": true
+      },
+      {
         "name": "python3-dateutil",
         "epoch": 1,
         "version": "2.8.1",
@@ -11447,6 +11914,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-idna",
+        "epoch": 0,
+        "version": "2.10",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/python3-idna-2.10-5.el9.noarch.rpm",
+        "checksum": "sha256:194acd1a65f4fcb3e3f2c2ff694646cf6a814ff881f867c6f65547258fd1b741",
+        "check_gpg": true
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.18",
@@ -11517,6 +11994,16 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pysocks",
+        "epoch": 0,
+        "version": "1.7.1",
+        "release": "10.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm",
+        "checksum": "sha256:c41be5244a320291dd66d0eef940f9916e5e327c0fdf3e3f5f9c529d0960edca",
+        "check_gpg": true
+      },
+      {
         "name": "python3-pyudev",
         "epoch": 0,
         "version": "0.22.0",
@@ -11527,6 +12014,26 @@
         "check_gpg": true
       },
       {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "4.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/python3-pyyaml-5.4.1-4.el9.x86_64.rpm",
+        "checksum": "sha256:7e6e354e0503b143139e8188aa0f8a1a01dc9ef1781f1392d34be9c68a53837b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-requests",
+        "epoch": 0,
+        "version": "2.25.1",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/python3-requests-2.25.1-5.el9.noarch.rpm",
+        "checksum": "sha256:f5ec1b86adb19cbf5be0e9be0f28b4c9a6c9abe9176e7b087b7f90ec3db5deb9",
+        "check_gpg": true
+      },
+      {
         "name": "python3-rpm",
         "epoch": 0,
         "version": "4.16.1.3",
@@ -11534,6 +12041,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/python3-rpm-4.16.1.3-10.el9.x86_64.rpm",
         "checksum": "sha256:95c3950af4f1a757cb07d16143163ce1584a57ed04c3436b1892712acd002488",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.4.0",
+        "release": "4.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/python3-setools-4.4.0-4.el9.x86_64.rpm",
+        "checksum": "sha256:70b97ef7a9647cc09a85ece81f480ae0fe41220f2e4d7399e4df0347f59b0910",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-setuptools",
+        "epoch": 0,
+        "version": "53.0.0",
+        "release": "9.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/python3-setuptools-53.0.0-9.el9.noarch.rpm",
+        "checksum": "sha256:ea14084371ab1d4872a7fa8cd304e640af2f196bf6a8254766eded76172700a7",
         "check_gpg": true
       },
       {
@@ -11554,6 +12081,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/python3-six-1.15.0-7.el9.noarch.rpm",
         "checksum": "sha256:42d24f3496d597de546a46b6ad1f70ab38adf7ceb5ebaeb8bcd62837051926f1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-urllib3",
+        "epoch": 0,
+        "version": "1.26.5",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/python3-urllib3-1.26.5-2.el9.noarch.rpm",
+        "checksum": "sha256:94c2a965d1482da0fcf2875571950e137506ae298eaaafffacf9b1d292d28d75",
         "check_gpg": true
       },
       {
@@ -12044,6 +12581,114 @@
         "2.centos.pool.ntp.org iburst"
       ]
     },
+    "cloud-init": {
+      "/etc/cloud": {
+        "cloud.cfg": {
+          "cloud_config_modules": [
+            "mounts",
+            "locale",
+            "set-passwords",
+            "rh_subscription",
+            "yum-add-repo",
+            "package-update-upgrade-install",
+            "timezone",
+            "puppet",
+            "chef",
+            "salt-minion",
+            "mcollective",
+            "disable-ec2-metadata",
+            "runcmd"
+          ],
+          "cloud_final_modules": [
+            "rightscale_userdata",
+            "scripts-per-once",
+            "scripts-per-boot",
+            "scripts-per-instance",
+            "scripts-user",
+            "ssh-authkey-fingerprints",
+            "keys-to-console",
+            "phone-home",
+            "final-message",
+            "power-state-change"
+          ],
+          "cloud_init_modules": [
+            "disk_setup",
+            "migrator",
+            "bootcmd",
+            "write-files",
+            "growpart",
+            "resizefs",
+            "set_hostname",
+            "update_hostname",
+            "update_etc_hosts",
+            "rsyslog",
+            "users-groups",
+            "ssh"
+          ],
+          "disable_root": 1,
+          "disable_vmware_customization": false,
+          "mount_default_fields": [
+            null,
+            null,
+            "auto",
+            "defaults,nofail,x-systemd.requires=cloud-init.service",
+            "0",
+            "2"
+          ],
+          "resize_rootfs_tmp": "/dev",
+          "ssh_deletekeys": 1,
+          "ssh_genkeytypes": [
+            "rsa",
+            "ecdsa",
+            "ed25519"
+          ],
+          "ssh_pwauth": 0,
+          "syslog_fix_perms": null,
+          "system_info": {
+            "default_user": {
+              "gecos": "Cloud User",
+              "groups": [
+                "adm",
+                "systemd-journal"
+              ],
+              "lock_passwd": true,
+              "name": "cloud-user",
+              "shell": "/bin/bash",
+              "sudo": [
+                "ALL=(ALL) NOPASSWD:ALL"
+              ]
+            },
+            "distro": "rhel",
+            "paths": {
+              "cloud_dir": "/var/lib/cloud",
+              "templates_dir": "/etc/cloud/templates"
+            },
+            "ssh_svcname": "sshd"
+          },
+          "users": [
+            "default"
+          ]
+        }
+      },
+      "/etc/cloud/cloud.cfg.d": {
+        "05_logging.cfg": {
+          "_log": [
+            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
+            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
+          ],
+          "log_cfgs": [
+            [
+              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
+            ]
+          ],
+          "output": {
+            "all": "| tee -a /var/log/cloud-init-output.log"
+          }
+        }
+      }
+    },
     "default-target": "graphical.target",
     "dnf": {
       "dnf.conf": {
@@ -12242,7 +12887,9 @@
       "centos-gpg-keys-9.0-9.el9.noarch",
       "centos-stream-release-9.0-9.el9.noarch",
       "centos-stream-repos-9.0-9.el9.noarch",
+      "checkpolicy-3.3-1.el9.x86_64",
       "chrony-4.1-3.el9.x86_64",
+      "cloud-init-21.1-16.el9.noarch",
       "coreutils-8.32-31.el9.x86_64",
       "coreutils-common-8.32-31.el9.x86_64",
       "cpio-2.13-16.el9.x86_64",
@@ -12263,6 +12910,8 @@
       "dejavu-sans-fonts-2.37-18.el9.noarch",
       "device-mapper-1.02.181-3.el9.x86_64",
       "device-mapper-libs-1.02.181-3.el9.x86_64",
+      "dhcp-client-4.4.2-15.b1.el9.x86_64",
+      "dhcp-common-4.4.2-15.b1.el9.noarch",
       "diffutils-3.7-12.el9.x86_64",
       "dmidecode-3.3-6.el9.x86_64",
       "dnf-4.10.0-3.el9.noarch",
@@ -12300,6 +12949,8 @@
       "gawk-all-langpacks-5.1.0-5.el9.x86_64",
       "gdbm-libs-1.19-4.el9.x86_64",
       "gdisk-1.0.7-5.el9.x86_64",
+      "geolite2-city-20191217-6.el9.noarch",
+      "geolite2-country-20191217-6.el9.noarch",
       "gettext-0.21-7.el9.x86_64",
       "gettext-libs-0.21-7.el9.x86_64",
       "glib2-2.68.4-5.el9.x86_64",
@@ -12330,6 +12981,7 @@
       "ima-evm-utils-1.4-4.el9.x86_64",
       "inih-49-5.el9.x86_64",
       "initscripts-service-10.11.1-1.el9.noarch",
+      "ipcalc-1.0.0-5.el9.x86_64",
       "iproute-5.13.0-5.el9.x86_64",
       "iproute-tc-5.13.0-5.el9.x86_64",
       "ipset-7.11-6.el9.x86_64",
@@ -12423,6 +13075,7 @@
       "libkcapi-hmaccalc-1.3.1-3.el9.x86_64",
       "libksba-1.5.1-4.el9.x86_64",
       "libldb-2.4.1-1.el9.x86_64",
+      "libmaxminddb-1.5.2-3.el9.x86_64",
       "libmnl-1.0.4-15.el9.x86_64",
       "libmodulemd-2.13.0-2.el9.x86_64",
       "libmount-2.37.2-1.el9.x86_64",
@@ -12542,26 +13195,49 @@
       "publicsuffix-list-dafsa-20210518-2.el9.noarch",
       "python-unversioned-command-3.9.10-1.el9.noarch",
       "python3-3.9.10-1.el9.x86_64",
+      "python3-audit-3.0.7-100.el9.x86_64",
+      "python3-babel-2.9.1-2.el9.noarch",
+      "python3-chardet-4.0.0-3.el9.noarch",
+      "python3-configobj-5.0.6-25.el9.noarch",
       "python3-dateutil-2.8.1-6.el9.noarch",
       "python3-dbus-1.2.18-2.el9.x86_64",
+      "python3-distro-1.5.0-7.el9.noarch",
       "python3-dnf-4.10.0-3.el9.noarch",
       "python3-dnf-plugins-core-4.0.24-2.el9.noarch",
       "python3-firewall-1.0.0-2.el9.noarch",
       "python3-gobject-base-3.40.1-5.el9.x86_64",
       "python3-gpg-1.15.1-5.el9.x86_64",
       "python3-hawkey-0.65.0-2.el9.x86_64",
+      "python3-idna-2.10-5.el9.noarch",
+      "python3-jinja2-2.11.3-4.el9.noarch",
+      "python3-jsonpatch-1.21-16.el9.noarch",
+      "python3-jsonpointer-2.0-4.el9.noarch",
       "python3-libcomps-0.1.18-1.el9.x86_64",
       "python3-libdnf-0.65.0-2.el9.x86_64",
       "python3-libs-3.9.10-1.el9.x86_64",
       "python3-libselinux-3.3-2.el9.x86_64",
+      "python3-libsemanage-3.3-1.el9.x86_64",
       "python3-linux-procfs-0.7.0-1.el9.noarch",
+      "python3-markupsafe-1.1.1-12.el9.x86_64",
+      "python3-netifaces-0.10.6-15.el9.x86_64",
       "python3-nftables-0.9.8-10.el9.x86_64",
+      "python3-oauthlib-3.1.1-2.el9.noarch",
       "python3-perf-5.14.0-55.el9.x86_64",
       "python3-pip-wheel-21.2.3-6.el9.noarch",
+      "python3-policycoreutils-3.3-2.el9.noarch",
+      "python3-prettytable-0.7.2-27.el9.noarch",
+      "python3-pyserial-3.4-12.el9.noarch",
+      "python3-pysocks-1.7.1-10.el9.noarch",
+      "python3-pytz-2021.1-4.el9.noarch",
       "python3-pyudev-0.22.0-6.el9.noarch",
+      "python3-pyyaml-5.4.1-4.el9.x86_64",
+      "python3-requests-2.25.1-5.el9.noarch",
       "python3-rpm-4.16.1.3-10.el9.x86_64",
+      "python3-setools-4.4.0-4.el9.x86_64",
+      "python3-setuptools-53.0.0-9.el9.noarch",
       "python3-setuptools-wheel-53.0.0-9.el9.noarch",
       "python3-six-1.15.0-7.el9.noarch",
+      "python3-urllib3-1.26.5-2.el9.noarch",
       "readline-8.1-4.el9.x86_64",
       "rootfiles-8.1-31.el9.noarch",
       "rpm-4.16.1.3-10.el9.x86_64",
@@ -12752,6 +13428,10 @@
       "auditd.service",
       "autovt@.service",
       "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
       "crond.service",
       "ctrl-alt-del.target",
       "dbus-broker.service",
@@ -12887,6 +13567,13 @@
       }
     },
     "systemd-service-dropins": {
+      "/etc/systemd/system": {
+        "sshd-keygen@.service.d": {
+          "Unit": {
+            "ConditionPathExists": "!/run/systemd/generator.early/multi-user.target.wants/cloud-init.target"
+          }
+        }
+      },
       "/usr/lib/systemd/system": {
         "systemd-hostnamed.service.d": {
           "Service": {
@@ -12908,6 +13595,9 @@
     "timezone": "New_York",
     "tmpfiles.d": {
       "/usr/lib/tmpfiles.d": {
+        "cloud-init.conf": [
+          "d /run/cloud-init 0700 root root - -"
+        ],
         "cryptsetup.conf": [
           "d /run/cryptsetup 0700 root root -"
         ],

--- a/test/data/manifests/rhel_85-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-vmdk-boot.json
@@ -331,6 +331,7 @@
                   "sha256:045b06d163f5c1e2980b8272502805d3a7e0038d29b5ff634d2fd8d132e29f11": {},
                   "sha256:0605f54945738b6f42f6fe0d79d64181ff4193ffb2589a3d9d40ef773001e61b": {},
                   "sha256:06bbb021f0549c739613edb28cb4f39b7389c718c063934c980d32df3e032d3b": {},
+                  "sha256:076bdcf066fabe9c611ceee12665d735136ecd306ec4c1e608bb1e0a4704ae55": {},
                   "sha256:07d885ed980e09242fa1b6b4faaa5aaf3ea1f24415ac86a6a1f2f08ab5797784": {},
                   "sha256:09149617095dc52e19cdce1e45c8245e1e92d371bd4d107320ff56788b9977f1": {},
                   "sha256:09ce0f412ad33ab81fca181f303f95bd65abb258fe137a6081184e2a7d31f859": {},
@@ -343,6 +344,7 @@
                   "sha256:1291973fb1c479d3d3dab62d7dbcda052ab998779a0eb2e45427d0e2257d8db4": {},
                   "sha256:134219ddd4f07902fcbd999c089200e0d77eb5139eec73aa9e56e0bdddb7a932": {},
                   "sha256:13d3c0c2db0b1207012bad406cfb60c509f40618be1a9d342ae06963a3930202": {},
+                  "sha256:13ffce0597b689dd53f55ea0d03dd6d013246634f5c6cbcef51fa549d9734b29": {},
                   "sha256:150e9dbb5a19483c85c25c722ff63a08d9411023c40faf88f42843fdf68ea275": {},
                   "sha256:166c89bfed4be944d5a8e0d12b389fda0d66190bef5b9fc4958a39653519a48b": {},
                   "sha256:176cd5cb58307c4a89ed986dbbcb765f306c08da3fa3fe2cb7b3e80076a3d7a9": {},
@@ -410,6 +412,7 @@
                   "sha256:3384bccab530807195eb9d72547aa588bdea55567ca86d1719f32402bf1cd0c9": {},
                   "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806": {},
                   "sha256:3423075b5f924b1512e91fb5c8532ef2768cd2b1b9591e4a2ac3b76d99aa380d": {},
+                  "sha256:3446bbd5d26c3a1b8cd64c077ae4bbeea8ef2ef349c590297bbe2a53e18ce9e6": {},
                   "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {},
                   "sha256:37504d807ac0bb6c429d7be9c636f7b755464023511d856846dbb9deb8f6a76d": {},
                   "sha256:382afcc614dbcd3817aa3f7e12e2a5c32b3e5ba91b27f7b86b7ef5102c7b82cb": {},
@@ -428,6 +431,7 @@
                   "sha256:3dfb211aa89fa4c41434d2526cd07f98e276b724e2bc6aa9a6be67f5a6d5d004": {},
                   "sha256:3e4ea07a068ac27709ed9ed3ddea98cffdb45c7bec92ff80252cfbaccb52797c": {},
                   "sha256:3e79690d58e6a213278c4f2789ad4dae58b09b8f5c0890e1ac7d843ae3f25c7b": {},
+                  "sha256:3e9dff1e55f3d4121bb4d85839f0e26a05bb95ed652abbe15535167528226414": {},
                   "sha256:3faad2fd944f90540a82431edb54d5c2f7ad8a845ec6f8ddaf9d36de6caee84c": {},
                   "sha256:40857d6b70f5b74a58da97a8cfcfcee56c08157c6d1eed56c92057b731a8ea95": {},
                   "sha256:411d65fe9e463458af055d06a4a89a1d822d26049198615c0afc9741c426c77c": {},
@@ -472,9 +476,13 @@
                   "sha256:55a58ea1e63e2cc102d82ab4d02e04e90e2c03819b2a2dee74395905868eb5fd": {},
                   "sha256:55ef38bc558e5b075e2c442ded40d37c742e66ecd8679a555ddf93ae08add193": {},
                   "sha256:589fa333c866d9a59bc607ec6c45b7df30c8602c80c16b2aac2c0f916ebed6e7": {},
+                  "sha256:58d5f26daf746cf161e1be4fb6cda4e320ef2a624f0ab7913ee498b26aad8659": {},
+                  "sha256:59bf7b92f9eecb7868e960dc05c269a9df088d2dc71ce85cf77bfad68e206f0b": {},
                   "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86": {},
+                  "sha256:5b1bc2ca63d563828a3a0968d42fb75ae0917366d06df8176d917f7c477f33b4": {},
                   "sha256:5b9e2d133d23e5eb353b8f0a864ce1a9ee6706fe61804e53068faabb53b79789": {},
                   "sha256:5d527a7fe40c223f9e8448cdb657daba3582d4ab296400c65294a4f1f921892b": {},
+                  "sha256:5d9c5b3341e9b10091a5bc66c08455ce7d9c62911fac6b759b847a46749a1adf": {},
                   "sha256:5e4046b9fb264bd8bfc6382bab675ae517c9d1d5e7c41737bdfc725702a8ddc2": {},
                   "sha256:5ea33f04ff63376f687b0049a853d1485f2e6532aec557f60ac9007d886ffecf": {},
                   "sha256:5f09266bdf2e8f299f73864c3fcc7c61f550dc1639bbfca86e3c8eb148e30946": {},
@@ -531,6 +539,8 @@
                   "sha256:7e6ddd3fa8ec2a4e5885de3c5565b084ced5b63eabca759c316b53819612e036": {},
                   "sha256:7e95dc277991981a081f73f4410219a196b7b0d02dbe1ad2ebfce172c215669e": {},
                   "sha256:7f2436df92ce3dacaf5a52d988e65b2cbfc6af8be917bdc14119940480efd7bb": {},
+                  "sha256:7f5386be44b3af8a75cd71f7675fd6e326e49086dd339bbaa7ffbf6c0a67b95d": {},
+                  "sha256:7f669e03c4edfd5b528fc354d259e076f472712cf700c273b236d492b59870d1": {},
                   "sha256:7f7f559d65b4b29a1695a644c3d0e04f36565feaa65416f4b84b309716ecf17f": {},
                   "sha256:802263173d9c487fc3ca584cc2a5b7b7bb49ac0d12d9026b3246d50fd0888fb1": {},
                   "sha256:80470c66bff8ddf9c0775ddf458c749698f507262f998c0cec325b0e9051cc3c": {},
@@ -550,6 +560,8 @@
                   "sha256:88fcfe6bbedbd020eb20cc623dfd4067aea08f44d285e15763233f1dbc2d96ec": {},
                   "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {},
                   "sha256:8b05d986058c83b2041499ed8d1466073bd492319db781a50f8c5f2b9bbe447e": {},
+                  "sha256:8c3deaabbd79922ad6eae143a100e0d5b04c10a729d1ac01128d843039d3eebf": {},
+                  "sha256:8c6da26441750b3970fe73b6a9d2d780931da6cdea48f10d0b34c65c79a9e341": {},
                   "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {},
                   "sha256:8cd85f86e29b30e48bb1869eda2f9d204764852690a61d292b50bb8461fe5a9f": {},
                   "sha256:8d20a617a35967f56dec39b90ca4effe1b87a1455f24a860c2a03a72cdd3b8cc": {},
@@ -558,6 +570,7 @@
                   "sha256:8dfb5536f04989c0aef22a8ae8dfd013cd2fd979f62b6f94e20f680e42d2cac5": {},
                   "sha256:8e673f0900f3a18c2632ba0c0403485b86136d06ced389af06d3a0a3ac043a64": {},
                   "sha256:8e838f5065490d117f247f55047de7e46ea36193432ff17eab9e4e7724c8c8e1": {},
+                  "sha256:8f00781eb679c6baf359099fa2a672ffccfc8e43b7c03c1dc635619cb25ff01d": {},
                   "sha256:90317599f1fbe047c780d4a432959cdffb9d34d47d9df9afe6031eb0f626fef7": {},
                   "sha256:90406300b99022d9a28db65bb1dd9c0e14654e8a2dd5c02f35426b3714a1d042": {},
                   "sha256:90a50b8d1215454320e28aa9fb253b5174d84f01e44f85e3d57d6792411e5810": {},
@@ -600,6 +613,7 @@
                   "sha256:a53f0be84231f676266183a16c0c474ba529f3a2858c6b86591221260a19840f": {},
                   "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {},
                   "sha256:a7de0cd4116b5b08f1f8f244161fffa403a1b91b3c8c1c0341a8e7c119ef9f69": {},
+                  "sha256:a8808c053ffb7ccf826d80fdd458b6521f2cc63e55eb90d79a504fbb66c36cb0": {},
                   "sha256:a9aa2b045a94eacae8f6b0a5a632d3e91794f63c955b7b080ef319cd6bcface6": {},
                   "sha256:aa4b8463be8bceddb296424e76ddecc80b72ffc8543b6746eadfc4972131b6e2": {},
                   "sha256:ac2800369b7f4dc05a8fec452eabedf02f153c11e188a1e80157e35592305690": {},
@@ -632,6 +646,7 @@
                   "sha256:ba9829f1952a37154d7e9f530556ee43621f2c69a02af1ffa846a353d08d5766": {},
                   "sha256:bb154b45f7a611cc7024e4ef9436d1ab7874741378ff4533084b5dd238d101a7": {},
                   "sha256:bb4a332cff094f2afeb8f4d0893b3240562501add9c258d567382db5fe0d341c": {},
+                  "sha256:bce8cbc50f5872bcee1bed9ff041bebfae10169f007cf97b268819e78b9d8835": {},
                   "sha256:bd37c05e277205686dade257e19f95839fad32f2278872dbc9969c50ec9da0b6": {},
                   "sha256:bd9271820c03337924ca655f164e34a158a4d3b88fb03c18eb822cb6a66a083f": {},
                   "sha256:bfe0baf8e53ba099173e519be3598433fd0a09888d67f933e359f24ce7ffcb66": {},
@@ -666,6 +681,7 @@
                   "sha256:caeab38e17ea650e826e64417185a8c24f72133477757580fcac0236de12ba49": {},
                   "sha256:cba623222f9b4d931bb18fbc7172e512bac8c2f073e906231e971dd1097ea619": {},
                   "sha256:cc3df9449002eacd595a73df52eb973d3b37e4c03d4669c7dce6ce7a26dabd6b": {},
+                  "sha256:ccfdbebdf0575395a80f2fa55e49c8358ca601fdbb0685f37e8c584226264eca": {},
                   "sha256:cd7c30d21e7240f60f0861c229e17fda43e855ab4c78fab39f47f7ae2be5720e": {},
                   "sha256:ce63708391f77873a344a2ff1ff148be88a5bac39693c9d0bb458f7b3ebd63b9": {},
                   "sha256:ce7e129103cab9de8081b9752a9990a632b5930e371988892e671bb47d42d14e": {},
@@ -701,7 +717,9 @@
                   "sha256:d9dcb469e4c1a90f2e0ed3332d37feb88f804c882aae21fb6dfdeb6564dccfe5": {},
                   "sha256:d9e5cea8712d1093241ba300b86d4349b46e51dcecbee4a88692dd2a4027a270": {},
                   "sha256:db515162530e2c50f9e271c33a4f3852bc92c57b2ec1aa1f7117a3d5f01dd467": {},
+                  "sha256:db8bc154626bdd906a1f50104031a5042bbe91db7f5a1473657795eedd4158c6": {},
                   "sha256:dc7cae6d236b36420e400d1a9731ba6006b3ba8c67d8267931196c7fb9dae873": {},
+                  "sha256:de870435340bf30620406df41b79e43adaf7d0a277db1635a0fae710df993fc0": {},
                   "sha256:df169d238e43e575b61b9eb02a392d9c2c75fe6b0bb678f8d8ca27e169347372": {},
                   "sha256:df49ae83611b2533047732fd1975981316d88e8faf35a64914714b97f8c6a662": {},
                   "sha256:df8d763da5dd3bef5b17f55d43228c6aeb0529889521b6d05bc21932d1711a00": {},
@@ -713,6 +731,8 @@
                   "sha256:e5949d6be25e68c70eb0560dc059c091ec990cf658dcec49413592247c53680b": {},
                   "sha256:e73e4038b7f9af1af684da6e3648e45c3232ee78d0db0d2d54334e89c63c8ff7": {},
                   "sha256:e7fb0b1c8cac6c9d79dc0fb6d974de2b0cd8e004ddf438df12545a366d1838d9": {},
+                  "sha256:e868499743c399baa6463fa64a2534a7d32f8e1cca7b1b47ec00c60b34250bfe": {},
+                  "sha256:e888454f4620debf3bdd76b59444e30ef5c2c8f81912ac6a37f525dc3eae7810": {},
                   "sha256:e8bd27a1513f118f9081d66c4401ad55f499033724e9fc6c7f20945a925edf33": {},
                   "sha256:e920a82cda55b110690f3c946ec2cd85f969599c71212463279763afcc33303d": {},
                   "sha256:eb2cdbba2b46409f72e715cee6773efb34c8114b13ed823d4dbbb6e1fcc6bc8d": {},
@@ -730,6 +750,7 @@
                   "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26": {},
                   "sha256:f0cb56a04fa3b27c1a3bb8896372077234123b36fe3461aca8ddc7b912030ce8": {},
                   "sha256:f114254f9dadd3dbedf108ab8d81bbb247d8eb19f9d018454a7c01d919a65c44": {},
+                  "sha256:f1784b0b9221581d9beac947a7a43cc9f4839ede18f38a0274461185788792a9": {},
                   "sha256:f1d5ff8f8133371628c0b6a57af4792958335ef9038fee14f9505e12605ac666": {},
                   "sha256:f39e031ea848d9605601b3e8e9424339cec44ecb521fbd1a415915a5f373eb37": {},
                   "sha256:f43d8fbd83779706c5d2d8ebec56b9cf7178dab9e02b53f952d0abbd198963ec": {},
@@ -753,6 +774,7 @@
                   "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {},
                   "sha256:fdcc4180cae8fa83ca54188fc2f6796a1bc8d7eb7106163b98dd93d974b48cd1": {},
                   "sha256:fdef90440ec3fcb1fb8385de7e6c5b3755639184b56e203f447713584ebfdf48": {},
+                  "sha256:fe1a3e821eab7aafd11152c5d5b9f6cf57de36d8ef3b517e0e2f2315b062742c": {},
                   "sha256:fe8a0a5f6f9a9fc8b92fec2d1305cd8c5c0658b48647b13dbe24d4d3b64f0e28": {},
                   "sha256:fec32d37b2f34c891a64a8c5e2faf3d08de25d144289b6f2b7f5fafdd5eec4d2": {},
                   "sha256:ff40cc757f3cff0853798692c1ecd01f4ee4c725093d3c599aa2dfd9f461288c": {}
@@ -1056,6 +1078,9 @@
           "sha256:06bbb021f0549c739613edb28cb4f39b7389c718c063934c980d32df3e032d3b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/platform-python-3.6.8-39.el8.x86_64.rpm"
           },
+          "sha256:076bdcf066fabe9c611ceee12665d735136ecd306ec4c1e608bb1e0a4704ae55": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-prettytable-0.7.2-14.el8.noarch.rpm"
+          },
           "sha256:07d885ed980e09242fa1b6b4faaa5aaf3ea1f24415ac86a6a1f2f08ab5797784": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/libunistring-0.9.9-3.el8.x86_64.rpm"
           },
@@ -1091,6 +1116,9 @@
           },
           "sha256:13d3c0c2db0b1207012bad406cfb60c509f40618be1a9d342ae06963a3930202": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/freetype-2.9.1-4.el8_3.1.x86_64.rpm"
+          },
+          "sha256:13ffce0597b689dd53f55ea0d03dd6d013246634f5c6cbcef51fa549d9734b29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-cffi-1.11.5-5.el8.x86_64.rpm"
           },
           "sha256:150e9dbb5a19483c85c25c722ff63a08d9411023c40faf88f42843fdf68ea275": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/popt-1.18-1.el8.x86_64.rpm"
@@ -1293,6 +1321,9 @@
           "sha256:3423075b5f924b1512e91fb5c8532ef2768cd2b1b9591e4a2ac3b76d99aa380d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/cracklib-dicts-2.9.6-15.el8.x86_64.rpm"
           },
+          "sha256:3446bbd5d26c3a1b8cd64c077ae4bbeea8ef2ef349c590297bbe2a53e18ce9e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-oauthlib-2.1.0-1.el8.noarch.rpm"
+          },
           "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
@@ -1346,6 +1377,9 @@
           },
           "sha256:3e79690d58e6a213278c4f2789ad4dae58b09b8f5c0890e1ac7d843ae3f25c7b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/libseccomp-2.5.1-1.el8.x86_64.rpm"
+          },
+          "sha256:3e9dff1e55f3d4121bb4d85839f0e26a05bb95ed652abbe15535167528226414": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-pyserial-3.1.1-8.el8.noarch.rpm"
           },
           "sha256:3faad2fd944f90540a82431edb54d5c2f7ad8a845ec6f8ddaf9d36de6caee84c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/libmount-2.32.1-28.el8.x86_64.rpm"
@@ -1485,14 +1519,26 @@
           "sha256:58cf5aa3c5b3f7bed1433b33818fb6327ec4d6cebe3772c99249e19bb14a8c03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-mako-1.0.6-13.el8.noarch.rpm"
           },
+          "sha256:58d5f26daf746cf161e1be4fb6cda4e320ef2a624f0ab7913ee498b26aad8659": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-cryptography-3.2.1-5.el8.x86_64.rpm"
+          },
+          "sha256:59bf7b92f9eecb7868e960dc05c269a9df088d2dc71ce85cf77bfad68e206f0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-jsonschema-2.6.0-4.el8.noarch.rpm"
+          },
           "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-dbus-1.2.4-15.el8.x86_64.rpm"
+          },
+          "sha256:5b1bc2ca63d563828a3a0968d42fb75ae0917366d06df8176d917f7c477f33b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-libsemanage-2.9-6.el8.x86_64.rpm"
           },
           "sha256:5b9e2d133d23e5eb353b8f0a864ce1a9ee6706fe61804e53068faabb53b79789": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/selinux-policy-targeted-3.14.3-75.el8.noarch.rpm"
           },
           "sha256:5d527a7fe40c223f9e8448cdb657daba3582d4ab296400c65294a4f1f921892b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/libselinux-2.9-5.el8.x86_64.rpm"
+          },
+          "sha256:5d9c5b3341e9b10091a5bc66c08455ce7d9c62911fac6b759b847a46749a1adf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-jsonpointer-1.10-11.el8.noarch.rpm"
           },
           "sha256:5e4046b9fb264bd8bfc6382bab675ae517c9d1d5e7c41737bdfc725702a8ddc2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/iwl5150-firmware-8.24.2.2-102.el8.1.noarch.rpm"
@@ -1668,8 +1714,14 @@
           "sha256:7f2436df92ce3dacaf5a52d988e65b2cbfc6af8be917bdc14119940480efd7bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-slip-0.6.4-11.el8.noarch.rpm"
           },
+          "sha256:7f5386be44b3af8a75cd71f7675fd6e326e49086dd339bbaa7ffbf6c0a67b95d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/cloud-init-21.1-3.el8.noarch.rpm"
+          },
           "sha256:7f564d267644d0e24ea856599ab95dba3bbdd7a0fc6554c803185d771a12d8e6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/syslinux-6.04-5.el8.x86_64.rpm"
+          },
+          "sha256:7f669e03c4edfd5b528fc354d259e076f472712cf700c273b236d492b59870d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-policycoreutils-2.9-15.el8.noarch.rpm"
           },
           "sha256:7f7f559d65b4b29a1695a644c3d0e04f36565feaa65416f4b84b309716ecf17f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/gdisk-1.0.3-6.el8.x86_64.rpm"
@@ -1731,6 +1783,12 @@
           "sha256:8b05d986058c83b2041499ed8d1466073bd492319db781a50f8c5f2b9bbe447e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/libblockdev-part-2.24-7.el8.x86_64.rpm"
           },
+          "sha256:8c3deaabbd79922ad6eae143a100e0d5b04c10a729d1ac01128d843039d3eebf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-pycparser-2.14-14.el8.noarch.rpm"
+          },
+          "sha256:8c6da26441750b3970fe73b6a9d2d780931da6cdea48f10d0b34c65c79a9e341": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm"
+          },
           "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
@@ -1754,6 +1812,9 @@
           },
           "sha256:8e838f5065490d117f247f55047de7e46ea36193432ff17eab9e4e7724c8c8e1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/snappy-1.1.8-3.el8.x86_64.rpm"
+          },
+          "sha256:8f00781eb679c6baf359099fa2a672ffccfc8e43b7c03c1dc635619cb25ff01d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-audit-3.0-0.17.20191104git1c2f876.el8.x86_64.rpm"
           },
           "sha256:90317599f1fbe047c780d4a432959cdffb9d34d47d9df9afe6031eb0f626fef7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/libtalloc-2.3.2-1.el8.x86_64.rpm"
@@ -1890,6 +1951,9 @@
           "sha256:a7de0cd4116b5b08f1f8f244161fffa403a1b91b3c8c1c0341a8e7c119ef9f69": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/kernel-4.18.0-325.el8.x86_64.rpm"
           },
+          "sha256:a8808c053ffb7ccf826d80fdd458b6521f2cc63e55eb90d79a504fbb66c36cb0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/checkpolicy-2.9-1.el8.x86_64.rpm"
+          },
           "sha256:a9aa2b045a94eacae8f6b0a5a632d3e91794f63c955b7b080ef319cd6bcface6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/lmdb-libs-0.9.24-1.el8.x86_64.rpm"
           },
@@ -1998,6 +2062,9 @@
           "sha256:bb4a332cff094f2afeb8f4d0893b3240562501add9c258d567382db5fe0d341c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/kernel-modules-4.18.0-325.el8.x86_64.rpm"
           },
+          "sha256:bce8cbc50f5872bcee1bed9ff041bebfae10169f007cf97b268819e78b9d8835": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-jsonpatch-1.21-2.el8.noarch.rpm"
+          },
           "sha256:bd37c05e277205686dade257e19f95839fad32f2278872dbc9969c50ec9da0b6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/librhsm-0.0.3-4.el8.x86_64.rpm"
           },
@@ -2099,6 +2166,9 @@
           },
           "sha256:cc3df9449002eacd595a73df52eb973d3b37e4c03d4669c7dce6ce7a26dabd6b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/audit-3.0-0.17.20191104git1c2f876.el8.x86_64.rpm"
+          },
+          "sha256:ccfdbebdf0575395a80f2fa55e49c8358ca601fdbb0685f37e8c584226264eca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-pytz-2017.2-9.el8.noarch.rpm"
           },
           "sha256:cd7c30d21e7240f60f0861c229e17fda43e855ab4c78fab39f47f7ae2be5720e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/libmetalink-0.1.3-7.el8.x86_64.rpm"
@@ -2208,8 +2278,14 @@
           "sha256:db515162530e2c50f9e271c33a4f3852bc92c57b2ec1aa1f7117a3d5f01dd467": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/libblockdev-utils-2.24-7.el8.x86_64.rpm"
           },
+          "sha256:db8bc154626bdd906a1f50104031a5042bbe91db7f5a1473657795eedd4158c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-setools-4.3.0-2.el8.x86_64.rpm"
+          },
           "sha256:dc7cae6d236b36420e400d1a9731ba6006b3ba8c67d8267931196c7fb9dae873": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/libdb-5.3.28-40.el8.x86_64.rpm"
+          },
+          "sha256:de870435340bf30620406df41b79e43adaf7d0a277db1635a0fae710df993fc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-pyyaml-3.12-12.el8.x86_64.rpm"
           },
           "sha256:df169d238e43e575b61b9eb02a392d9c2c75fe6b0bb678f8d8ca27e169347372": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/libpwquality-1.4.4-3.el8.x86_64.rpm"
@@ -2255,6 +2331,9 @@
           },
           "sha256:e868499743c399baa6463fa64a2534a7d32f8e1cca7b1b47ec00c60b34250bfe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-markupsafe-0.23-19.el8.x86_64.rpm"
+          },
+          "sha256:e888454f4620debf3bdd76b59444e30ef5c2c8f81912ac6a37f525dc3eae7810": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-babel-2.5.1-7.el8.noarch.rpm"
           },
           "sha256:e8bd27a1513f118f9081d66c4401ad55f499033724e9fc6c7f20945a925edf33": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/dracut-config-generic-049-136.git20210426.el8.x86_64.rpm"
@@ -2309,6 +2388,9 @@
           },
           "sha256:f114254f9dadd3dbedf108ab8d81bbb247d8eb19f9d018454a7c01d919a65c44": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/libblockdev-loop-2.24-7.el8.x86_64.rpm"
+          },
+          "sha256:f1784b0b9221581d9beac947a7a43cc9f4839ede18f38a0274461185788792a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-ply-3.9-9.el8.noarch.rpm"
           },
           "sha256:f1d5ff8f8133371628c0b6a57af4792958335ef9038fee14f9505e12605ac666": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/libsss_certmap-2.5.2-1.el8.x86_64.rpm"
@@ -2381,6 +2463,9 @@
           },
           "sha256:fdef90440ec3fcb1fb8385de7e6c5b3755639184b56e203f447713584ebfdf48": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/libssh-0.9.4-3.el8.x86_64.rpm"
+          },
+          "sha256:fe1a3e821eab7aafd11152c5d5b9f6cf57de36d8ef3b517e0e2f2315b062742c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-jwt-1.6.1-2.el8.noarch.rpm"
           },
           "sha256:fe8a0a5f6f9a9fc8b92fec2d1305cd8c5c0658b48647b13dbe24d4d3b64f0e28": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/shadow-utils-4.6-13.el8.x86_64.rpm"
@@ -6236,6 +6321,15 @@
         "checksum": "sha256:81009534d9589d8a9ceada4052d1b29afd82ad56693d7420725b5925bf23a851"
       },
       {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "1.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/checkpolicy-2.9-1.el8.x86_64.rpm",
+        "checksum": "sha256:a8808c053ffb7ccf826d80fdd458b6521f2cc63e55eb90d79a504fbb66c36cb0"
+      },
+      {
         "name": "chkconfig",
         "epoch": 0,
         "version": "1.19.1",
@@ -8819,6 +8913,24 @@
         "checksum": "sha256:f8c191d8b952621d10a1055be960bbe07be66f557c5a9d007f8908abcde1b9af"
       },
       {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0",
+        "release": "0.17.20191104git1c2f876.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-audit-3.0-0.17.20191104git1c2f876.el8.x86_64.rpm",
+        "checksum": "sha256:8f00781eb679c6baf359099fa2a672ffccfc8e43b7c03c1dc635619cb25ff01d"
+      },
+      {
+        "name": "python3-cffi",
+        "epoch": 0,
+        "version": "1.11.5",
+        "release": "5.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-cffi-1.11.5-5.el8.x86_64.rpm",
+        "checksum": "sha256:13ffce0597b689dd53f55ea0d03dd6d013246634f5c6cbcef51fa549d9734b29"
+      },
+      {
         "name": "python3-chardet",
         "epoch": 0,
         "version": "3.0.4",
@@ -8844,6 +8956,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm",
         "checksum": "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367"
+      },
+      {
+        "name": "python3-cryptography",
+        "epoch": 0,
+        "version": "3.2.1",
+        "release": "5.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-cryptography-3.2.1-5.el8.x86_64.rpm",
+        "checksum": "sha256:58d5f26daf746cf161e1be4fb6cda4e320ef2a624f0ab7913ee498b26aad8659"
       },
       {
         "name": "python3-dateutil",
@@ -8972,6 +9093,15 @@
         "checksum": "sha256:49ea248bc51c089015b2169887bedb5faf3f97f97479077929baf3272ad18d54"
       },
       {
+        "name": "python3-jwt",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-jwt-1.6.1-2.el8.noarch.rpm",
+        "checksum": "sha256:fe1a3e821eab7aafd11152c5d5b9f6cf57de36d8ef3b517e0e2f2315b062742c"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.16",
@@ -9017,6 +9147,15 @@
         "checksum": "sha256:45740507b141cacf5bf5360a9e5823266f878a3c7ce8e212e3d0e7692d8dfc22"
       },
       {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-libsemanage-2.9-6.el8.x86_64.rpm",
+        "checksum": "sha256:5b1bc2ca63d563828a3a0968d42fb75ae0917366d06df8176d917f7c477f33b4"
+      },
+      {
         "name": "python3-libxml2",
         "epoch": 0,
         "version": "2.9.7",
@@ -9044,6 +9183,15 @@
         "checksum": "sha256:3dfb211aa89fa4c41434d2526cd07f98e276b724e2bc6aa9a6be67f5a6d5d004"
       },
       {
+        "name": "python3-oauthlib",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-oauthlib-2.1.0-1.el8.noarch.rpm",
+        "checksum": "sha256:3446bbd5d26c3a1b8cd64c077ae4bbeea8ef2ef349c590297bbe2a53e18ce9e6"
+      },
+      {
         "name": "python3-perf",
         "epoch": 0,
         "version": "4.18.0",
@@ -9060,6 +9208,33 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-pip-wheel-9.0.3-20.el8.noarch.rpm",
         "checksum": "sha256:e53699b8142244c10df48394869ae2ff0f840db2403021a75d8d3d1f53a7c86d"
+      },
+      {
+        "name": "python3-ply",
+        "epoch": 0,
+        "version": "3.9",
+        "release": "9.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-ply-3.9-9.el8.noarch.rpm",
+        "checksum": "sha256:f1784b0b9221581d9beac947a7a43cc9f4839ede18f38a0274461185788792a9"
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "15.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-policycoreutils-2.9-15.el8.noarch.rpm",
+        "checksum": "sha256:7f669e03c4edfd5b528fc354d259e076f472712cf700c273b236d492b59870d1"
+      },
+      {
+        "name": "python3-pycparser",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-pycparser-2.14-14.el8.noarch.rpm",
+        "checksum": "sha256:8c3deaabbd79922ad6eae143a100e0d5b04c10a729d1ac01128d843039d3eebf"
       },
       {
         "name": "python3-pysocks",
@@ -9080,6 +9255,15 @@
         "checksum": "sha256:4ad66a3a1dd79384852669609567108dcc429607d40ca8adc5f1dbe6a9d6bdde"
       },
       {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "3.12",
+        "release": "12.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-pyyaml-3.12-12.el8.x86_64.rpm",
+        "checksum": "sha256:de870435340bf30620406df41b79e43adaf7d0a277db1635a0fae710df993fc0"
+      },
+      {
         "name": "python3-requests",
         "epoch": 0,
         "version": "2.20.0",
@@ -9096,6 +9280,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-rpm-4.14.3-15.el8.x86_64.rpm",
         "checksum": "sha256:9d232bc82a3dfe77c84a88ae1fcd939cd202afa81a9cc2db2ee53e6500d6a8a8"
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.3.0",
+        "release": "2.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.5-20210730/Packages/python3-setools-4.3.0-2.el8.x86_64.rpm",
+        "checksum": "sha256:db8bc154626bdd906a1f50104031a5042bbe91db7f5a1473657795eedd4158c6"
       },
       {
         "name": "python3-setuptools-wheel",
@@ -9629,6 +9822,15 @@
         "checksum": "sha256:43a4f1c39b2a8b212d50af73d0d510adfdc4ac61be8ecdc6bd718f6cab0e5afc"
       },
       {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "21.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/cloud-init-21.1-3.el8.noarch.rpm",
+        "checksum": "sha256:7f5386be44b3af8a75cd71f7675fd6e326e49086dd339bbaa7ffbf6c0a67b95d"
+      },
+      {
         "name": "langpacks-en",
         "epoch": 0,
         "version": "1.0",
@@ -9881,6 +10083,87 @@
         "checksum": "sha256:98226d71dddd3186e73b3146b3e50f538549619c5920e9248e69f6cf3b908b14"
       },
       {
+        "name": "python3-babel",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-babel-2.5.1-7.el8.noarch.rpm",
+        "checksum": "sha256:e888454f4620debf3bdd76b59444e30ef5c2c8f81912ac6a37f525dc3eae7810"
+      },
+      {
+        "name": "python3-jinja2",
+        "epoch": 0,
+        "version": "2.10.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm",
+        "checksum": "sha256:8c6da26441750b3970fe73b6a9d2d780931da6cdea48f10d0b34c65c79a9e341"
+      },
+      {
+        "name": "python3-jsonpatch",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-jsonpatch-1.21-2.el8.noarch.rpm",
+        "checksum": "sha256:bce8cbc50f5872bcee1bed9ff041bebfae10169f007cf97b268819e78b9d8835"
+      },
+      {
+        "name": "python3-jsonpointer",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "11.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-jsonpointer-1.10-11.el8.noarch.rpm",
+        "checksum": "sha256:5d9c5b3341e9b10091a5bc66c08455ce7d9c62911fac6b759b847a46749a1adf"
+      },
+      {
+        "name": "python3-jsonschema",
+        "epoch": 0,
+        "version": "2.6.0",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-jsonschema-2.6.0-4.el8.noarch.rpm",
+        "checksum": "sha256:59bf7b92f9eecb7868e960dc05c269a9df088d2dc71ce85cf77bfad68e206f0b"
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "0.23",
+        "release": "19.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-markupsafe-0.23-19.el8.x86_64.rpm",
+        "checksum": "sha256:e868499743c399baa6463fa64a2534a7d32f8e1cca7b1b47ec00c60b34250bfe"
+      },
+      {
+        "name": "python3-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-prettytable-0.7.2-14.el8.noarch.rpm",
+        "checksum": "sha256:076bdcf066fabe9c611ceee12665d735136ecd306ec4c1e608bb1e0a4704ae55"
+      },
+      {
+        "name": "python3-pyserial",
+        "epoch": 0,
+        "version": "3.1.1",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-pyserial-3.1.1-8.el8.noarch.rpm",
+        "checksum": "sha256:3e9dff1e55f3d4121bb4d85839f0e26a05bb95ed652abbe15535167528226414"
+      },
+      {
+        "name": "python3-pytz",
+        "epoch": 0,
+        "version": "2017.2",
+        "release": "9.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.5-20210730/Packages/python3-pytz-2017.2-9.el8.noarch.rpm",
+        "checksum": "sha256:ccfdbebdf0575395a80f2fa55e49c8358ca601fdbb0685f37e8c584226264eca"
+      },
+      {
         "name": "python3-unbound",
         "epoch": 0,
         "version": "1.7.3",
@@ -9993,6 +10276,114 @@
       "pool": [
         "2.rhel.pool.ntp.org iburst"
       ]
+    },
+    "cloud-init": {
+      "/etc/cloud": {
+        "cloud.cfg": {
+          "cloud_config_modules": [
+            "mounts",
+            "locale",
+            "set-passwords",
+            "rh_subscription",
+            "yum-add-repo",
+            "package-update-upgrade-install",
+            "timezone",
+            "puppet",
+            "chef",
+            "salt-minion",
+            "mcollective",
+            "disable-ec2-metadata",
+            "runcmd"
+          ],
+          "cloud_final_modules": [
+            "rightscale_userdata",
+            "scripts-per-once",
+            "scripts-per-boot",
+            "scripts-per-instance",
+            "scripts-user",
+            "ssh-authkey-fingerprints",
+            "keys-to-console",
+            "phone-home",
+            "final-message",
+            "power-state-change"
+          ],
+          "cloud_init_modules": [
+            "disk_setup",
+            "migrator",
+            "bootcmd",
+            "write-files",
+            "growpart",
+            "resizefs",
+            "set_hostname",
+            "update_hostname",
+            "update_etc_hosts",
+            "rsyslog",
+            "users-groups",
+            "ssh"
+          ],
+          "disable_root": 1,
+          "disable_vmware_customization": false,
+          "mount_default_fields": [
+            null,
+            null,
+            "auto",
+            "defaults,nofail,x-systemd.requires=cloud-init.service",
+            "0",
+            "2"
+          ],
+          "resize_rootfs_tmp": "/dev",
+          "ssh_deletekeys": 1,
+          "ssh_genkeytypes": [
+            "rsa",
+            "ecdsa",
+            "ed25519"
+          ],
+          "ssh_pwauth": 0,
+          "syslog_fix_perms": null,
+          "system_info": {
+            "default_user": {
+              "gecos": "Cloud User",
+              "groups": [
+                "adm",
+                "systemd-journal"
+              ],
+              "lock_passwd": true,
+              "name": "cloud-user",
+              "shell": "/bin/bash",
+              "sudo": [
+                "ALL=(ALL) NOPASSWD:ALL"
+              ]
+            },
+            "distro": "rhel",
+            "paths": {
+              "cloud_dir": "/var/lib/cloud",
+              "templates_dir": "/etc/cloud/templates"
+            },
+            "ssh_svcname": "sshd"
+          },
+          "users": [
+            "default"
+          ]
+        }
+      },
+      "/etc/cloud/cloud.cfg.d": {
+        "05_logging.cfg": {
+          "_log": [
+            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
+            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
+          ],
+          "log_cfgs": [
+            [
+              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
+            ]
+          ],
+          "output": {
+            "all": "| tee -a /var/log/cloud-init-output.log"
+          }
+        }
+      }
     },
     "default-target": "graphical.target",
     "dnf": {
@@ -10159,8 +10550,10 @@
       "bzip2-libs-1.0.6-26.el8.x86_64",
       "c-ares-1.13.0-5.el8.x86_64",
       "ca-certificates-2021.2.50-82.el8.noarch",
+      "checkpolicy-2.9-1.el8.x86_64",
       "chkconfig-1.19.1-1.el8.x86_64",
       "chrony-4.1-1.el8.x86_64",
+      "cloud-init-21.1-3.el8.noarch",
       "coreutils-8.30-12.el8.x86_64",
       "coreutils-common-8.30-12.el8.x86_64",
       "cpio-2.12-10.el8.x86_64",
@@ -10477,9 +10870,13 @@
       "prefixdevname-0.1.0-6.el8.x86_64",
       "procps-ng-3.3.15-6.el8.x86_64",
       "publicsuffix-list-dafsa-20180723-1.el8.noarch",
+      "python3-audit-3.0-0.17.20191104git1c2f876.el8.x86_64",
+      "python3-babel-2.5.1-7.el8.noarch",
+      "python3-cffi-1.11.5-5.el8.x86_64",
       "python3-chardet-3.0.4-7.el8.noarch",
       "python3-cloud-what-1.28.19-1.el8.x86_64",
       "python3-configobj-5.0.6-11.el8.noarch",
+      "python3-cryptography-3.2.1-5.el8.x86_64",
       "python3-dateutil-2.6.1-6.el8.noarch",
       "python3-dbus-1.2.4-15.el8.x86_64",
       "python3-decorator-4.2.1-2.el8.noarch",
@@ -10494,20 +10891,36 @@
       "python3-idna-2.5-5.el8.noarch",
       "python3-iniparse-0.4-31.el8.noarch",
       "python3-inotify-0.9.6-13.el8.noarch",
+      "python3-jinja2-2.10.1-3.el8.noarch",
+      "python3-jsonpatch-1.21-2.el8.noarch",
+      "python3-jsonpointer-1.10-11.el8.noarch",
+      "python3-jsonschema-2.6.0-4.el8.noarch",
+      "python3-jwt-1.6.1-2.el8.noarch",
       "python3-libcomps-0.1.16-2.el8.x86_64",
       "python3-libdnf-0.63.0-1.el8.x86_64",
       "python3-librepo-1.14.0-2.el8.x86_64",
       "python3-libs-3.6.8-39.el8.x86_64",
       "python3-libselinux-2.9-5.el8.x86_64",
+      "python3-libsemanage-2.9-6.el8.x86_64",
       "python3-libxml2-2.9.7-11.el8.x86_64",
       "python3-linux-procfs-0.6.3-1.el8.noarch",
+      "python3-markupsafe-0.23-19.el8.x86_64",
       "python3-nftables-0.9.3-20.el8.x86_64",
+      "python3-oauthlib-2.1.0-1.el8.noarch",
       "python3-perf-4.18.0-325.el8.x86_64",
       "python3-pip-wheel-9.0.3-20.el8.noarch",
+      "python3-ply-3.9-9.el8.noarch",
+      "python3-policycoreutils-2.9-15.el8.noarch",
+      "python3-prettytable-0.7.2-14.el8.noarch",
+      "python3-pycparser-2.14-14.el8.noarch",
+      "python3-pyserial-3.1.1-8.el8.noarch",
       "python3-pysocks-1.6.8-3.el8.noarch",
+      "python3-pytz-2017.2-9.el8.noarch",
       "python3-pyudev-0.21.0-7.el8.noarch",
+      "python3-pyyaml-3.12-12.el8.x86_64",
       "python3-requests-2.20.0-2.1.el8_1.noarch",
       "python3-rpm-4.14.3-15.el8.x86_64",
+      "python3-setools-4.3.0-2.el8.x86_64",
       "python3-setuptools-wheel-39.2.0-6.el8.noarch",
       "python3-six-1.11.0-8.el8.noarch",
       "python3-slip-0.6.4-11.el8.noarch",
@@ -10765,6 +11178,10 @@
       "auditd.service",
       "autovt@.service",
       "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
       "crond.service",
       "ctrl-alt-del.target",
       "dbus-org.fedoraproject.FirewallD1.service",
@@ -10907,6 +11324,9 @@
     "timezone": "New_York",
     "tmpfiles.d": {
       "/usr/lib/tmpfiles.d": {
+        "cloud-init.conf": [
+          "d /run/cloud-init 0700 root root - -"
+        ],
         "cryptsetup.conf": [
           "d /run/cryptsetup 0700 root root -"
         ],

--- a/test/data/manifests/rhel_86-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-vmdk-boot.json
@@ -335,6 +335,7 @@
                   "sha256:0403842bda6dbbde303e9551f5b32c09d262cc8a7938b442e62bc5981f4a3f40": {},
                   "sha256:069bdcddf935c48adcb5029438f6007a416952daa96d2071f430e0e9ca5418ec": {},
                   "sha256:06f6a82e268aa006507fb1f82f01893f996fd47ad1cfa5f839c7861e8fd317cf": {},
+                  "sha256:076bdcf066fabe9c611ceee12665d735136ecd306ec4c1e608bb1e0a4704ae55": {},
                   "sha256:07ce753de89c0f6cc82ee926100777bdd0c91cb3d3ee9315cd8d93320875e66c": {},
                   "sha256:07d885ed980e09242fa1b6b4faaa5aaf3ea1f24415ac86a6a1f2f08ab5797784": {},
                   "sha256:09149617095dc52e19cdce1e45c8245e1e92d371bd4d107320ff56788b9977f1": {},
@@ -357,12 +358,14 @@
                   "sha256:134219ddd4f07902fcbd999c089200e0d77eb5139eec73aa9e56e0bdddb7a932": {},
                   "sha256:13d3c0c2db0b1207012bad406cfb60c509f40618be1a9d342ae06963a3930202": {},
                   "sha256:13dbb2d6d6ae68cae6313d09c404b75ebbe55dbf2d6b9fca7ae31a61af077bfa": {},
+                  "sha256:13ffce0597b689dd53f55ea0d03dd6d013246634f5c6cbcef51fa549d9734b29": {},
                   "sha256:14175dab807188a8261298dc3ba7b7cd19a9fbf36d0ee5b5c6cacc7e424998e4": {},
                   "sha256:150e9dbb5a19483c85c25c722ff63a08d9411023c40faf88f42843fdf68ea275": {},
                   "sha256:15e42b06b36f9c09a3983aa03eb9f7f7f2b94f7e588eeb8cb943a17a9578ea38": {},
                   "sha256:17c1fcfda1c7367e5bddeafa29193379ce8712958d4b735e2227e7a07950e858": {},
                   "sha256:17df8c56a274f06952217b88b14f1baa03357cc8c161752dae5933b05097b098": {},
                   "sha256:184f1319a9216616e5cd9857b69d5d661443894557528729115bf21c3f35bb03": {},
+                  "sha256:19dba7cb30c3cb598886326df0ec1114c6e195a57c9ce3a8b78b83555e9e8648": {},
                   "sha256:1b1dc181584833cdd7520bb26a4e03dcffb35985a9d1254b36f824401a970fe9": {},
                   "sha256:1b6fe19e2856f752a2cd8f917db539dbe9fc1b1560fff3341864b13ffb0ccae0": {},
                   "sha256:1b9c2dc9be278b1a3342dc080d55eff0c2fdce806b037682e431af83c534817e": {},
@@ -382,6 +385,7 @@
                   "sha256:1f9b3ad37f40d4e908b9cf610e85f1b69d1140ff40911b452f88779e364d8889": {},
                   "sha256:1fc776d8b85cb0e33643734ffb0552a2616c1c5ce2edb5ebb3bdbc20c1486065": {},
                   "sha256:1ff27852aeaf1f6a13adeba0167e03c72af294c3f8ca267f05832f66c569e257": {},
+                  "sha256:206de21c82d76de550bcc1959138472640b0a950a311b753203f5dfe5b201b7b": {},
                   "sha256:20ad0a3db2a075842747682638513899bb7d455c81cbee108d13cd64e173f260": {},
                   "sha256:224388a69a7ab8f379b42c09106fb398d77f7e7077c3f1e9680452d746d755fe": {},
                   "sha256:226b4efe6fb8e19d17cf4ffed266a413dac4801ad804887e5e00f7fb8e6c2ef9": {},
@@ -401,6 +405,7 @@
                   "sha256:2822e9a376d50f24e53b0d30730a47870ce90bf12ef435cb4f06a450e02b4c20": {},
                   "sha256:28ccf9ff472c824f6c5a3c2a0c076bfa221b8e48368e43de9b3c2e83d67e8b5d": {},
                   "sha256:29d6e6786af661a3e01ce9fbe290b59e86c4902b40a0f29b3b58f6a076841fd3": {},
+                  "sha256:29ea55621defd44df6d0de87cb3a9727ac25fdf3179b63670e54cc7faa2996ee": {},
                   "sha256:2ae7eca09c469bbf5c362daa544ccb453f22d7267a85e7aec006a83cce163aa8": {},
                   "sha256:2b18950e446e1bddde2f91b7d86e004d24bd43ad7f73ca3d13e5db0765d1d250": {},
                   "sha256:2b7a6aa5837347ac64fcdce693ea694b9f33a96be88e35defe666df16429f12b": {},
@@ -419,6 +424,7 @@
                   "sha256:3384bccab530807195eb9d72547aa588bdea55567ca86d1719f32402bf1cd0c9": {},
                   "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806": {},
                   "sha256:3423075b5f924b1512e91fb5c8532ef2768cd2b1b9591e4a2ac3b76d99aa380d": {},
+                  "sha256:3446bbd5d26c3a1b8cd64c077ae4bbeea8ef2ef349c590297bbe2a53e18ce9e6": {},
                   "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {},
                   "sha256:3681d29b44ff583fbac1d8ef0fddfc1ae43565296e5c4014801523755ee26022": {},
                   "sha256:37504d807ac0bb6c429d7be9c636f7b755464023511d856846dbb9deb8f6a76d": {},
@@ -434,6 +440,8 @@
                   "sha256:3ded289944ae1be6daded7105456bcb8508f155cc7fd2807e546b2fe32f9b002": {},
                   "sha256:3e4ea07a068ac27709ed9ed3ddea98cffdb45c7bec92ff80252cfbaccb52797c": {},
                   "sha256:3e8e2a991ffed874a3f454d23eb3082744db8459257bfcf47f542f9edcf1ecb4": {},
+                  "sha256:3e9dff1e55f3d4121bb4d85839f0e26a05bb95ed652abbe15535167528226414": {},
+                  "sha256:3edf7d29e530e6568416d4455e9fbaa511aba236c603da9928e689fae77b9874": {},
                   "sha256:400c6d6d91fdffb0296ae46d155719787bc5f39f1f18c0391019bdef998fa8a4": {},
                   "sha256:4038a2471c2324909553d183c1faf8072c442cd85fb2aff2b124844f207160d9": {},
                   "sha256:403980be89cb21247a5a1750e8fbee915f111ac53ff9089f72d303211df23a23": {},
@@ -456,6 +464,7 @@
                   "sha256:48e0e5143bf28f7220fc3c31db376c1ef0ed129fd3d2f82e3ce8531528924fd6": {},
                   "sha256:4969e01de0186db1dd8523e81ba82b6a4f43a3b31d253f4cf1b82803bc16699f": {},
                   "sha256:49b6b2a486bd32714619e81782623f126486452bbd2295a2ab1f3e997b97d327": {},
+                  "sha256:49c191045e168a303ba2bc655b5ecccf7fe19851db3d0563f52c50164a2ed8ba": {},
                   "sha256:49ea248bc51c089015b2169887bedb5faf3f97f97479077929baf3272ad18d54": {},
                   "sha256:49f89e7b459eaa297e518c0e55d81d1b0d8181959346673babb158103422652d": {},
                   "sha256:4a62975251933dcaff77fdbd7704e8a12bea0ecb6eaaae5ea5e552bedd6788ec": {},
@@ -491,14 +500,18 @@
                   "sha256:57ec379830cbfb310ae02166b02768a042fb06c888d56bfc89736298187c5ae3": {},
                   "sha256:584b98ef37799bd7395a09a4aa5e046613fef0e9a46bcde32926ba94031ad2cc": {},
                   "sha256:589fa333c866d9a59bc607ec6c45b7df30c8602c80c16b2aac2c0f916ebed6e7": {},
+                  "sha256:58d5f26daf746cf161e1be4fb6cda4e320ef2a624f0ab7913ee498b26aad8659": {},
                   "sha256:58fc7019292d991d418fa623cfec793be36e5a0791b2888df221265826822af4": {},
+                  "sha256:59bf7b92f9eecb7868e960dc05c269a9df088d2dc71ce85cf77bfad68e206f0b": {},
                   "sha256:59e60702ca65224a082d2b40a55572680acb639d65dffc0cbb05fc08f50e05eb": {},
                   "sha256:5a85222c8e9997a8b609b915a8fbae756de9b9bff732db852fb15fe0524f2d86": {},
                   "sha256:5af8d36d62fb7633297da810e5ca7de0137ce72b98494028fd9672b66b6ed3fa": {},
+                  "sha256:5b1bc2ca63d563828a3a0968d42fb75ae0917366d06df8176d917f7c477f33b4": {},
                   "sha256:5bb5323b336e4526befc55de0db40355cb338f69f62d260017a22e8174e1ba75": {},
                   "sha256:5bbd30ba58763a8d45ab278c3b4303cae5dfd6b8c7ee8eedfd3e8ffa107d45b6": {},
                   "sha256:5beed8560b5b56d6e6a6851451e7f6d2bbc7cf1790043873826a5adec89fde8a": {},
                   "sha256:5d527a7fe40c223f9e8448cdb657daba3582d4ab296400c65294a4f1f921892b": {},
+                  "sha256:5d9c5b3341e9b10091a5bc66c08455ce7d9c62911fac6b759b847a46749a1adf": {},
                   "sha256:5ee54ba9a16859ab501b65e05773c6160ed32b7af77a07ba455a32acd588310f": {},
                   "sha256:5fe7bfa470c95a39d2e07654ff861e05da015b1479113c464801dcb4359fcc4f": {},
                   "sha256:5ffaf4869bdd844266a156b9f1fda9d64e4f79db592384a145bf064aaca47b41": {},
@@ -523,9 +536,11 @@
                   "sha256:6e8e103c2241b106db810d05fc042e0bd7ce709c8148ecd6e225e7f78ea27d99": {},
                   "sha256:6ef0f876469f7c290b53362dd983a556edd6b5c8aace9d5e94c10bf27f0179bd": {},
                   "sha256:6ff975465dcff2d8b7f6f1efb8c865aff9baed1500e8f48e4a569700fb1208ea": {},
+                  "sha256:70d76d9f1ed43efa346f634d5237c8a533b7e6209c36a9c6f0754afd1ddfc539": {},
                   "sha256:70e42cbbd3b21cf9e670a3aaadf55105e45ef0a4aa9d4fc021930f441a87d396": {},
                   "sha256:713ec69b972a8e88622b3fcd3b84fccdbd6c333b68b6c52151c2350edad2576a": {},
                   "sha256:72384e5b49843827a64dd83881e381be7a7df4e4bb95a6ebd075dd37b74b380b": {},
+                  "sha256:723963983258ad5c85fc708c519361f4668db7703f8dbfeae6901c1459bd1010": {},
                   "sha256:72ae60bdc56f07b2131d19c75dce9100a48e46ae08ef4ae77dcffdaadbd57519": {},
                   "sha256:72f73e19d728816d4890cc6b6d4f39af8882b185ccdbd392972c702e90c7e077": {},
                   "sha256:73c29baa2cd94f1ae6a1d1333818969a281b16dd4262f413ad284c5333719a4d": {},
@@ -569,6 +584,8 @@
                   "sha256:88590efc37e205ae9b2048fcfea719157c5a3c7a9b7a650d0b7afb131e479a8b": {},
                   "sha256:8a2de5f0e170c44199145a6fa047c888eb6fcc00f67da35e452ab493b30c3f2e": {},
                   "sha256:8b04c8eb33a3af6b22e143b11fc887db47ff188eac5f0a1d80fb99f8a9bf3d44": {},
+                  "sha256:8c3deaabbd79922ad6eae143a100e0d5b04c10a729d1ac01128d843039d3eebf": {},
+                  "sha256:8c6da26441750b3970fe73b6a9d2d780931da6cdea48f10d0b34c65c79a9e341": {},
                   "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {},
                   "sha256:8d145155b38c4c12869b95f24bbb0ee49f3ea09978362a4bc9aba2972144c16d": {},
                   "sha256:8d371e753071edc796d2eadb8278980290511be6279fdf46649c81b859497d6a": {},
@@ -589,6 +606,7 @@
                   "sha256:9891bce6c368d49fd189fb184c8a96489ed0d15e8bc58039768854425d8cc6a4": {},
                   "sha256:98daaa0ba7c4c91b8f0fe4d2e1117d23495f7ec5899dddbc2117f76b7e7550dd": {},
                   "sha256:995831ad6397fbd6e91038c6889981a0b7c649c95192999dc184b98c26d48fea": {},
+                  "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74": {},
                   "sha256:998c3e82a6bb9e040d225d8e85b5b55316d2ca92fcbb4d2ad0e6fa9e896c5cdb": {},
                   "sha256:99c7ed0ee28d5fc74b6b8833d3e6eeac81e35b67d2dae17aa247d2476525550f": {},
                   "sha256:9a6eb680e8debcd0b97575a76e9cf0d0655ef7f875b362542e0d129f5e423419": {},
@@ -596,6 +614,7 @@
                   "sha256:9a9ca6857f517f1249d2eb496fe904590d6203e4a9547a28e0b23f21c4cae24a": {},
                   "sha256:9b0634c2c2cedbd9072b0bc3a05f57b22bf3c7fe25fb414c0d140996ab3a2f59": {},
                   "sha256:9b1251422cfd498da3569583dea926198827e6e5fcf2a3d3d9c5521401ad0fc9": {},
+                  "sha256:9b850e461a6cf53a2eaec959bbccd115d88bd0b1be03f58f8c6282fdefae864a": {},
                   "sha256:9bd47c00f8bf9354b06ef159a5aed91ab67c4155ce02752dfe6148314dbb11e1": {},
                   "sha256:9c5594fcac97c0f8813d7a188e2368e3b1095025fc4a0ecbd5d17e54c0c93f97": {},
                   "sha256:9c72be297996b031e3805d85349c98b548382574b3e2fdeb1671651fcf08f47a": {},
@@ -611,6 +630,7 @@
                   "sha256:a438c26e0cfbd535073a0b68110267c4c04ea303620268b3c599e2c136ceb27c": {},
                   "sha256:a53f0be84231f676266183a16c0c474ba529f3a2858c6b86591221260a19840f": {},
                   "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {},
+                  "sha256:a8808c053ffb7ccf826d80fdd458b6521f2cc63e55eb90d79a504fbb66c36cb0": {},
                   "sha256:a90c86f0186d0743c093ed8cd8b1ea7b47a636ba25088dfa4123eb8384df7477": {},
                   "sha256:a9aa2b045a94eacae8f6b0a5a632d3e91794f63c955b7b080ef319cd6bcface6": {},
                   "sha256:a9ece4c02cb38584287a36c11f506f0c8a8f278724742531b9e2b0ace6585bbe": {},
@@ -646,8 +666,10 @@
                   "sha256:ba59500c8304ec75121cc2c5f9d5917748ff8b293aca3b49c9d1d971feb606f4": {},
                   "sha256:bb068735539526ca9da28ebff3922012d691198017fe3afbb5efb74eb5844fe9": {},
                   "sha256:bb30cc2c9a183835131bf0a7783c2bff56f70777060221d6f939a2ac7ea797f9": {},
+                  "sha256:bba321ec811001b3fb136a768177a8a8e2b99f59d961535fd89854ccb34365d4": {},
                   "sha256:bbcb6a8162cff9a1908d4f6c2e54050ae9f37eb8dceee4d5aa814e90460aed9a": {},
                   "sha256:bbcd5e57bdf8280e7e7f06fe35e0d45753b5e874821a74ba1c4aae4f0088ba7d": {},
+                  "sha256:bce8cbc50f5872bcee1bed9ff041bebfae10169f007cf97b268819e78b9d8835": {},
                   "sha256:bd37c05e277205686dade257e19f95839fad32f2278872dbc9969c50ec9da0b6": {},
                   "sha256:bd43f498b97fc0d7b11efadeeac94f4b24b1edf733685c74b5ba4acb2c2f941d": {},
                   "sha256:bd5aa8dd6e421f4184293c1d6458c8785939930505d988eb4f4c72d5932c30e6": {},
@@ -668,6 +690,7 @@
                   "sha256:c501f1c985a8d0cb43ca89a4f2759f904b24f6147c607a99cc0b235932af59fc": {},
                   "sha256:c5de92eae3182b972bf0d6d59d33c0d50fc1cae852252b47a4babd0020821d15": {},
                   "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306": {},
+                  "sha256:c60aede8488f68a001f3495bd6e6d894fc3a44bb488f4550b5970ab5904d0a1e": {},
                   "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8": {},
                   "sha256:c6c7aa6efa4b965ce11fd74268378a02918b970611d5621e4a1b05af128b3f86": {},
                   "sha256:c8192b0eb0496d79d1a3925c1d7eb95abde0d4a4a2c44a86a9a78f8de6dab2d9": {},
@@ -678,6 +701,7 @@
                   "sha256:cab1aa23fc15400d291bd026fa2f2dbcde83d0ad86bceaabf5ddc16364bdeb70": {},
                   "sha256:cac59a5629e7229653c29c0d575bd8f8c2d3774474615eb65615109afb151981": {},
                   "sha256:cc60605cd4164fccd1f6b5cb07d29b55d878e1b50163be076f506eefdf46f595": {},
+                  "sha256:ccfdbebdf0575395a80f2fa55e49c8358ca601fdbb0685f37e8c584226264eca": {},
                   "sha256:ce63708391f77873a344a2ff1ff148be88a5bac39693c9d0bb458f7b3ebd63b9": {},
                   "sha256:ce7e129103cab9de8081b9752a9990a632b5930e371988892e671bb47d42d14e": {},
                   "sha256:ce810948b525e851c88a7c5ba71f8c070d91b84c8531a50dc8ea6650f115b3b5": {},
@@ -702,6 +726,7 @@
                   "sha256:d51fac44d322890f636097d85a8fd0bec3af5cc22d83440a13308b7b7ea5723b": {},
                   "sha256:d570af0578f5b2c6225f1f2354404f65bccf91c3974e98dcbc0c7b55a61b9b46": {},
                   "sha256:d5f93aa67f44d44c7c17b73d8677d3ac2ce06214f4d123859a3e3cc9def75fe0": {},
+                  "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87": {},
                   "sha256:d759703d633257a88457c38d94b9a7836e0ec8eeb72df385df348423e668ae08": {},
                   "sha256:d805c42ee9293a8ba35f49af63e3f7d813420d4a62ee4cff5ecd7391be851a9b": {},
                   "sha256:d84beeb7e2ff758872ad3b2f446ead7c0cebdb7baee49e06fac829c58e0e8ec7": {},
@@ -711,6 +736,7 @@
                   "sha256:dc0e2e71435cc36ddb20b9c5c0a32566d3aad2f18efca3614efc9dd56cf5ed80": {},
                   "sha256:dc28397f174b147917ff788379672663ebe4c89eff4bae329c32c88272d59c45": {},
                   "sha256:dd1590cec04ac5a59f21caf17aa3990aa582cc68a03c2909021a0960244cc0b7": {},
+                  "sha256:de870435340bf30620406df41b79e43adaf7d0a277db1635a0fae710df993fc0": {},
                   "sha256:df169d238e43e575b61b9eb02a392d9c2c75fe6b0bb678f8d8ca27e169347372": {},
                   "sha256:df24ba770ecc28f7ae037d02aadd3c512183e748612fa1c607adf43a50381501": {},
                   "sha256:df49ae83611b2533047732fd1975981316d88e8faf35a64914714b97f8c6a662": {},
@@ -720,6 +746,8 @@
                   "sha256:e22840ee14aa1993e75fd690749c01dbb7d4419c2b210fef173ff99a76f61ff6": {},
                   "sha256:e51a4020963b331f39714c550cbb47b1013fa9208d254cb9bf7e39ead3ede870": {},
                   "sha256:e731fe5d9d2250003782623046350dc258bb59d83c55dfdbf2b0df0e8840cd6e": {},
+                  "sha256:e868499743c399baa6463fa64a2534a7d32f8e1cca7b1b47ec00c60b34250bfe": {},
+                  "sha256:e888454f4620debf3bdd76b59444e30ef5c2c8f81912ac6a37f525dc3eae7810": {},
                   "sha256:e920a82cda55b110690f3c946ec2cd85f969599c71212463279763afcc33303d": {},
                   "sha256:e97859c02b9792799880b9f2616a3b2a9c1cd31690c8343fe957422a7f186d23": {},
                   "sha256:e9a0c5e3436198eb9b6e1d18650717f8c2ec8dbd30d3b3076706eafe562feb1c": {},
@@ -736,9 +764,11 @@
                   "sha256:ef7150ec9a0d120a0c8bfac4cdeab054de1be2a4eaf6ffb32d5f4e2902cc2e28": {},
                   "sha256:ef9144f8c9d3f8c1a28146055370065e7b546f1163caabd08bc7d54667702982": {},
                   "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26": {},
+                  "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a": {},
                   "sha256:f0cb56a04fa3b27c1a3bb8896372077234123b36fe3461aca8ddc7b912030ce8": {},
                   "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc": {},
                   "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613": {},
+                  "sha256:f1784b0b9221581d9beac947a7a43cc9f4839ede18f38a0274461185788792a9": {},
                   "sha256:f52434c2edd4de318b4dde9eb47941de86f805d096145277eb9a2f31e1ebe315": {},
                   "sha256:f548f7cfa81c12e67c4896d15b9c65357eb66cba99508e74e5ad034ea92ed41a": {},
                   "sha256:f63ad13c6fc281b01c48fb1e516dfb9540034899aac1aacd81a569016d28940a": {},
@@ -758,6 +788,7 @@
                   "sha256:fd60066d9141529ea385fa8fc3af88d0f6ac0cb7a8515af0abe9b65498707f6f": {},
                   "sha256:fd9e5c379cd3482d32686fb13881827a39037e7a7afa92c62d58c1f05fcb797f": {},
                   "sha256:fdcc4180cae8fa83ca54188fc2f6796a1bc8d7eb7106163b98dd93d974b48cd1": {},
+                  "sha256:fe1a3e821eab7aafd11152c5d5b9f6cf57de36d8ef3b517e0e2f2315b062742c": {},
                   "sha256:fec32d37b2f34c891a64a8c5e2faf3d08de25d144289b6f2b7f5fafdd5eec4d2": {},
                   "sha256:fed07d8c0175dd6a7b9dc7547bc515c08c7e5f0aad5c96cded276be39658ef50": {}
                 }
@@ -1059,6 +1090,9 @@
           "sha256:06f6a82e268aa006507fb1f82f01893f996fd47ad1cfa5f839c7861e8fd317cf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/grub2-pc-2.02-106.el8.x86_64.rpm"
           },
+          "sha256:076bdcf066fabe9c611ceee12665d735136ecd306ec4c1e608bb1e0a4704ae55": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-prettytable-0.7.2-14.el8.noarch.rpm"
+          },
           "sha256:07ce753de89c0f6cc82ee926100777bdd0c91cb3d3ee9315cd8d93320875e66c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/jansson-2.14-1.el8.x86_64.rpm"
           },
@@ -1125,6 +1159,9 @@
           "sha256:13dbb2d6d6ae68cae6313d09c404b75ebbe55dbf2d6b9fca7ae31a61af077bfa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/ca-certificates-2021.2.50-80.0.el8_4.noarch.rpm"
           },
+          "sha256:13ffce0597b689dd53f55ea0d03dd6d013246634f5c6cbcef51fa549d9734b29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-cffi-1.11.5-5.el8.x86_64.rpm"
+          },
           "sha256:14175dab807188a8261298dc3ba7b7cd19a9fbf36d0ee5b5c6cacc7e424998e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libssh-config-0.9.6-3.el8.noarch.rpm"
           },
@@ -1142,6 +1179,9 @@
           },
           "sha256:184f1319a9216616e5cd9857b69d5d661443894557528729115bf21c3f35bb03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/gnupg2-smime-2.2.20-2.el8.x86_64.rpm"
+          },
+          "sha256:19dba7cb30c3cb598886326df0ec1114c6e195a57c9ce3a8b78b83555e9e8648": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/geolite2-city-20180605-1.el8.noarch.rpm"
           },
           "sha256:1b1dc181584833cdd7520bb26a4e03dcffb35985a9d1254b36f824401a970fe9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/NetworkManager-1.36.0-0.4.el8.x86_64.rpm"
@@ -1200,6 +1240,9 @@
           "sha256:1ff27852aeaf1f6a13adeba0167e03c72af294c3f8ca267f05832f66c569e257": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libtevent-0.11.0-0.el8.x86_64.rpm"
           },
+          "sha256:206de21c82d76de550bcc1959138472640b0a950a311b753203f5dfe5b201b7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/ipcalc-0.2.4-4.el8.x86_64.rpm"
+          },
           "sha256:20ad0a3db2a075842747682638513899bb7d455c81cbee108d13cd64e173f260": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/subscription-manager-1.28.25-1.el8.x86_64.rpm"
           },
@@ -1256,6 +1299,9 @@
           },
           "sha256:29d6e6786af661a3e01ce9fbe290b59e86c4902b40a0f29b3b58f6a076841fd3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/systemd-libs-239-56.el8.x86_64.rpm"
+          },
+          "sha256:29ea55621defd44df6d0de87cb3a9727ac25fdf3179b63670e54cc7faa2996ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-audit-3.0.7-1.el8.x86_64.rpm"
           },
           "sha256:2ae7eca09c469bbf5c362daa544ccb453f22d7267a85e7aec006a83cce163aa8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/pcre2-10.32-2.el8.x86_64.rpm"
@@ -1314,6 +1360,9 @@
           "sha256:3423075b5f924b1512e91fb5c8532ef2768cd2b1b9591e4a2ac3b76d99aa380d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/cracklib-dicts-2.9.6-15.el8.x86_64.rpm"
           },
+          "sha256:3446bbd5d26c3a1b8cd64c077ae4bbeea8ef2ef349c590297bbe2a53e18ce9e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-oauthlib-2.1.0-1.el8.noarch.rpm"
+          },
           "sha256:352af964ab839022310eaf2a4d1ed3d7824eaa1ff948088d4414768ee649f786": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-chardet-3.0.4-7.el8.noarch.rpm"
           },
@@ -1361,6 +1410,12 @@
           },
           "sha256:3e8e2a991ffed874a3f454d23eb3082744db8459257bfcf47f542f9edcf1ecb4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/iwl1000-firmware-39.31.5.1-105.el8.1.noarch.rpm"
+          },
+          "sha256:3e9dff1e55f3d4121bb4d85839f0e26a05bb95ed652abbe15535167528226414": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-pyserial-3.1.1-8.el8.noarch.rpm"
+          },
+          "sha256:3edf7d29e530e6568416d4455e9fbaa511aba236c603da9928e689fae77b9874": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-netifaces-0.10.6-4.el8.x86_64.rpm"
           },
           "sha256:400c6d6d91fdffb0296ae46d155719787bc5f39f1f18c0391019bdef998fa8a4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/systemd-udev-239-56.el8.x86_64.rpm"
@@ -1433,6 +1488,9 @@
           },
           "sha256:49b6b2a486bd32714619e81782623f126486452bbd2295a2ab1f3e997b97d327": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/crontabs-1.11-17.20190603git.el8.noarch.rpm"
+          },
+          "sha256:49c191045e168a303ba2bc655b5ecccf7fe19851db3d0563f52c50164a2ed8ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dhcp-client-4.3.6-47.el8.x86_64.rpm"
           },
           "sha256:49ea248bc51c089015b2169887bedb5faf3f97f97479077929baf3272ad18d54": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-inotify-0.9.6-13.el8.noarch.rpm"
@@ -1548,8 +1606,14 @@
           "sha256:58cf5aa3c5b3f7bed1433b33818fb6327ec4d6cebe3772c99249e19bb14a8c03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-mako-1.0.6-13.el8.noarch.rpm"
           },
+          "sha256:58d5f26daf746cf161e1be4fb6cda4e320ef2a624f0ab7913ee498b26aad8659": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-cryptography-3.2.1-5.el8.x86_64.rpm"
+          },
           "sha256:58fc7019292d991d418fa623cfec793be36e5a0791b2888df221265826822af4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-cloud-what-1.28.25-1.el8.x86_64.rpm"
+          },
+          "sha256:59bf7b92f9eecb7868e960dc05c269a9df088d2dc71ce85cf77bfad68e206f0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-jsonschema-2.6.0-4.el8.noarch.rpm"
           },
           "sha256:59e60702ca65224a082d2b40a55572680acb639d65dffc0cbb05fc08f50e05eb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libdrm-2.4.108-1.el8.x86_64.rpm"
@@ -1559,6 +1623,9 @@
           },
           "sha256:5af8d36d62fb7633297da810e5ca7de0137ce72b98494028fd9672b66b6ed3fa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-libs-3.6.8-45.el8.x86_64.rpm"
+          },
+          "sha256:5b1bc2ca63d563828a3a0968d42fb75ae0917366d06df8176d917f7c477f33b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-libsemanage-2.9-6.el8.x86_64.rpm"
           },
           "sha256:5bb5323b336e4526befc55de0db40355cb338f69f62d260017a22e8174e1ba75": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/subscription-manager-rhsm-certificates-1.28.25-1.el8.x86_64.rpm"
@@ -1571,6 +1638,9 @@
           },
           "sha256:5d527a7fe40c223f9e8448cdb657daba3582d4ab296400c65294a4f1f921892b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libselinux-2.9-5.el8.x86_64.rpm"
+          },
+          "sha256:5d9c5b3341e9b10091a5bc66c08455ce7d9c62911fac6b759b847a46749a1adf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-jsonpointer-1.10-11.el8.noarch.rpm"
           },
           "sha256:5ee54ba9a16859ab501b65e05773c6160ed32b7af77a07ba455a32acd588310f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/iwl2030-firmware-18.168.6.1-105.el8.1.noarch.rpm"
@@ -1647,6 +1717,9 @@
           "sha256:6ff975465dcff2d8b7f6f1efb8c865aff9baed1500e8f48e4a569700fb1208ea": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/p11-kit-trust-0.23.22-1.el8.x86_64.rpm"
           },
+          "sha256:70d76d9f1ed43efa346f634d5237c8a533b7e6209c36a9c6f0754afd1ddfc539": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dhcp-common-4.3.6-47.el8.noarch.rpm"
+          },
           "sha256:70e42cbbd3b21cf9e670a3aaadf55105e45ef0a4aa9d4fc021930f441a87d396": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libblockdev-2.24-8.el8.x86_64.rpm"
           },
@@ -1655,6 +1728,9 @@
           },
           "sha256:72384e5b49843827a64dd83881e381be7a7df4e4bb95a6ebd075dd37b74b380b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/iptables-ebtables-1.8.4-22.el8.x86_64.rpm"
+          },
+          "sha256:723963983258ad5c85fc708c519361f4668db7703f8dbfeae6901c1459bd1010": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bind-export-libs-9.11.36-2.el8.x86_64.rpm"
           },
           "sha256:72ae60bdc56f07b2131d19c75dce9100a48e46ae08ef4ae77dcffdaadbd57519": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libuser-0.62-24.el8.x86_64.rpm"
@@ -1791,6 +1867,12 @@
           "sha256:8b04c8eb33a3af6b22e143b11fc887db47ff188eac5f0a1d80fb99f8a9bf3d44": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libstdc++-8.5.0-10.el8.x86_64.rpm"
           },
+          "sha256:8c3deaabbd79922ad6eae143a100e0d5b04c10a729d1ac01128d843039d3eebf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pycparser-2.14-14.el8.noarch.rpm"
+          },
+          "sha256:8c6da26441750b3970fe73b6a9d2d780931da6cdea48f10d0b34c65c79a9e341": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm"
+          },
           "sha256:8c9c059292e68dfbdec942133c22ef69fb4113166def6ad66903a1973bc9bccb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/efi-filesystem-3-3.el8.noarch.rpm"
           },
@@ -1857,6 +1939,9 @@
           "sha256:995831ad6397fbd6e91038c6889981a0b7c649c95192999dc184b98c26d48fea": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/initscripts-10.00.15-1.el8.x86_64.rpm"
           },
+          "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libmaxminddb-1.2.0-10.el8.x86_64.rpm"
+          },
           "sha256:998c3e82a6bb9e040d225d8e85b5b55316d2ca92fcbb4d2ad0e6fa9e896c5cdb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libmspack-0.7-0.3.alpha.el8.4.x86_64.rpm"
           },
@@ -1877,6 +1962,9 @@
           },
           "sha256:9b1251422cfd498da3569583dea926198827e6e5fcf2a3d3d9c5521401ad0fc9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/redhat-release-8.6-0.0.el8.x86_64.rpm"
+          },
+          "sha256:9b850e461a6cf53a2eaec959bbccd115d88bd0b1be03f58f8c6282fdefae864a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dhcp-libs-4.3.6-47.el8.x86_64.rpm"
           },
           "sha256:9bd47c00f8bf9354b06ef159a5aed91ab67c4155ce02752dfe6148314dbb11e1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/json-c-0.13.1-3.el8.x86_64.rpm"
@@ -1934,6 +2022,9 @@
           },
           "sha256:a7a6053537ea1476969ad10005915cfd6618a5d573fb3320547712abbb6e4280": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pysocks-1.6.8-3.el8.noarch.rpm"
+          },
+          "sha256:a8808c053ffb7ccf826d80fdd458b6521f2cc63e55eb90d79a504fbb66c36cb0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/checkpolicy-2.9-1.el8.x86_64.rpm"
           },
           "sha256:a90c86f0186d0743c093ed8cd8b1ea7b47a636ba25088dfa4123eb8384df7477": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/glibc-all-langpacks-2.28-184.el8.x86_64.rpm"
@@ -2049,11 +2140,17 @@
           "sha256:bb30cc2c9a183835131bf0a7783c2bff56f70777060221d6f939a2ac7ea797f9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/util-linux-2.32.1-32.el8.x86_64.rpm"
           },
+          "sha256:bba321ec811001b3fb136a768177a8a8e2b99f59d961535fd89854ccb34365d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/cloud-init-21.1-13.el8.noarch.rpm"
+          },
           "sha256:bbcb6a8162cff9a1908d4f6c2e54050ae9f37eb8dceee4d5aa814e90460aed9a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-librepo-1.14.2-1.el8.x86_64.rpm"
           },
           "sha256:bbcd5e57bdf8280e7e7f06fe35e0d45753b5e874821a74ba1c4aae4f0088ba7d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/vim-minimal-8.0.1763-16.el8_5.7.x86_64.rpm"
+          },
+          "sha256:bce8cbc50f5872bcee1bed9ff041bebfae10169f007cf97b268819e78b9d8835": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-jsonpatch-1.21-2.el8.noarch.rpm"
           },
           "sha256:bd37c05e277205686dade257e19f95839fad32f2278872dbc9969c50ec9da0b6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/librhsm-0.0.3-4.el8.x86_64.rpm"
@@ -2115,6 +2212,9 @@
           "sha256:c5fb6e950b077770f207e29bb31e408739272058892ba8bf0066a9483575d306": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/shim-x64-15.4-2.el8_1.x86_64.rpm"
           },
+          "sha256:c60aede8488f68a001f3495bd6e6d894fc3a44bb488f4550b5970ab5904d0a1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/geolite2-country-20180605-1.el8.noarch.rpm"
+          },
           "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-1.02.181-3.el8.x86_64.rpm"
           },
@@ -2144,6 +2244,9 @@
           },
           "sha256:cc60605cd4164fccd1f6b5cb07d29b55d878e1b50163be076f506eefdf46f595": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/curl-7.61.1-22.el8.x86_64.rpm"
+          },
+          "sha256:ccfdbebdf0575395a80f2fa55e49c8358ca601fdbb0685f37e8c584226264eca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-pytz-2017.2-9.el8.noarch.rpm"
           },
           "sha256:ce63708391f77873a344a2ff1ff148be88a5bac39693c9d0bb458f7b3ebd63b9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/findutils-4.6.0-20.el8.x86_64.rpm"
@@ -2220,6 +2323,9 @@
           "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm"
           },
+          "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm"
+          },
           "sha256:d759703d633257a88457c38d94b9a7836e0ec8eeb72df385df348423e668ae08": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-nftables-0.9.3-24.el8.x86_64.rpm"
           },
@@ -2250,6 +2356,9 @@
           "sha256:dd1590cec04ac5a59f21caf17aa3990aa582cc68a03c2909021a0960244cc0b7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/openssh-clients-8.0p1-13.el8.x86_64.rpm"
           },
+          "sha256:de870435340bf30620406df41b79e43adaf7d0a277db1635a0fae710df993fc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pyyaml-3.12-12.el8.x86_64.rpm"
+          },
           "sha256:df169d238e43e575b61b9eb02a392d9c2c75fe6b0bb678f8d8ca27e169347372": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libpwquality-1.4.4-3.el8.x86_64.rpm"
           },
@@ -2279,6 +2388,9 @@
           },
           "sha256:e868499743c399baa6463fa64a2534a7d32f8e1cca7b1b47ec00c60b34250bfe": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-markupsafe-0.23-19.el8.x86_64.rpm"
+          },
+          "sha256:e888454f4620debf3bdd76b59444e30ef5c2c8f81912ac6a37f525dc3eae7810": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-babel-2.5.1-7.el8.noarch.rpm"
           },
           "sha256:e920a82cda55b110690f3c946ec2cd85f969599c71212463279763afcc33303d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/unbound-libs-1.7.3-17.el8.x86_64.rpm"
@@ -2331,6 +2443,9 @@
           "sha256:efa20ae5eca5860656d0131086470cb8d5c3a1ae2819301e7d015f06bbb68a26": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/slang-2.3.2-3.el8.x86_64.rpm"
           },
+          "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-setools-4.3.0-3.el8.x86_64.rpm"
+          },
           "sha256:f0cb56a04fa3b27c1a3bb8896372077234123b36fe3461aca8ddc7b912030ce8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/kbd-legacy-2.0.4-10.el8.noarch.rpm"
           },
@@ -2339,6 +2454,9 @@
           },
           "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm"
+          },
+          "sha256:f1784b0b9221581d9beac947a7a43cc9f4839ede18f38a0274461185788792a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-ply-3.9-9.el8.noarch.rpm"
           },
           "sha256:f52434c2edd4de318b4dde9eb47941de86f805d096145277eb9a2f31e1ebe315": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/squashfs-tools-4.3-20.el8.x86_64.rpm"
@@ -2399,6 +2517,9 @@
           },
           "sha256:fdcc4180cae8fa83ca54188fc2f6796a1bc8d7eb7106163b98dd93d974b48cd1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/hostname-3.20-6.el8.x86_64.rpm"
+          },
+          "sha256:fe1a3e821eab7aafd11152c5d5b9f6cf57de36d8ef3b517e0e2f2315b062742c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-jwt-1.6.1-2.el8.noarch.rpm"
           },
           "sha256:fec32d37b2f34c891a64a8c5e2faf3d08de25d144289b6f2b7f5fafdd5eec4d2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/parted-3.2-39.el8.x86_64.rpm"
@@ -6233,6 +6354,15 @@
         "checksum": "sha256:7c20910d5e52fcdd461eac21d57899d0091822aed80c6252db688ca373883640"
       },
       {
+        "name": "bind-export-libs",
+        "epoch": 32,
+        "version": "9.11.36",
+        "release": "2.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/bind-export-libs-9.11.36-2.el8.x86_64.rpm",
+        "checksum": "sha256:723963983258ad5c85fc708c519361f4668db7703f8dbfeae6901c1459bd1010"
+      },
+      {
         "name": "biosdevname",
         "epoch": 0,
         "version": "0.7.3",
@@ -6285,6 +6415,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/ca-certificates-2021.2.50-80.0.el8_4.noarch.rpm",
         "checksum": "sha256:13dbb2d6d6ae68cae6313d09c404b75ebbe55dbf2d6b9fca7ae31a61af077bfa"
+      },
+      {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "1.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/checkpolicy-2.9-1.el8.x86_64.rpm",
+        "checksum": "sha256:a8808c053ffb7ccf826d80fdd458b6521f2cc63e55eb90d79a504fbb66c36cb0"
       },
       {
         "name": "chkconfig",
@@ -6492,6 +6631,33 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.3.6",
+        "release": "47.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dhcp-client-4.3.6-47.el8.x86_64.rpm",
+        "checksum": "sha256:49c191045e168a303ba2bc655b5ecccf7fe19851db3d0563f52c50164a2ed8ba"
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.3.6",
+        "release": "47.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dhcp-common-4.3.6-47.el8.noarch.rpm",
+        "checksum": "sha256:70d76d9f1ed43efa346f634d5237c8a533b7e6209c36a9c6f0754afd1ddfc539"
+      },
+      {
+        "name": "dhcp-libs",
+        "epoch": 12,
+        "version": "4.3.6",
+        "release": "47.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/dhcp-libs-4.3.6-47.el8.x86_64.rpm",
+        "checksum": "sha256:9b850e461a6cf53a2eaec959bbccd115d88bd0b1be03f58f8c6282fdefae864a"
       },
       {
         "name": "diffutils",
@@ -7095,6 +7261,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/initscripts-10.00.15-1.el8.x86_64.rpm",
         "checksum": "sha256:995831ad6397fbd6e91038c6889981a0b7c649c95192999dc184b98c26d48fea"
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "4.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/ipcalc-0.2.4-4.el8.x86_64.rpm",
+        "checksum": "sha256:206de21c82d76de550bcc1959138472640b0a950a311b753203f5dfe5b201b7b"
       },
       {
         "name": "iproute",
@@ -8870,6 +9045,24 @@
         "checksum": "sha256:f8c191d8b952621d10a1055be960bbe07be66f557c5a9d007f8908abcde1b9af"
       },
       {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0.7",
+        "release": "1.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-audit-3.0.7-1.el8.x86_64.rpm",
+        "checksum": "sha256:29ea55621defd44df6d0de87cb3a9727ac25fdf3179b63670e54cc7faa2996ee"
+      },
+      {
+        "name": "python3-cffi",
+        "epoch": 0,
+        "version": "1.11.5",
+        "release": "5.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-cffi-1.11.5-5.el8.x86_64.rpm",
+        "checksum": "sha256:13ffce0597b689dd53f55ea0d03dd6d013246634f5c6cbcef51fa549d9734b29"
+      },
+      {
         "name": "python3-chardet",
         "epoch": 0,
         "version": "3.0.4",
@@ -8895,6 +9088,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-configobj-5.0.6-11.el8.noarch.rpm",
         "checksum": "sha256:3a9aede6732c73278d74c413ad9559c1ccf0c0bbdfd1b61734cf984e75d20367"
+      },
+      {
+        "name": "python3-cryptography",
+        "epoch": 0,
+        "version": "3.2.1",
+        "release": "5.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-cryptography-3.2.1-5.el8.x86_64.rpm",
+        "checksum": "sha256:58d5f26daf746cf161e1be4fb6cda4e320ef2a624f0ab7913ee498b26aad8659"
       },
       {
         "name": "python3-dateutil",
@@ -9023,6 +9225,15 @@
         "checksum": "sha256:49ea248bc51c089015b2169887bedb5faf3f97f97479077929baf3272ad18d54"
       },
       {
+        "name": "python3-jwt",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-jwt-1.6.1-2.el8.noarch.rpm",
+        "checksum": "sha256:fe1a3e821eab7aafd11152c5d5b9f6cf57de36d8ef3b517e0e2f2315b062742c"
+      },
+      {
         "name": "python3-libcomps",
         "epoch": 0,
         "version": "0.1.18",
@@ -9068,6 +9279,15 @@
         "checksum": "sha256:45740507b141cacf5bf5360a9e5823266f878a3c7ce8e212e3d0e7692d8dfc22"
       },
       {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-libsemanage-2.9-6.el8.x86_64.rpm",
+        "checksum": "sha256:5b1bc2ca63d563828a3a0968d42fb75ae0917366d06df8176d917f7c477f33b4"
+      },
+      {
         "name": "python3-libxml2",
         "epoch": 0,
         "version": "2.9.7",
@@ -9095,6 +9315,15 @@
         "checksum": "sha256:d759703d633257a88457c38d94b9a7836e0ec8eeb72df385df348423e668ae08"
       },
       {
+        "name": "python3-oauthlib",
+        "epoch": 0,
+        "version": "2.1.0",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-oauthlib-2.1.0-1.el8.noarch.rpm",
+        "checksum": "sha256:3446bbd5d26c3a1b8cd64c077ae4bbeea8ef2ef349c590297bbe2a53e18ce9e6"
+      },
+      {
         "name": "python3-perf",
         "epoch": 0,
         "version": "4.18.0",
@@ -9111,6 +9340,33 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pip-wheel-9.0.3-22.el8.noarch.rpm",
         "checksum": "sha256:df85e1d96bfe211f3cfb0ac2e1bcb87c7c37ff075032efac64598e43bc128b8e"
+      },
+      {
+        "name": "python3-ply",
+        "epoch": 0,
+        "version": "3.9",
+        "release": "9.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-ply-3.9-9.el8.noarch.rpm",
+        "checksum": "sha256:f1784b0b9221581d9beac947a7a43cc9f4839ede18f38a0274461185788792a9"
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "2.9",
+        "release": "18.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-policycoreutils-2.9-18.el8.noarch.rpm",
+        "checksum": "sha256:d743c71dea25a9046b727816114bb2c781f47bedff367ca82de54a4d7dd0cf87"
+      },
+      {
+        "name": "python3-pycparser",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pycparser-2.14-14.el8.noarch.rpm",
+        "checksum": "sha256:8c3deaabbd79922ad6eae143a100e0d5b04c10a729d1ac01128d843039d3eebf"
       },
       {
         "name": "python3-pysocks",
@@ -9131,6 +9387,15 @@
         "checksum": "sha256:4ad66a3a1dd79384852669609567108dcc429607d40ca8adc5f1dbe6a9d6bdde"
       },
       {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "3.12",
+        "release": "12.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-pyyaml-3.12-12.el8.x86_64.rpm",
+        "checksum": "sha256:de870435340bf30620406df41b79e43adaf7d0a277db1635a0fae710df993fc0"
+      },
+      {
         "name": "python3-requests",
         "epoch": 0,
         "version": "2.20.0",
@@ -9147,6 +9412,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-rpm-4.14.3-21.el8.x86_64.rpm",
         "checksum": "sha256:ac32f4279d00cc5ca5024ec826daccb70836f4c64547f3983853873aca6fb6ec"
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.3.0",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/python3-setools-4.3.0-3.el8.x86_64.rpm",
+        "checksum": "sha256:f03096a6301a6b055af4893b3e436cdf5725698fc4b4589cd2cc3859b083802a"
       },
       {
         "name": "python3-setuptools-wheel",
@@ -9671,6 +9945,33 @@
         "checksum": "sha256:43a4f1c39b2a8b212d50af73d0d510adfdc4ac61be8ecdc6bd718f6cab0e5afc"
       },
       {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "21.1",
+        "release": "13.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/cloud-init-21.1-13.el8.noarch.rpm",
+        "checksum": "sha256:bba321ec811001b3fb136a768177a8a8e2b99f59d961535fd89854ccb34365d4"
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20180605",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/geolite2-city-20180605-1.el8.noarch.rpm",
+        "checksum": "sha256:19dba7cb30c3cb598886326df0ec1114c6e195a57c9ce3a8b78b83555e9e8648"
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20180605",
+        "release": "1.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/geolite2-country-20180605-1.el8.noarch.rpm",
+        "checksum": "sha256:c60aede8488f68a001f3495bd6e6d894fc3a44bb488f4550b5970ab5904d0a1e"
+      },
+      {
         "name": "glibc-gconv-extra",
         "epoch": 0,
         "version": "2.28",
@@ -9806,6 +10107,15 @@
         "checksum": "sha256:b3056b22b99fdf7a10647ab30a5c2af408216cf33c3be56653f51b85ca90cb86"
       },
       {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "10.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/libmaxminddb-1.2.0-10.el8.x86_64.rpm",
+        "checksum": "sha256:995a5401cd86404d14d08c0aeafeaa8da3f540b1806f9d0e233d75dec9e45c74"
+      },
+      {
         "name": "libmspack",
         "epoch": 0,
         "version": "0.7",
@@ -9932,6 +10242,96 @@
         "checksum": "sha256:72f73e19d728816d4890cc6b6d4f39af8882b185ccdbd392972c702e90c7e077"
       },
       {
+        "name": "python3-babel",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "7.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-babel-2.5.1-7.el8.noarch.rpm",
+        "checksum": "sha256:e888454f4620debf3bdd76b59444e30ef5c2c8f81912ac6a37f525dc3eae7810"
+      },
+      {
+        "name": "python3-jinja2",
+        "epoch": 0,
+        "version": "2.10.1",
+        "release": "3.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-jinja2-2.10.1-3.el8.noarch.rpm",
+        "checksum": "sha256:8c6da26441750b3970fe73b6a9d2d780931da6cdea48f10d0b34c65c79a9e341"
+      },
+      {
+        "name": "python3-jsonpatch",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "2.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-jsonpatch-1.21-2.el8.noarch.rpm",
+        "checksum": "sha256:bce8cbc50f5872bcee1bed9ff041bebfae10169f007cf97b268819e78b9d8835"
+      },
+      {
+        "name": "python3-jsonpointer",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "11.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-jsonpointer-1.10-11.el8.noarch.rpm",
+        "checksum": "sha256:5d9c5b3341e9b10091a5bc66c08455ce7d9c62911fac6b759b847a46749a1adf"
+      },
+      {
+        "name": "python3-jsonschema",
+        "epoch": 0,
+        "version": "2.6.0",
+        "release": "4.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-jsonschema-2.6.0-4.el8.noarch.rpm",
+        "checksum": "sha256:59bf7b92f9eecb7868e960dc05c269a9df088d2dc71ce85cf77bfad68e206f0b"
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "0.23",
+        "release": "19.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-markupsafe-0.23-19.el8.x86_64.rpm",
+        "checksum": "sha256:e868499743c399baa6463fa64a2534a7d32f8e1cca7b1b47ec00c60b34250bfe"
+      },
+      {
+        "name": "python3-netifaces",
+        "epoch": 0,
+        "version": "0.10.6",
+        "release": "4.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-netifaces-0.10.6-4.el8.x86_64.rpm",
+        "checksum": "sha256:3edf7d29e530e6568416d4455e9fbaa511aba236c603da9928e689fae77b9874"
+      },
+      {
+        "name": "python3-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "14.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-prettytable-0.7.2-14.el8.noarch.rpm",
+        "checksum": "sha256:076bdcf066fabe9c611ceee12665d735136ecd306ec4c1e608bb1e0a4704ae55"
+      },
+      {
+        "name": "python3-pyserial",
+        "epoch": 0,
+        "version": "3.1.1",
+        "release": "8.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-pyserial-3.1.1-8.el8.noarch.rpm",
+        "checksum": "sha256:3e9dff1e55f3d4121bb4d85839f0e26a05bb95ed652abbe15535167528226414"
+      },
+      {
+        "name": "python3-pytz",
+        "epoch": 0,
+        "version": "2017.2",
+        "release": "9.el8",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/python3-pytz-2017.2-9.el8.noarch.rpm",
+        "checksum": "sha256:ccfdbebdf0575395a80f2fa55e49c8358ca601fdbb0685f37e8c584226264eca"
+      },
+      {
         "name": "python3-unbound",
         "epoch": 0,
         "version": "1.7.3",
@@ -10042,6 +10442,114 @@
         "2.rhel.pool.ntp.org iburst"
       ]
     },
+    "cloud-init": {
+      "/etc/cloud": {
+        "cloud.cfg": {
+          "cloud_config_modules": [
+            "mounts",
+            "locale",
+            "set-passwords",
+            "rh_subscription",
+            "yum-add-repo",
+            "package-update-upgrade-install",
+            "timezone",
+            "puppet",
+            "chef",
+            "salt-minion",
+            "mcollective",
+            "disable-ec2-metadata",
+            "runcmd"
+          ],
+          "cloud_final_modules": [
+            "rightscale_userdata",
+            "scripts-per-once",
+            "scripts-per-boot",
+            "scripts-per-instance",
+            "scripts-user",
+            "ssh-authkey-fingerprints",
+            "keys-to-console",
+            "phone-home",
+            "final-message",
+            "power-state-change"
+          ],
+          "cloud_init_modules": [
+            "disk_setup",
+            "migrator",
+            "bootcmd",
+            "write-files",
+            "growpart",
+            "resizefs",
+            "set_hostname",
+            "update_hostname",
+            "update_etc_hosts",
+            "rsyslog",
+            "users-groups",
+            "ssh"
+          ],
+          "disable_root": 1,
+          "disable_vmware_customization": false,
+          "mount_default_fields": [
+            null,
+            null,
+            "auto",
+            "defaults,nofail,x-systemd.requires=cloud-init.service",
+            "0",
+            "2"
+          ],
+          "resize_rootfs_tmp": "/dev",
+          "ssh_deletekeys": 1,
+          "ssh_genkeytypes": [
+            "rsa",
+            "ecdsa",
+            "ed25519"
+          ],
+          "ssh_pwauth": 0,
+          "syslog_fix_perms": null,
+          "system_info": {
+            "default_user": {
+              "gecos": "Cloud User",
+              "groups": [
+                "adm",
+                "systemd-journal"
+              ],
+              "lock_passwd": true,
+              "name": "cloud-user",
+              "shell": "/bin/bash",
+              "sudo": [
+                "ALL=(ALL) NOPASSWD:ALL"
+              ]
+            },
+            "distro": "rhel",
+            "paths": {
+              "cloud_dir": "/var/lib/cloud",
+              "templates_dir": "/etc/cloud/templates"
+            },
+            "ssh_svcname": "sshd"
+          },
+          "users": [
+            "default"
+          ]
+        }
+      },
+      "/etc/cloud/cloud.cfg.d": {
+        "05_logging.cfg": {
+          "_log": [
+            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
+            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
+          ],
+          "log_cfgs": [
+            [
+              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
+            ]
+          ],
+          "output": {
+            "all": "| tee -a /var/log/cloud-init-output.log"
+          }
+        }
+      }
+    },
     "default-target": "graphical.target",
     "dnf": {
       "dnf.conf": {
@@ -10129,11 +10637,11 @@
       "man:x:15:",
       "mem:x:8:",
       "nobody:x:65534:",
-      "polkitd:x:996:",
+      "polkitd:x:994:",
       "redhat:x:1000:",
       "render:x:998:",
       "root:x:0:",
-      "ssh_keys:x:995:",
+      "ssh_keys:x:996:",
       "sshd:x:74:",
       "sssd:x:993:",
       "sys:x:3:",
@@ -10143,7 +10651,7 @@
       "tape:x:33:",
       "tss:x:59:",
       "tty:x:5:",
-      "unbound:x:994:",
+      "unbound:x:995:",
       "users:x:100:",
       "utempter:x:35:",
       "utmp:x:22:",
@@ -10200,14 +10708,17 @@
       "authselect-libs-1.2.2-3.el8.x86_64",
       "basesystem-11-5.el8.noarch",
       "bash-4.4.20-3.el8.x86_64",
+      "bind-export-libs-9.11.36-2.el8.x86_64",
       "biosdevname-0.7.3-2.el8.x86_64",
       "brotli-1.0.6-3.el8.x86_64",
       "bubblewrap-0.4.0-1.el8.x86_64",
       "bzip2-libs-1.0.6-26.el8.x86_64",
       "c-ares-1.13.0-6.el8.x86_64",
       "ca-certificates-2021.2.50-80.0.el8_4.noarch",
+      "checkpolicy-2.9-1.el8.x86_64",
       "chkconfig-1.19.1-1.el8.x86_64",
       "chrony-4.1-1.el8.x86_64",
+      "cloud-init-21.1-13.el8.noarch",
       "coreutils-8.30-12.el8.x86_64",
       "coreutils-common-8.30-12.el8.x86_64",
       "cpio-2.12-11.el8.x86_64",
@@ -10229,6 +10740,9 @@
       "dbus-tools-1.12.8-18.el8.x86_64",
       "device-mapper-1.02.181-3.el8.x86_64",
       "device-mapper-libs-1.02.181-3.el8.x86_64",
+      "dhcp-client-4.3.6-47.el8.x86_64",
+      "dhcp-common-4.3.6-47.el8.noarch",
+      "dhcp-libs-4.3.6-47.el8.x86_64",
       "diffutils-3.6-6.el8.x86_64",
       "dmidecode-3.3-1.el8.x86_64",
       "dnf-4.7.0-5.el8.noarch",
@@ -10266,6 +10780,8 @@
       "gdbm-1.18-1.el8.x86_64",
       "gdbm-libs-1.18-1.el8.x86_64",
       "gdisk-1.0.3-8.el8.x86_64",
+      "geolite2-city-20180605-1.el8.noarch",
+      "geolite2-country-20180605-1.el8.noarch",
       "gettext-0.19.8.1-17.el8.x86_64",
       "gettext-libs-0.19.8.1-17.el8.x86_64",
       "glib2-2.56.4-158.el8.x86_64",
@@ -10300,6 +10816,7 @@
       "ima-evm-utils-1.3.2-12.el8.x86_64",
       "info-6.5-7.el8_5.x86_64",
       "initscripts-10.00.15-1.el8.x86_64",
+      "ipcalc-0.2.4-4.el8.x86_64",
       "iproute-5.15.0-2.el8.x86_64",
       "iprutils-2.4.19-1.el8.x86_64",
       "ipset-7.1-1.el8.x86_64",
@@ -10391,6 +10908,7 @@
       "libkcapi-hmaccalc-1.2.0-2.el8.x86_64",
       "libksba-1.3.5-7.el8.x86_64",
       "libldb-2.4.1-1.el8.x86_64",
+      "libmaxminddb-1.2.0-10.el8.x86_64",
       "libmnl-1.0.4-6.el8.x86_64",
       "libmodulemd-2.13.0-1.el8.x86_64",
       "libmount-2.32.1-32.el8.x86_64",
@@ -10525,9 +11043,13 @@
       "protobuf-c-1.3.0-6.el8.x86_64",
       "psmisc-23.1-5.el8.x86_64",
       "publicsuffix-list-dafsa-20180723-1.el8.noarch",
+      "python3-audit-3.0.7-1.el8.x86_64",
+      "python3-babel-2.5.1-7.el8.noarch",
+      "python3-cffi-1.11.5-5.el8.x86_64",
       "python3-chardet-3.0.4-7.el8.noarch",
       "python3-cloud-what-1.28.25-1.el8.x86_64",
       "python3-configobj-5.0.6-11.el8.noarch",
+      "python3-cryptography-3.2.1-5.el8.x86_64",
       "python3-dateutil-2.6.1-6.el8.noarch",
       "python3-dbus-1.2.4-15.el8.x86_64",
       "python3-decorator-4.2.1-2.el8.noarch",
@@ -10542,20 +11064,37 @@
       "python3-idna-2.5-5.el8.noarch",
       "python3-iniparse-0.4-31.el8.noarch",
       "python3-inotify-0.9.6-13.el8.noarch",
+      "python3-jinja2-2.10.1-3.el8.noarch",
+      "python3-jsonpatch-1.21-2.el8.noarch",
+      "python3-jsonpointer-1.10-11.el8.noarch",
+      "python3-jsonschema-2.6.0-4.el8.noarch",
+      "python3-jwt-1.6.1-2.el8.noarch",
       "python3-libcomps-0.1.18-1.el8.x86_64",
       "python3-libdnf-0.63.0-5.el8.x86_64",
       "python3-librepo-1.14.2-1.el8.x86_64",
       "python3-libs-3.6.8-45.el8.x86_64",
       "python3-libselinux-2.9-5.el8.x86_64",
+      "python3-libsemanage-2.9-6.el8.x86_64",
       "python3-libxml2-2.9.7-9.el8_4.2.x86_64",
       "python3-linux-procfs-0.7.0-1.el8.noarch",
+      "python3-markupsafe-0.23-19.el8.x86_64",
+      "python3-netifaces-0.10.6-4.el8.x86_64",
       "python3-nftables-0.9.3-24.el8.x86_64",
+      "python3-oauthlib-2.1.0-1.el8.noarch",
       "python3-perf-4.18.0-361.el8.x86_64",
       "python3-pip-wheel-9.0.3-22.el8.noarch",
+      "python3-ply-3.9-9.el8.noarch",
+      "python3-policycoreutils-2.9-18.el8.noarch",
+      "python3-prettytable-0.7.2-14.el8.noarch",
+      "python3-pycparser-2.14-14.el8.noarch",
+      "python3-pyserial-3.1.1-8.el8.noarch",
       "python3-pysocks-1.6.8-3.el8.noarch",
+      "python3-pytz-2017.2-9.el8.noarch",
       "python3-pyudev-0.21.0-7.el8.noarch",
+      "python3-pyyaml-3.12-12.el8.x86_64",
       "python3-requests-2.20.0-2.1.el8_1.noarch",
       "python3-rpm-4.14.3-21.el8.x86_64",
+      "python3-setools-4.3.0-3.el8.x86_64",
       "python3-setuptools-wheel-39.2.0-6.el8.noarch",
       "python3-six-1.11.0-8.el8.noarch",
       "python3-slip-0.6.4-11.el8.noarch",
@@ -10671,7 +11210,7 @@
       "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
       "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
       "operator:x:11:0:operator:/root:/sbin/nologin",
-      "polkitd:x:998:996:User for polkitd:/:/sbin/nologin",
+      "polkitd:x:997:994:User for polkitd:/:/sbin/nologin",
       "redhat:x:1000:1000::/home/redhat:/bin/bash",
       "root:x:0:0:root:/root:/bin/bash",
       "shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown",
@@ -10681,7 +11220,7 @@
       "systemd-coredump:x:999:997:systemd Core Dumper:/:/sbin/nologin",
       "systemd-resolve:x:193:193:systemd Resolver:/:/sbin/nologin",
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
-      "unbound:x:997:994:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
+      "unbound:x:998:995:Unbound DNS resolver:/etc/unbound:/sbin/nologin"
     ],
     "rhsm": {
       "dnf-plugins": {
@@ -10811,6 +11350,10 @@
       "auditd.service",
       "autovt@.service",
       "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
       "crond.service",
       "ctrl-alt-del.target",
       "dbus-org.fedoraproject.FirewallD1.service",
@@ -10954,6 +11497,9 @@
     "timezone": "New_York",
     "tmpfiles.d": {
       "/usr/lib/tmpfiles.d": {
+        "cloud-init.conf": [
+          "d /run/cloud-init 0700 root root - -"
+        ],
         "cryptsetup.conf": [
           "d /run/cryptsetup 0700 root root -"
         ],

--- a/test/data/manifests/rhel_90-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-vmdk-boot.json
@@ -318,6 +318,7 @@
                   "sha256:004e7c0e5cb9e300f39884c24dfdb7ddb686c84a2350691b24fa07b05102e325": {},
                   "sha256:01939e7ae8b55ea022e463a1a19b395fea414ab1756400481c7393288acc2487": {},
                   "sha256:01bf315b3bc44c28515c4d33d49173b23d7979d2a09b7b15f749d434b60851e6": {},
+                  "sha256:01de25f463fc6423b7770ba03bdc8370f14e7651ac34a313ccddadd6096036a3": {},
                   "sha256:01ee08215db321154bdf46600fc37b2d44b77831728b1db7d114a784494f1f18": {},
                   "sha256:038fa32c8fbbc1278525a7e91c9645597f09bca2ab83ffd4aeff58bbfc396036": {},
                   "sha256:04b2a2c24b1cf2425cc21b47f0a2d5ef347e9aee43cce9d1cbd7de0c2c9a58d3": {},
@@ -340,6 +341,7 @@
                   "sha256:0f97ae871b19c01313979bfc246d1d9aa6cc6bd9a8d3c9f496e6427a3ff50796": {},
                   "sha256:10c85fd026aff5d64b65705350e0fd7b8be02fc17544b13151dd24690f61c19f": {},
                   "sha256:11294092640d1f35e541eedb8b4444b7901ada15de61612658041b0cc9635c34": {},
+                  "sha256:125a80014cd57e96b0f14c80a87a676852f664a67325a5e721b0292f8363bafd": {},
                   "sha256:1289b71edf0faa3874c651c1b8ffc760017c6749748bbd6037e6aefbf6029cd8": {},
                   "sha256:144f40b60300da8dabf918a94fe915e10fbb7a87123968a5dfc10873a9014a03": {},
                   "sha256:147e281881105acfb8aa184a1d59faff4e3c1249205a86abb900b8d7a02cacbe": {},
@@ -348,7 +350,9 @@
                   "sha256:1666616736888ea84007eea30f6a3cacf7d7a0be2286388d2aa0e2c04d4e9d95": {},
                   "sha256:17127ca6f27ec841e7b0cd6520bb0ae3d0e523b03ca8709d808b045b44992c34": {},
                   "sha256:1749334511ad1fdf2699bb0b231eebc9af72722d90786463d0eedff460a8a660": {},
+                  "sha256:185c9b26e524ad1e026cb223f05b6eaf9fd5769ced16ff9897080aa8735ffe64": {},
                   "sha256:190d8e4a72a7e1ee9d492429c2627d06668244d9a95b8b88fdbf6c9f0bb78efc": {},
+                  "sha256:1a17cbe0a1a6667c8bb1e1bb954e5b5ed03879164325f0aa585de85816b5da3f": {},
                   "sha256:1a91c11ac1b40db298284bdc320a07f66e5e3db1cb22818c28f72d5227411f2a": {},
                   "sha256:1aa1d059f7696ae397f8746d8d4fe5ead73bac461f53cce01b92db73fbd2fa81": {},
                   "sha256:1aa1d61e6d7cbe15828b381be2057c68dd4dec5fc98db0c6e9afad36e63e8b90": {},
@@ -356,6 +360,7 @@
                   "sha256:1d1f3a871a9a690760fb3554d6d4f7939681debb21f60c0711955b822b4f5203": {},
                   "sha256:1d378937b7e206fae8fdfb691b9ab6d93870d50f4f678ee332e7be462d2ead8f": {},
                   "sha256:1d78714f790bbd6ba9ce602a40c27d94bcbdbf1a238d3f4f15de4a0503257640": {},
+                  "sha256:1ec50183819655e0eaadec0295e0c153581aa194b4f063480830b377cb0bed5e": {},
                   "sha256:1eccf723e9479d332fb0c2ca94e895822191fe308facac257ffb1ed6f61eb471": {},
                   "sha256:20a46ac392014c17b6c2192a87d419189a2632830554d436f2895d15269c6f98": {},
                   "sha256:210ce4b006e8d129524123cc2379c01c529e185767f54cc5a6f9dafb21cd9c24": {},
@@ -421,6 +426,8 @@
                   "sha256:44d73e10c58816ff1a215c6b5cefa4a24237892ec4bcd47e2d7d5bb84fa16619": {},
                   "sha256:45cb0635b63c6adb54e252c0fb42eb6312d96c057e7eb770651539a787917b02": {},
                   "sha256:46c603ad7ad3e2d7ae44a150349542f3e78f56488cfc0d4ae96dc763b156ea94": {},
+                  "sha256:476b59e484e2c1654d26693a74eef5c2e9655089347c9d12609b1474863baff9": {},
+                  "sha256:4846ecf18d3670ad6fbdcc1c29d6cdd37faa4ae20786c64d080307daae1a6f97": {},
                   "sha256:48efd7c1c0061eea12b162a9645519ab70bd31a6bf5ef9135396f77aa34c4707": {},
                   "sha256:4900de5fe7cf57df87d84d84a35e2031bb0668494c12da6d26c617f0d23f060d": {},
                   "sha256:49f08de6d6a15b7fc18f3fcd2784fcbc3525f89db1f9c490af67c5a002af669d": {},
@@ -428,8 +435,10 @@
                   "sha256:4bda8ee8a7962ae327930f1a6a76030cbfd4b3d41961320bc8f73ca0d22ba37a": {},
                   "sha256:4bedb8eb364a8eaa57a69989b82f33161d50499a85b89aa056db5dad0de1bcfa": {},
                   "sha256:4d8ff13569b3b231b3fb847e9e22615c6e08215d1f2c0c78eac2e345b9efd394": {},
+                  "sha256:4da11286bb79e5b384e611328bb12ba654de4b0ad0548faf5a33572f6e9f9b8a": {},
                   "sha256:4dbae3cd048aca496d94e979b233fe7a5ee7126a476aeba828bf02dd6e316215": {},
                   "sha256:4e9aec51ee46d7265d6edd1245b5d5ab5e8336dc2a4ca17f2cace2ce8bae3761": {},
+                  "sha256:4eb20658678a66b8df80906d0a89c86a41e759c6f537860d97002d9f1ef38c44": {},
                   "sha256:4f22c5e4ae6cb0e58f5c7a4aed26edc8d9da00daa0cb62ad6a5c3c593c914e38": {},
                   "sha256:4f4bb2005d7ba107f5b8850123b9ecc31d65e5a45fcb421cbe847d37c33dea08": {},
                   "sha256:4f6741962c5b9346e5daf41795407976e8f22c42d64066c239e482556abba9cf": {},
@@ -457,7 +466,10 @@
                   "sha256:598ab332a213d929861baaec1eb4fdd110a495e6ecee182a0726b6d11f2acc76": {},
                   "sha256:5ae707b0785b6a36943aa4abc7fed6b4ffcb57adbea536effbbc981f4588ce2e": {},
                   "sha256:5b12804c6d28b5c368618f671d2e654c7587b3cc76d162b0c0b08f3b30528fee": {},
+                  "sha256:5c06d2a85bec668b8a9ba52b9d237770e37a2e4db014e7e8dc0cebaaf692af1e": {},
+                  "sha256:5cc6df7774a9bcc7db6e48f610b779db2f1848ee7af81a75fb53725f9ee58117": {},
                   "sha256:5ce0b29210f80ae4f1e44f0ca9ef44b806f1268ce3309c43a5f1fcda005c3344": {},
+                  "sha256:5cf4276217a72649895226707d4c0e3edd6ea64b66702793fab3907177c73069": {},
                   "sha256:5d5d28f8506343379b2ecd7e5d3d03032631bee662a91fd014beede70556c431": {},
                   "sha256:5eddffbe9de57d1f1a30fc0b4e8515b3f71cd7ff99c6397f024478b5cb9ab8e8": {},
                   "sha256:5f0966a795ba6ccf9cf12b9977e91000a253564469649e7e538d8511f737073e": {},
@@ -482,6 +494,7 @@
                   "sha256:6ceb9cc5fc9892922d3ef06e0228236b210b2dab104065a587b713b6b92de3e5": {},
                   "sha256:6d05af91bf2bfbf5f3bafaaaf6370d69457aa0297f336e4819735bb4e7ad071c": {},
                   "sha256:6d0fe13a3ac9edd9b33f56c25dda414c38e383660c4e4cd9b62d1d7f3f2ea3e4": {},
+                  "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa": {},
                   "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a": {},
                   "sha256:6e7ff4ef538a85596df359947fa5069052a532dd1ce8c2eeedd1557639c08ec1": {},
                   "sha256:6e8b2ac0825c8776769500438ba1dd3ec740d12f0ea363744714856fc695697a": {},
@@ -499,11 +512,14 @@
                   "sha256:746988d3ce76d009c66d2df693641b9085e5971bc1e09d6efeb03c6279b41f1a": {},
                   "sha256:7493224a1482e44507df3a479b7664a8776b9506a288b6f53a3713bf4298f1b2": {},
                   "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a": {},
+                  "sha256:76403bb0496ba71bb4c17e714469c9d6e66aad263d2b8ad3775a10d3a792dbfc": {},
                   "sha256:765687f46efaba1ec1c36178993916f4015c1ffeab0615ac336ffc2c82cf439a": {},
                   "sha256:770c850634d50d11aeb04f7ccacd960693fe9e3b9cfb91d47cda44ff7021e9e6": {},
                   "sha256:776d77fe1d2f1789b123e0ad220bed3ff9b22c84971d768405caf2fca651e9eb": {},
+                  "sha256:7948aec4859ead1f36daffb891da5f8c9f0528b17a48107f1eb0f8e682f3dc06": {},
                   "sha256:7a0b587bfdd7e9ab76560ea93e3f7fbd1c6dc0511bc6d3519f83e6431f22ffe6": {},
                   "sha256:7a3875492d4dc61cf37660bac6ba8d71759a3fbf8e17bcd0c26cb04cfb5e1b5b": {},
+                  "sha256:7a6305278faf25731f723d72b74140e408163a51b5b201f76cfbc3fff8c34331": {},
                   "sha256:7a9f8a5107e8f7a6132dce9c6a23b5a0c8c4ca41fab4e130c466b632e19f862c": {},
                   "sha256:7ad3d7984e1c37cc17819e84e8b0e731836ca5a7a56108b0d8e8378028b581b3": {},
                   "sha256:7b4d475adb465ba577d1989c21fe5715f9be277189195fe0d28fe92cbfa80731": {},
@@ -536,9 +552,11 @@
                   "sha256:8d5ddd8e1d627f7d76ef360c7c5a8c821ff53648d5c1326eaef25840287220e9": {},
                   "sha256:8d8bd0daace1317130e5e7e80a0197c096716b9e0701c2fa769daeb0d0b8bbca": {},
                   "sha256:8eabe73d0d804283743c72af63d9d233c079250c502ba7f7cfa3225984497aac": {},
+                  "sha256:8ec2dc9f04bc54f5546ca7edb5cef76e4248e58dd9b5dcc77e94cd0e98c332b1": {},
                   "sha256:8f717694adb432139bb61c081753c0de00cb36ad6110c28a7a1ca7b1aa60d671": {},
                   "sha256:903dbd59906b4f008d91e0be3ebfa0a2c01c9b5fd62100453795fa0341c0cdc4": {},
                   "sha256:90aaa842cdec4f40e944b2198dd45c027e739871073fb00b55298b6de29a8acb": {},
+                  "sha256:90c4477700695fae364b625f105e290f85c29dea86c871925042e57920a95b47": {},
                   "sha256:90d042d6b6740a3fccf19a8cb0d77943b7a7de1bb3f20beefd3c1638ebda6446": {},
                   "sha256:91bbb5424ae42b10017d8416d31e37a1ed9b337fcb32841985d6e44ca9225cb9": {},
                   "sha256:91f971774121881ee03af51e9b8e8b9e7c4afa357d8c01f8a3e6bba2e95d19ac": {},
@@ -577,6 +595,7 @@
                   "sha256:a4a40f483c498a01a52c54c6d513b6b22db5919c9f3140a7cf9e745d14058eb8": {},
                   "sha256:a50bb26a28ee7e6379c86b5b91285299b71569fa87ea968d800a56090b7a179d": {},
                   "sha256:a5760ff14cf9b01904b8c23ecb2c7002249df20d1dceb20a89eadbb8523fda26": {},
+                  "sha256:a5b96bcf046b287c9a70ceca82fa73b6cc4712ea42132da40bad800a43b43213": {},
                   "sha256:a69d00ba5c26d5840f62a59ad8d63ee7eae3a3123169877532b4130f743b0d80": {},
                   "sha256:a6fd1db30750fefdb6b2ddb91731c4e59c25ca9ee1c18530ebfe41f7158a66b4": {},
                   "sha256:a70f262697b69ef066b630f719b4cbd2e3aef74ef367042d9389504fa1bd7776": {},
@@ -612,6 +631,7 @@
                   "sha256:b9bde4162250023103d95908fbca44fff6636a46176f92cf1761c1c3a4580a2f": {},
                   "sha256:baceeefd317afdcfa43d898b9ddb2266b0c08fe16e4e69d53c976f295cc5ae90": {},
                   "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee": {},
+                  "sha256:bb55cc345886d53cebce5dee454dd9a922348551114f3380831066e053da0a98": {},
                   "sha256:bb871a469a9f26c097c92b959dec683a44b8fec6c66e7f869ecc6fc9b9ed7fdd": {},
                   "sha256:bc0f73fb262df04514d6ce8f4d970adefc7385be519e759c9d61bf7f715cc6e1": {},
                   "sha256:bd6a3956f8d84430d1e03ee2a4cf18629a3846ac4341cd49771a6f89271bdf78": {},
@@ -646,6 +666,7 @@
                   "sha256:cf756251450efcb49efd925527a3843217f9076ea8392f2f22b63bba56eba2d1": {},
                   "sha256:cf943b1956ec13cc3accbe6165578b8b216e7b53410fd89c86a129fee7e0295a": {},
                   "sha256:cf9c271c85d461922948f52a3e89b53448d924d33e94b13daf5d9324f0342dd7": {},
+                  "sha256:d075919b3ea033169ae1b24ba9d5819c912f378385da4e52d4fb724d04a29de6": {},
                   "sha256:d07d38957b3cc41160a80dc704ac0102d2e061b81e4b594a154bde0afbba0ec2": {},
                   "sha256:d27e0519a4e01e29b4559fd0fe47f50d675c4bbec5e04be305922e9876d8a9e6": {},
                   "sha256:d29ecd66022a56de162965e975fcaf0801d0b91d66c41b4f274794aae5fc2c9b": {},
@@ -669,6 +690,7 @@
                   "sha256:dfbb0c4f2c524b731e2c2ed7d352541183667ad7981fb01de6474c6be5e52951": {},
                   "sha256:dffac89417d819b7c2a65d116d45c2a2c12c9385553a48fa3336dfe92d30e9de": {},
                   "sha256:e0882a2ed0dfd34af53563bb3d578893c5ec630bb3110df4613db3d84b6f0e17": {},
+                  "sha256:e1db2b8ef517dd16ff87dfa16bc01313bc98d3c5761be28c13250de37ed88aab": {},
                   "sha256:e1f66d5f3bcbe2946ebfd1a30adaeb4ff281bf13e8ea7a72ddf4d37703385acb": {},
                   "sha256:e2015f60dbe784330d5df43f3f05c68c307694600a636a1706bf86527cc82e82": {},
                   "sha256:e2fbd5786c552a45be3ef9b4062bea3b9695622bd2971caf2c5e9928f650e2b1": {},
@@ -719,12 +741,15 @@
                   "sha256:f8405090fb3e392da790f5a58bb0a8bb535fe531105ee2133dce4ed4fa50d352": {},
                   "sha256:f84294afdeaddb4f44243b80e3b32cf65a5aff76e5b7528f4810657c90559181": {},
                   "sha256:f91b3de89d9598092e093d262e35c4d7ac0ec9b2f8d3c5ea0cbdd620c47664d6": {},
+                  "sha256:fa3abe9c3196c58b2a2943bd759eb30542962d3464970ce4171627e741160f28": {},
                   "sha256:fa79287a2dbe7ccce1ac973db8f85efcd64a8dcd9567a62aac02fa1d284a60c4": {},
                   "sha256:fb0fb2767a1c2826d6450117af42a714403ead9dad5345b02590aa8e2d5ba77f": {},
                   "sha256:fb3d2020dca3f3674da8d25c5acdac1c9eee7acbc933acc720b39e92266265a7": {},
                   "sha256:fb3f65343bbf744f8bc221083b60e7321b1453e1701a257c8bd9342fce220ba4": {},
+                  "sha256:fccd311803e002eeb0fdd8fc7d33c4a808c75d7849ee8be7c1f4dad6d0d27c70": {},
                   "sha256:ff0485d800ee30f30f9c1d9f250d88bd2a87a5f6fec9a5b1dca7d2a7553fafc8": {},
                   "sha256:ff20c1890d9d5eb5135f21acf2b55f27fddac48934285b5b0fa72b591480edbb": {},
+                  "sha256:ff756f758cc70a077b8628e4fb8166a29cce7abb62108e43f196b870f28ebce9": {},
                   "sha256:ff8d06130b2dd5e4f2715ad521d07435f68bab8b99e1a443f0b87767e9a5af77": {}
                 }
               }
@@ -1061,6 +1086,9 @@
           "sha256:01bf315b3bc44c28515c4d33d49173b23d7979d2a09b7b15f749d434b60851e6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/readline-8.1-4.el9.x86_64.rpm"
           },
+          "sha256:01de25f463fc6423b7770ba03bdc8370f14e7651ac34a313ccddadd6096036a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pyyaml-5.4.1-4.el9.x86_64.rpm"
+          },
           "sha256:01ee08215db321154bdf46600fc37b2d44b77831728b1db7d114a784494f1f18": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/gdbm-libs-1.19-4.el9.x86_64.rpm"
           },
@@ -1133,6 +1161,9 @@
           "sha256:11294092640d1f35e541eedb8b4444b7901ada15de61612658041b0cc9635c34": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/util-linux-core-2.37.2-1.el9.x86_64.rpm"
           },
+          "sha256:125a80014cd57e96b0f14c80a87a676852f664a67325a5e721b0292f8363bafd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-jinja2-2.11.3-4.el9.noarch.rpm"
+          },
           "sha256:1289b71edf0faa3874c651c1b8ffc760017c6749748bbd6037e6aefbf6029cd8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-libselinux-3.3-2.el9.x86_64.rpm"
           },
@@ -1157,8 +1188,14 @@
           "sha256:1749334511ad1fdf2699bb0b231eebc9af72722d90786463d0eedff460a8a660": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/file-libs-5.39-8.el9.x86_64.rpm"
           },
+          "sha256:185c9b26e524ad1e026cb223f05b6eaf9fd5769ced16ff9897080aa8735ffe64": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/ipcalc-1.0.0-5.el9.x86_64.rpm"
+          },
           "sha256:190d8e4a72a7e1ee9d492429c2627d06668244d9a95b8b88fdbf6c9f0bb78efc": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/cryptsetup-libs-2.4.3-1.el9.x86_64.rpm"
+          },
+          "sha256:1a17cbe0a1a6667c8bb1e1bb954e5b5ed03879164325f0aa585de85816b5da3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-pyserial-3.4-12.el9.noarch.rpm"
           },
           "sha256:1a91c11ac1b40db298284bdc320a07f66e5e3db1cb22818c28f72d5227411f2a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libudisks2-2.9.4-2.el9.x86_64.rpm"
@@ -1180,6 +1217,9 @@
           },
           "sha256:1d78714f790bbd6ba9ce602a40c27d94bcbdbf1a238d3f4f15de4a0503257640": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/selinux-policy-34.1.23-1.el9.noarch.rpm"
+          },
+          "sha256:1ec50183819655e0eaadec0295e0c153581aa194b4f063480830b377cb0bed5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-configobj-5.0.6-25.el9.noarch.rpm"
           },
           "sha256:1eccf723e9479d332fb0c2ca94e895822191fe308facac257ffb1ed6f61eb471": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/rpm-4.16.1.3-10.el9.x86_64.rpm"
@@ -1388,6 +1428,12 @@
           "sha256:46c603ad7ad3e2d7ae44a150349542f3e78f56488cfc0d4ae96dc763b156ea94": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libpath_utils-0.2.1-51.el9.x86_64.rpm"
           },
+          "sha256:476b59e484e2c1654d26693a74eef5c2e9655089347c9d12609b1474863baff9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libmaxminddb-1.5.2-3.el9.x86_64.rpm"
+          },
+          "sha256:4846ecf18d3670ad6fbdcc1c29d6cdd37faa4ae20786c64d080307daae1a6f97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-babel-2.9.1-2.el9.noarch.rpm"
+          },
           "sha256:48efd7c1c0061eea12b162a9645519ab70bd31a6bf5ef9135396f77aa34c4707": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libxslt-1.1.34-9.el9.x86_64.rpm"
           },
@@ -1409,11 +1455,17 @@
           "sha256:4d8ff13569b3b231b3fb847e9e22615c6e08215d1f2c0c78eac2e345b9efd394": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/groff-base-1.22.4-10.el9.x86_64.rpm"
           },
+          "sha256:4da11286bb79e5b384e611328bb12ba654de4b0ad0548faf5a33572f6e9f9b8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/cloud-init-21.1-16.el9.noarch.rpm"
+          },
           "sha256:4dbae3cd048aca496d94e979b233fe7a5ee7126a476aeba828bf02dd6e316215": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl7260-firmware-25.30.13.0-124.el9.noarch.rpm"
           },
           "sha256:4e9aec51ee46d7265d6edd1245b5d5ab5e8336dc2a4ca17f2cace2ce8bae3761": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/jansson-2.14-1.el9.x86_64.rpm"
+          },
+          "sha256:4eb20658678a66b8df80906d0a89c86a41e759c6f537860d97002d9f1ef38c44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-jsonpatch-1.21-16.el9.noarch.rpm"
           },
           "sha256:4f22c5e4ae6cb0e58f5c7a4aed26edc8d9da00daa0cb62ad6a5c3c593c914e38": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/filesystem-3.16-2.el9.x86_64.rpm"
@@ -1499,11 +1551,20 @@
           "sha256:5b12804c6d28b5c368618f671d2e654c7587b3cc76d162b0c0b08f3b30528fee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-setuptools-53.0.0-9.el9.noarch.rpm"
           },
+          "sha256:5c06d2a85bec668b8a9ba52b9d237770e37a2e4db014e7e8dc0cebaaf692af1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-policycoreutils-3.3-2.el9.noarch.rpm"
+          },
           "sha256:5c13de80c046533f130eb3a503e69f25d6a146b439173d7115569d10cfed8361": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/syslinux-nonlinux-6.04-0.19.el9.noarch.rpm"
           },
+          "sha256:5cc6df7774a9bcc7db6e48f610b779db2f1848ee7af81a75fb53725f9ee58117": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/geolite2-city-20191217-6.el9.noarch.rpm"
+          },
           "sha256:5ce0b29210f80ae4f1e44f0ca9ef44b806f1268ce3309c43a5f1fcda005c3344": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/pigz-2.5-4.el9.x86_64.rpm"
+          },
+          "sha256:5cf4276217a72649895226707d4c0e3edd6ea64b66702793fab3907177c73069": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-distro-1.5.0-7.el9.noarch.rpm"
           },
           "sha256:5d5d28f8506343379b2ecd7e5d3d03032631bee662a91fd014beede70556c431": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl1000-firmware-39.31.5.1-124.el9.noarch.rpm"
@@ -1580,6 +1641,9 @@
           "sha256:6d0fe13a3ac9edd9b33f56c25dda414c38e383660c4e4cd9b62d1d7f3f2ea3e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/authselect-libs-1.2.3-7.el9.x86_64.rpm"
           },
+          "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-pytz-2021.1-4.el9.noarch.rpm"
+          },
           "sha256:6dc29803a24a6c6bdc4b8254173d407bac437535c86da678b78b9f37806df76a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efibootmgr-16-12.el9.x86_64.rpm"
           },
@@ -1634,6 +1698,9 @@
           "sha256:7555233a951d6e316dd982bff58c418ee20810b26237ffd49ca8ca8744f0a52a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libatasmart-0.19-22.el9.x86_64.rpm"
           },
+          "sha256:76403bb0496ba71bb4c17e714469c9d6e66aad263d2b8ad3775a10d3a792dbfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dhcp-common-4.4.2-15.b1.el9.noarch.rpm"
+          },
           "sha256:765687f46efaba1ec1c36178993916f4015c1ffeab0615ac336ffc2c82cf439a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/kbd-misc-2.4.0-8.el9.noarch.rpm"
           },
@@ -1642,6 +1709,9 @@
           },
           "sha256:776d77fe1d2f1789b123e0ad220bed3ff9b22c84971d768405caf2fca651e9eb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/librepo-1.14.2-1.el9.x86_64.rpm"
+          },
+          "sha256:7948aec4859ead1f36daffb891da5f8c9f0528b17a48107f1eb0f8e682f3dc06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-jsonpointer-2.0-4.el9.noarch.rpm"
           },
           "sha256:7a0b587bfdd7e9ab76560ea93e3f7fbd1c6dc0511bc6d3519f83e6431f22ffe6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/lsscsi-0.32-6.el9.x86_64.rpm"
@@ -1754,6 +1824,9 @@
           "sha256:8eb6cbb3e7ae18e864db682ce5ee6039ac18e3b53eef0131cbfcc667ffa5edb9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/lorax-templates-rhel-9.0-32.el9.noarch.rpm"
           },
+          "sha256:8ec2dc9f04bc54f5546ca7edb5cef76e4248e58dd9b5dcc77e94cd0e98c332b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/checkpolicy-3.3-1.el9.x86_64.rpm"
+          },
           "sha256:8f717694adb432139bb61c081753c0de00cb36ad6110c28a7a1ca7b1aa60d671": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libgomp-11.2.1-9.1.el9.x86_64.rpm"
           },
@@ -1762,6 +1835,9 @@
           },
           "sha256:90aaa842cdec4f40e944b2198dd45c027e739871073fb00b55298b6de29a8acb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/keyutils-libs-1.6.1-4.el9.x86_64.rpm"
+          },
+          "sha256:90c4477700695fae364b625f105e290f85c29dea86c871925042e57920a95b47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-setools-4.4.0-4.el9.x86_64.rpm"
           },
           "sha256:90d042d6b6740a3fccf19a8cb0d77943b7a7de1bb3f20beefd3c1638ebda6446": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/systemd-rpm-macros-249-9.el9.noarch.rpm"
@@ -1880,6 +1956,9 @@
           "sha256:a5760ff14cf9b01904b8c23ecb2c7002249df20d1dceb20a89eadbb8523fda26": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libuuid-2.37.2-1.el9.x86_64.rpm"
           },
+          "sha256:a5b96bcf046b287c9a70ceca82fa73b6cc4712ea42132da40bad800a43b43213": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-audit-3.0.7-100.el9.x86_64.rpm"
+          },
           "sha256:a69d00ba5c26d5840f62a59ad8d63ee7eae3a3123169877532b4130f743b0d80": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-rpm-4.16.1.3-10.el9.x86_64.rpm"
           },
@@ -1997,6 +2076,9 @@
           "sha256:baeaa4efc049628c161a2f1e71ce0e0ffc7c143c2633010a7f0e84bdc0a8d7ee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/fuse-libs-2.9.9-15.el9.x86_64.rpm"
           },
+          "sha256:bb55cc345886d53cebce5dee454dd9a922348551114f3380831066e053da0a98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-prettytable-0.7.2-27.el9.noarch.rpm"
+          },
           "sha256:bb871a469a9f26c097c92b959dec683a44b8fec6c66e7f869ecc6fc9b9ed7fdd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/subscription-manager-1.29.23-1.el9.x86_64.rpm"
           },
@@ -2102,6 +2184,9 @@
           "sha256:cf9c271c85d461922948f52a3e89b53448d924d33e94b13daf5d9324f0342dd7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-gpg-1.15.1-5.el9.x86_64.rpm"
           },
+          "sha256:d075919b3ea033169ae1b24ba9d5819c912f378385da4e52d4fb724d04a29de6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/geolite2-country-20191217-6.el9.noarch.rpm"
+          },
           "sha256:d07d38957b3cc41160a80dc704ac0102d2e061b81e4b594a154bde0afbba0ec2": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dbus-libs-1.12.20-5.el9.x86_64.rpm"
           },
@@ -2173,6 +2258,9 @@
           },
           "sha256:e0882a2ed0dfd34af53563bb3d578893c5ec630bb3110df4613db3d84b6f0e17": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/grubby-8.40-54.el9.x86_64.rpm"
+          },
+          "sha256:e1db2b8ef517dd16ff87dfa16bc01313bc98d3c5761be28c13250de37ed88aab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-libsemanage-3.3-1.el9.x86_64.rpm"
           },
           "sha256:e1f66d5f3bcbe2946ebfd1a30adaeb4ff281bf13e8ea7a72ddf4d37703385acb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/openssh-8.7p1-6.el9.x86_64.rpm"
@@ -2333,6 +2421,9 @@
           "sha256:f91b3de89d9598092e093d262e35c4d7ac0ec9b2f8d3c5ea0cbdd620c47664d6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/efivar-libs-37-17.el9.x86_64.rpm"
           },
+          "sha256:fa3abe9c3196c58b2a2943bd759eb30542962d3464970ce4171627e741160f28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-oauthlib-3.1.1-2.el9.noarch.rpm"
+          },
           "sha256:fa79287a2dbe7ccce1ac973db8f85efcd64a8dcd9567a62aac02fa1d284a60c4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/zstd-1.5.0-2.el9.x86_64.rpm"
           },
@@ -2345,6 +2436,9 @@
           "sha256:fb3f65343bbf744f8bc221083b60e7321b1453e1701a257c8bd9342fce220ba4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-subscription-manager-rhsm-1.29.23-1.el9.x86_64.rpm"
           },
+          "sha256:fccd311803e002eeb0fdd8fc7d33c4a808c75d7849ee8be7c1f4dad6d0d27c70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-netifaces-0.10.6-15.el9.x86_64.rpm"
+          },
           "sha256:fe65351b850c4520e5c22ddfc15515dcab0b547119cd7d3c2e0181cda988d1e7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/xz-lzma-compat-5.2.5-7.el9.x86_64.rpm"
           },
@@ -2353,6 +2447,9 @@
           },
           "sha256:ff20c1890d9d5eb5135f21acf2b55f27fddac48934285b5b0fa72b591480edbb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libacl-2.3.1-3.el9.x86_64.rpm"
+          },
+          "sha256:ff756f758cc70a077b8628e4fb8166a29cce7abb62108e43f196b870f28ebce9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dhcp-client-4.4.2-15.b1.el9.x86_64.rpm"
           },
           "sha256:ff8d06130b2dd5e4f2715ad521d07435f68bab8b99e1a443f0b87767e9a5af77": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-librepo-1.14.2-1.el9.x86_64.rpm"
@@ -5689,6 +5786,24 @@
         "checksum": "sha256:0f97ae871b19c01313979bfc246d1d9aa6cc6bd9a8d3c9f496e6427a3ff50796"
       },
       {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "15.b1.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dhcp-client-4.4.2-15.b1.el9.x86_64.rpm",
+        "checksum": "sha256:ff756f758cc70a077b8628e4fb8166a29cce7abb62108e43f196b870f28ebce9"
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "15.b1.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dhcp-common-4.4.2-15.b1.el9.noarch.rpm",
+        "checksum": "sha256:76403bb0496ba71bb4c17e714469c9d6e66aad263d2b8ad3775a10d3a792dbfc"
+      },
+      {
         "name": "diffutils",
         "epoch": 0,
         "version": "3.7",
@@ -6236,6 +6351,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/initscripts-service-10.11.1-1.el9.noarch.rpm",
         "checksum": "sha256:27bd6aa29c515b71bbfe7639ae357782afb45748d7e10ae6bd05c1449e5eb440"
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "5.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/ipcalc-1.0.0-5.el9.x86_64.rpm",
+        "checksum": "sha256:185c9b26e524ad1e026cb223f05b6eaf9fd5769ced16ff9897080aa8735ffe64"
       },
       {
         "name": "iproute",
@@ -8119,6 +8243,15 @@
         "checksum": "sha256:3c3ada58a1436a70257fba2b11a51595382c21fa992ca7ba679821a92694914f"
       },
       {
+        "name": "python3-pyyaml",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "4.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pyyaml-5.4.1-4.el9.x86_64.rpm",
+        "checksum": "sha256:01de25f463fc6423b7770ba03bdc8370f14e7651ac34a313ccddadd6096036a3"
+      },
+      {
         "name": "python3-requests",
         "epoch": 0,
         "version": "2.25.1",
@@ -8135,6 +8268,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-rpm-4.16.1.3-10.el9.x86_64.rpm",
         "checksum": "sha256:a69d00ba5c26d5840f62a59ad8d63ee7eae3a3123169877532b4130f743b0d80"
+      },
+      {
+        "name": "python3-setools",
+        "epoch": 0,
+        "version": "4.4.0",
+        "release": "4.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-setools-4.4.0-4.el9.x86_64.rpm",
+        "checksum": "sha256:90c4477700695fae364b625f105e290f85c29dea86c871925042e57920a95b47"
       },
       {
         "name": "python3-setuptools",
@@ -8650,6 +8792,24 @@
         "checksum": "sha256:fa79287a2dbe7ccce1ac973db8f85efcd64a8dcd9567a62aac02fa1d284a60c4"
       },
       {
+        "name": "checkpolicy",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/checkpolicy-3.3-1.el9.x86_64.rpm",
+        "checksum": "sha256:8ec2dc9f04bc54f5546ca7edb5cef76e4248e58dd9b5dcc77e94cd0e98c332b1"
+      },
+      {
+        "name": "cloud-init",
+        "epoch": 0,
+        "version": "21.1",
+        "release": "16.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/cloud-init-21.1-16.el9.noarch.rpm",
+        "checksum": "sha256:4da11286bb79e5b384e611328bb12ba654de4b0ad0548faf5a33572f6e9f9b8a"
+      },
+      {
         "name": "flashrom",
         "epoch": 0,
         "version": "1.2",
@@ -8684,6 +8844,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/gdisk-1.0.7-5.el9.x86_64.rpm",
         "checksum": "sha256:eb8973df11266ce57f1db004883df3f14690c17646992c2d977f81cd6ba560f7"
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/geolite2-city-20191217-6.el9.noarch.rpm",
+        "checksum": "sha256:5cc6df7774a9bcc7db6e48f610b779db2f1848ee7af81a75fb53725f9ee58117"
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/geolite2-country-20191217-6.el9.noarch.rpm",
+        "checksum": "sha256:d075919b3ea033169ae1b24ba9d5819c912f378385da4e52d4fb724d04a29de6"
       },
       {
         "name": "langpacks-core-en",
@@ -8839,6 +9017,15 @@
         "checksum": "sha256:a891d5fb2fcfab640f66d16eb802eebf8ea9dcc5f14048937c52e3fb812032b3"
       },
       {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libmaxminddb-1.5.2-3.el9.x86_64.rpm",
+        "checksum": "sha256:476b59e484e2c1654d26693a74eef5c2e9655089347c9d12609b1474863baff9"
+      },
+      {
         "name": "libmspack",
         "epoch": 0,
         "version": "0.10.1",
@@ -8974,6 +9161,69 @@
         "checksum": "sha256:266b865a39f7a256d48151f38e5871d55d9d2f49bfa4d666e4e16430a499c201"
       },
       {
+        "name": "python3-audit",
+        "epoch": 0,
+        "version": "3.0.7",
+        "release": "100.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-audit-3.0.7-100.el9.x86_64.rpm",
+        "checksum": "sha256:a5b96bcf046b287c9a70ceca82fa73b6cc4712ea42132da40bad800a43b43213"
+      },
+      {
+        "name": "python3-babel",
+        "epoch": 0,
+        "version": "2.9.1",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-babel-2.9.1-2.el9.noarch.rpm",
+        "checksum": "sha256:4846ecf18d3670ad6fbdcc1c29d6cdd37faa4ae20786c64d080307daae1a6f97"
+      },
+      {
+        "name": "python3-configobj",
+        "epoch": 0,
+        "version": "5.0.6",
+        "release": "25.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-configobj-5.0.6-25.el9.noarch.rpm",
+        "checksum": "sha256:1ec50183819655e0eaadec0295e0c153581aa194b4f063480830b377cb0bed5e"
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-distro-1.5.0-7.el9.noarch.rpm",
+        "checksum": "sha256:5cf4276217a72649895226707d4c0e3edd6ea64b66702793fab3907177c73069"
+      },
+      {
+        "name": "python3-jinja2",
+        "epoch": 0,
+        "version": "2.11.3",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-jinja2-2.11.3-4.el9.noarch.rpm",
+        "checksum": "sha256:125a80014cd57e96b0f14c80a87a676852f664a67325a5e721b0292f8363bafd"
+      },
+      {
+        "name": "python3-jsonpatch",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "16.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-jsonpatch-1.21-16.el9.noarch.rpm",
+        "checksum": "sha256:4eb20658678a66b8df80906d0a89c86a41e759c6f537860d97002d9f1ef38c44"
+      },
+      {
+        "name": "python3-jsonpointer",
+        "epoch": 0,
+        "version": "2.0",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-jsonpointer-2.0-4.el9.noarch.rpm",
+        "checksum": "sha256:7948aec4859ead1f36daffb891da5f8c9f0528b17a48107f1eb0f8e682f3dc06"
+      },
+      {
         "name": "python3-libselinux",
         "epoch": 0,
         "version": "3.3",
@@ -8981,6 +9231,78 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-libselinux-3.3-2.el9.x86_64.rpm",
         "checksum": "sha256:1289b71edf0faa3874c651c1b8ffc760017c6749748bbd6037e6aefbf6029cd8"
+      },
+      {
+        "name": "python3-libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-libsemanage-3.3-1.el9.x86_64.rpm",
+        "checksum": "sha256:e1db2b8ef517dd16ff87dfa16bc01313bc98d3c5761be28c13250de37ed88aab"
+      },
+      {
+        "name": "python3-markupsafe",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "12.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-markupsafe-1.1.1-12.el9.x86_64.rpm",
+        "checksum": "sha256:7a6305278faf25731f723d72b74140e408163a51b5b201f76cfbc3fff8c34331"
+      },
+      {
+        "name": "python3-netifaces",
+        "epoch": 0,
+        "version": "0.10.6",
+        "release": "15.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-netifaces-0.10.6-15.el9.x86_64.rpm",
+        "checksum": "sha256:fccd311803e002eeb0fdd8fc7d33c4a808c75d7849ee8be7c1f4dad6d0d27c70"
+      },
+      {
+        "name": "python3-oauthlib",
+        "epoch": 0,
+        "version": "3.1.1",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-oauthlib-3.1.1-2.el9.noarch.rpm",
+        "checksum": "sha256:fa3abe9c3196c58b2a2943bd759eb30542962d3464970ce4171627e741160f28"
+      },
+      {
+        "name": "python3-policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-policycoreutils-3.3-2.el9.noarch.rpm",
+        "checksum": "sha256:5c06d2a85bec668b8a9ba52b9d237770e37a2e4db014e7e8dc0cebaaf692af1e"
+      },
+      {
+        "name": "python3-prettytable",
+        "epoch": 0,
+        "version": "0.7.2",
+        "release": "27.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-prettytable-0.7.2-27.el9.noarch.rpm",
+        "checksum": "sha256:bb55cc345886d53cebce5dee454dd9a922348551114f3380831066e053da0a98"
+      },
+      {
+        "name": "python3-pyserial",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "12.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-pyserial-3.4-12.el9.noarch.rpm",
+        "checksum": "sha256:1a17cbe0a1a6667c8bb1e1bb954e5b5ed03879164325f0aa585de85816b5da3f"
+      },
+      {
+        "name": "python3-pytz",
+        "epoch": 0,
+        "version": "2021.1",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-pytz-2021.1-4.el9.noarch.rpm",
+        "checksum": "sha256:6d854c991181c69bf0c08d075ecf15e404d17611bddf66e0b7c749abe543aafa"
       },
       {
         "name": "rpm-plugin-systemd-inhibit",
@@ -9072,6 +9394,114 @@
       "pool": [
         "2.rhel.pool.ntp.org iburst"
       ]
+    },
+    "cloud-init": {
+      "/etc/cloud": {
+        "cloud.cfg": {
+          "cloud_config_modules": [
+            "mounts",
+            "locale",
+            "set-passwords",
+            "rh_subscription",
+            "yum-add-repo",
+            "package-update-upgrade-install",
+            "timezone",
+            "puppet",
+            "chef",
+            "salt-minion",
+            "mcollective",
+            "disable-ec2-metadata",
+            "runcmd"
+          ],
+          "cloud_final_modules": [
+            "rightscale_userdata",
+            "scripts-per-once",
+            "scripts-per-boot",
+            "scripts-per-instance",
+            "scripts-user",
+            "ssh-authkey-fingerprints",
+            "keys-to-console",
+            "phone-home",
+            "final-message",
+            "power-state-change"
+          ],
+          "cloud_init_modules": [
+            "disk_setup",
+            "migrator",
+            "bootcmd",
+            "write-files",
+            "growpart",
+            "resizefs",
+            "set_hostname",
+            "update_hostname",
+            "update_etc_hosts",
+            "rsyslog",
+            "users-groups",
+            "ssh"
+          ],
+          "disable_root": 1,
+          "disable_vmware_customization": false,
+          "mount_default_fields": [
+            null,
+            null,
+            "auto",
+            "defaults,nofail,x-systemd.requires=cloud-init.service",
+            "0",
+            "2"
+          ],
+          "resize_rootfs_tmp": "/dev",
+          "ssh_deletekeys": 1,
+          "ssh_genkeytypes": [
+            "rsa",
+            "ecdsa",
+            "ed25519"
+          ],
+          "ssh_pwauth": 0,
+          "syslog_fix_perms": null,
+          "system_info": {
+            "default_user": {
+              "gecos": "Cloud User",
+              "groups": [
+                "adm",
+                "systemd-journal"
+              ],
+              "lock_passwd": true,
+              "name": "cloud-user",
+              "shell": "/bin/bash",
+              "sudo": [
+                "ALL=(ALL) NOPASSWD:ALL"
+              ]
+            },
+            "distro": "rhel",
+            "paths": {
+              "cloud_dir": "/var/lib/cloud",
+              "templates_dir": "/etc/cloud/templates"
+            },
+            "ssh_svcname": "sshd"
+          },
+          "users": [
+            "default"
+          ]
+        }
+      },
+      "/etc/cloud/cloud.cfg.d": {
+        "05_logging.cfg": {
+          "_log": [
+            "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+            "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n",
+            "[handler_cloudLogHandler]\nclass=handlers.SysLogHandler\nlevel=DEBUG\nformatter=simpleFormatter\nargs=(\"/dev/log\", handlers.SysLogHandler.LOG_USER)\n"
+          ],
+          "log_cfgs": [
+            [
+              "[loggers]\nkeys=root,cloudinit\n\n[handlers]\nkeys=consoleHandler,cloudLogHandler\n\n[formatters]\nkeys=simpleFormatter,arg0Formatter\n\n[logger_root]\nlevel=DEBUG\nhandlers=consoleHandler,cloudLogHandler\n\n[logger_cloudinit]\nlevel=DEBUG\nqualname=cloudinit\nhandlers=\npropagate=1\n\n[handler_consoleHandler]\nclass=StreamHandler\nlevel=WARNING\nformatter=arg0Formatter\nargs=(sys.stderr,)\n\n[formatter_arg0Formatter]\nformat=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s\n\n[formatter_simpleFormatter]\nformat=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s\n",
+              "[handler_cloudLogHandler]\nclass=FileHandler\nlevel=DEBUG\nformatter=arg0Formatter\nargs=('/var/log/cloud-init.log', 'a', 'UTF-8')\n"
+            ]
+          ],
+          "output": {
+            "all": "| tee -a /var/log/cloud-init-output.log"
+          }
+        }
+      }
     },
     "default-target": "graphical.target",
     "dnf": {
@@ -9268,7 +9698,9 @@
       "bzip2-libs-1.0.8-8.el9.x86_64",
       "c-ares-1.17.1-5.el9.x86_64",
       "ca-certificates-2020.2.50-94.el9.noarch",
+      "checkpolicy-3.3-1.el9.x86_64",
       "chrony-4.1-3.el9.x86_64",
+      "cloud-init-21.1-16.el9.noarch",
       "coreutils-8.32-31.el9.x86_64",
       "coreutils-common-8.32-31.el9.x86_64",
       "cpio-2.13-16.el9.x86_64",
@@ -9289,6 +9721,8 @@
       "dejavu-sans-fonts-2.37-18.el9.noarch",
       "device-mapper-1.02.181-3.el9.x86_64",
       "device-mapper-libs-1.02.181-3.el9.x86_64",
+      "dhcp-client-4.4.2-15.b1.el9.x86_64",
+      "dhcp-common-4.4.2-15.b1.el9.noarch",
       "diffutils-3.7-12.el9.x86_64",
       "dmidecode-3.3-6.el9.x86_64",
       "dnf-4.10.0-3.el9.noarch",
@@ -9326,6 +9760,8 @@
       "gawk-all-langpacks-5.1.0-5.el9.x86_64",
       "gdbm-libs-1.19-4.el9.x86_64",
       "gdisk-1.0.7-5.el9.x86_64",
+      "geolite2-city-20191217-6.el9.noarch",
+      "geolite2-country-20191217-6.el9.noarch",
       "gettext-0.21-7.el9.x86_64",
       "gettext-libs-0.21-7.el9.x86_64",
       "glib2-2.68.4-5.el9.x86_64",
@@ -9357,6 +9793,7 @@
       "ima-evm-utils-1.4-4.el9.x86_64",
       "inih-49-5.el9.x86_64",
       "initscripts-service-10.11.1-1.el9.noarch",
+      "ipcalc-1.0.0-5.el9.x86_64",
       "iproute-5.15.0-2.el9.x86_64",
       "iproute-tc-5.15.0-2.el9.x86_64",
       "ipset-7.11-6.el9.x86_64",
@@ -9451,6 +9888,7 @@
       "libkcapi-hmaccalc-1.3.1-3.el9.x86_64",
       "libksba-1.5.1-4.el9.x86_64",
       "libldb-2.4.1-1.el9.x86_64",
+      "libmaxminddb-1.5.2-3.el9.x86_64",
       "libmnl-1.0.4-15.el9.x86_64",
       "libmodulemd-2.13.0-2.el9.x86_64",
       "libmount-2.37.2-1.el9.x86_64",
@@ -9571,11 +10009,15 @@
       "publicsuffix-list-dafsa-20210518-2.el9.noarch",
       "python-unversioned-command-3.9.10-1.el9.noarch",
       "python3-3.9.10-1.el9.x86_64",
+      "python3-audit-3.0.7-100.el9.x86_64",
+      "python3-babel-2.9.1-2.el9.noarch",
       "python3-chardet-4.0.0-3.el9.noarch",
       "python3-cloud-what-1.29.23-1.el9.x86_64",
+      "python3-configobj-5.0.6-25.el9.noarch",
       "python3-dateutil-2.8.1-6.el9.noarch",
       "python3-dbus-1.2.18-2.el9.x86_64",
       "python3-decorator-4.4.2-6.el9.noarch",
+      "python3-distro-1.5.0-7.el9.noarch",
       "python3-dmidecode-3.12.2-27.el9.x86_64",
       "python3-dnf-4.10.0-3.el9.noarch",
       "python3-dnf-plugins-core-4.0.24-2.el9.noarch",
@@ -9587,20 +10029,33 @@
       "python3-idna-2.10-5.el9.noarch",
       "python3-iniparse-0.4-45.el9.noarch",
       "python3-inotify-0.9.6-25.el9.noarch",
+      "python3-jinja2-2.11.3-4.el9.noarch",
+      "python3-jsonpatch-1.21-16.el9.noarch",
+      "python3-jsonpointer-2.0-4.el9.noarch",
       "python3-libcomps-0.1.18-1.el9.x86_64",
       "python3-libdnf-0.65.0-2.el9.x86_64",
       "python3-librepo-1.14.2-1.el9.x86_64",
       "python3-libs-3.9.10-1.el9.x86_64",
       "python3-libselinux-3.3-2.el9.x86_64",
+      "python3-libsemanage-3.3-1.el9.x86_64",
       "python3-libxml2-2.9.12-4.el9.x86_64",
       "python3-linux-procfs-0.7.0-1.el9.noarch",
+      "python3-markupsafe-1.1.1-12.el9.x86_64",
+      "python3-netifaces-0.10.6-15.el9.x86_64",
       "python3-nftables-0.9.8-10.el9.x86_64",
+      "python3-oauthlib-3.1.1-2.el9.noarch",
       "python3-perf-5.14.0-55.el9.x86_64",
       "python3-pip-wheel-21.2.3-6.el9.noarch",
+      "python3-policycoreutils-3.3-2.el9.noarch",
+      "python3-prettytable-0.7.2-27.el9.noarch",
+      "python3-pyserial-3.4-12.el9.noarch",
       "python3-pysocks-1.7.1-10.el9.noarch",
+      "python3-pytz-2021.1-4.el9.noarch",
       "python3-pyudev-0.22.0-6.el9.noarch",
+      "python3-pyyaml-5.4.1-4.el9.x86_64",
       "python3-requests-2.25.1-5.el9.noarch",
       "python3-rpm-4.16.1.3-10.el9.x86_64",
+      "python3-setools-4.4.0-4.el9.x86_64",
       "python3-setuptools-53.0.0-9.el9.noarch",
       "python3-setuptools-wheel-53.0.0-9.el9.noarch",
       "python3-six-1.15.0-7.el9.noarch",
@@ -9855,6 +10310,10 @@
       "auditd.service",
       "autovt@.service",
       "chronyd.service",
+      "cloud-config.service",
+      "cloud-final.service",
+      "cloud-init-local.service",
+      "cloud-init.service",
       "crond.service",
       "ctrl-alt-del.target",
       "dbus-broker.service",
@@ -9992,6 +10451,13 @@
       }
     },
     "systemd-service-dropins": {
+      "/etc/systemd/system": {
+        "sshd-keygen@.service.d": {
+          "Unit": {
+            "ConditionPathExists": "!/run/systemd/generator.early/multi-user.target.wants/cloud-init.target"
+          }
+        }
+      },
       "/usr/lib/systemd/system": {
         "systemd-hostnamed.service.d": {
           "Service": {
@@ -10013,6 +10479,9 @@
     "timezone": "New_York",
     "tmpfiles.d": {
       "/usr/lib/tmpfiles.d": {
+        "cloud-init.conf": [
+          "d /run/cloud-init 0700 root root - -"
+        ],
         "cryptsetup.conf": [
           "d /run/cryptsetup 0700 root root -"
         ],


### PR DESCRIPTION
- Add `cloud-init` to the default package set of VMDK image on RHEL-85/86/90
- Extend the `api.sh` test case to test VMDK image uploaded to S3 in VSphere and run it in the CI
- Cloud API: upload stream-optimized VMDK to S3

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
