### PR TITLE
deploy: work around a podman bug in CS8 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,7 +118,7 @@ Container:
   parallel:
     matrix:
       - RUNNER:
-          - aws/centos-stream-8-x86_64
+          - aws/rhel-8.5-ga-x86_64
 
 Packer:
   stage: test

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -68,6 +68,13 @@ if [[ $ID == "rhel" && ${VERSION_ID%.*} == "9" ]]; then
   sudo systemctl stop tmp.mount && sudo systemctl mask tmp.mount
 fi
 
+if [[ $ID == "centos" && $VERSION_ID == "8" ]]; then
+    # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2065292
+    # Remove when podman-4.0.2-2.el8 is in Centos 8 repositories
+    greenprint "Updating libseccomp on Centos 8"
+    sudo dnf upgrade -y libseccomp
+fi
+
 # Distro version that this script is running on.
 DISTRO_VERSION=${ID}-${VERSION_ID}
 


### PR DESCRIPTION
Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2065292

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
