### PR TITLE
job queue: reschedule interrupted jobs

### DIFF
--- a/cmd/osbuild-service-maintenance/db_test.go
+++ b/cmd/osbuild-service-maintenance/db_test.go
@@ -55,7 +55,7 @@ func testDeleteJob(t *testing.T, d db, q *dbjobqueue.DBJobQueue) {
 
 	res, err := json.Marshal(result)
 	require.NoError(t, err)
-	err = q.FinishJob(id, res)
+	err = q.RequeueOrFinishJob(id, 0, res)
 	require.NoError(t, err)
 
 	_, _, r, _, _, _, _, _, _, err := q.JobStatus(id)

--- a/pkg/jobqueue/dbjobqueue/schemas/006_retry_count.sql
+++ b/pkg/jobqueue/dbjobqueue/schemas/006_retry_count.sql
@@ -1,0 +1,16 @@
+-- add the expires_at column
+ALTER TABLE jobs
+ADD COLUMN retries BIGINT DEFAULT 0;
+
+-- We added a column, thus we have to recreate the view.
+CREATE OR REPLACE VIEW ready_jobs AS
+SELECT *
+FROM jobs
+WHERE started_at IS NULL
+  AND canceled = FALSE
+  AND id NOT IN (
+    SELECT job_id
+    FROM job_dependencies JOIN jobs ON dependency_id = id
+    WHERE finished_at IS NULL
+)
+ORDER BY queued_at ASC

--- a/pkg/jobqueue/jobqueue.go
+++ b/pkg/jobqueue/jobqueue.go
@@ -49,9 +49,12 @@ type JobQueue interface {
 	// can be unmarshaled to the type given in Enqueue().
 	DequeueByID(ctx context.Context, id uuid.UUID) (uuid.UUID, []uuid.UUID, string, json.RawMessage, error)
 
-	// Mark the job with `id` as finished. `result` must fit the associated
-	// job type and must be serializable to JSON.
-	FinishJob(id uuid.UUID, result interface{}) error
+	// Tries to requeue a running job by its ID
+	//
+	// Returns the given job to the pending state. If the job has reached
+	// the maxRetries number of retries already, finish the job instead.
+	// `result` must fit the associated job type and must be serializable to JSON.
+	RequeueOrFinishJob(id uuid.UUID, maxRetries uint64, result interface{}) error
 
 	// Cancel a job. Does nothing if the job has already finished.
 	CancelJob(id uuid.UUID) error
@@ -95,6 +98,6 @@ var (
 	ErrNotExist       = errors.New("job does not exist")
 	ErrNotPending     = errors.New("job is not pending")
 	ErrNotRunning     = errors.New("job is not running")
-	ErrCanceled       = errors.New("job ws canceled")
+	ErrCanceled       = errors.New("job was canceled")
 	ErrDequeueTimeout = errors.New("dequeue context timed out or was canceled")
 )


### PR DESCRIPTION
We are currently losing jobs if workers are restarted while building. Let's restart each job up to two times before giving up. We need to have a limit in place in case a bug in the worker causes a certain job to always fail.

In the future we could teach the workers to notify us on graceful shutdown and handle that case better, so we don't have to rely on heartbeats. In this case, the limit on the number of retries could be higher, as we know it is not a bug on our side, but just normal operation of the infrastructure.