### PR TITLE
worker: introduce proxy support for koji

### DIFF
--- a/cmd/osbuild-worker/jobimpl-koji-finalize.go
+++ b/cmd/osbuild-worker/jobimpl-koji-finalize.go
@@ -25,7 +25,6 @@ func (impl *KojiFinalizeJobImpl) kojiImport(
 	buildRoots []koji.BuildRoot,
 	images []koji.Image,
 	directory, token string) error {
-	transport := koji.CreateKojiTransport(impl.relaxTimeoutFactor)
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
@@ -36,6 +35,8 @@ func (impl *KojiFinalizeJobImpl) kojiImport(
 	if !exists {
 		return fmt.Errorf("Koji server has not been configured: %s", serverURL.Hostname())
 	}
+
+	transport := koji.CreateKojiTransport(impl.relaxTimeoutFactor, kojiServer.Proxy)
 
 	k, err := koji.NewFromGSSAPI(server, &kojiServer.KerberosCredentials, transport)
 	if err != nil {
@@ -57,8 +58,6 @@ func (impl *KojiFinalizeJobImpl) kojiImport(
 }
 
 func (impl *KojiFinalizeJobImpl) kojiFail(server string, buildID int, token string) error {
-	transport := koji.CreateKojiTransport(impl.relaxTimeoutFactor)
-
 	serverURL, err := url.Parse(server)
 	if err != nil {
 		return err
@@ -68,6 +67,8 @@ func (impl *KojiFinalizeJobImpl) kojiFail(server string, buildID int, token stri
 	if !exists {
 		return fmt.Errorf("Koji server has not been configured: %s", serverURL.Hostname())
 	}
+
+	transport := koji.CreateKojiTransport(impl.relaxTimeoutFactor, kojiServer.Proxy)
 
 	k, err := koji.NewFromGSSAPI(server, &kojiServer.KerberosCredentials, transport)
 	if err != nil {

--- a/cmd/osbuild-worker/jobimpl-koji-finalize.go
+++ b/cmd/osbuild-worker/jobimpl-koji-finalize.go
@@ -15,7 +15,7 @@ import (
 )
 
 type KojiFinalizeJobImpl struct {
-	KojiServers        map[string]koji.GSSAPICredentials
+	KojiServers        map[string]KojiServer
 	relaxTimeoutFactor uint
 }
 
@@ -32,12 +32,12 @@ func (impl *KojiFinalizeJobImpl) kojiImport(
 		return err
 	}
 
-	creds, exists := impl.KojiServers[serverURL.Hostname()]
+	kojiServer, exists := impl.KojiServers[serverURL.Hostname()]
 	if !exists {
 		return fmt.Errorf("Koji server has not been configured: %s", serverURL.Hostname())
 	}
 
-	k, err := koji.NewFromGSSAPI(server, &creds, transport)
+	k, err := koji.NewFromGSSAPI(server, &kojiServer.KerberosCredentials, transport)
 	if err != nil {
 		return err
 	}
@@ -64,12 +64,12 @@ func (impl *KojiFinalizeJobImpl) kojiFail(server string, buildID int, token stri
 		return err
 	}
 
-	creds, exists := impl.KojiServers[serverURL.Hostname()]
+	kojiServer, exists := impl.KojiServers[serverURL.Hostname()]
 	if !exists {
 		return fmt.Errorf("Koji server has not been configured: %s", serverURL.Hostname())
 	}
 
-	k, err := koji.NewFromGSSAPI(server, &creds, transport)
+	k, err := koji.NewFromGSSAPI(server, &kojiServer.KerberosCredentials, transport)
 	if err != nil {
 		return err
 	}

--- a/cmd/osbuild-worker/jobimpl-koji-init.go
+++ b/cmd/osbuild-worker/jobimpl-koji-init.go
@@ -17,8 +17,6 @@ type KojiInitJobImpl struct {
 }
 
 func (impl *KojiInitJobImpl) kojiInit(server, name, version, release string) (string, uint64, error) {
-	transport := koji.CreateKojiTransport(impl.relaxTimeoutFactor)
-
 	serverURL, err := url.Parse(server)
 	if err != nil {
 		return "", 0, err
@@ -28,6 +26,8 @@ func (impl *KojiInitJobImpl) kojiInit(server, name, version, release string) (st
 	if !exists {
 		return "", 0, fmt.Errorf("Koji server has not been configured: %s", serverURL.Hostname())
 	}
+
+	transport := koji.CreateKojiTransport(impl.relaxTimeoutFactor, kojiServer.Proxy)
 
 	k, err := koji.NewFromGSSAPI(server, &kojiServer.KerberosCredentials, transport)
 	if err != nil {

--- a/cmd/osbuild-worker/jobimpl-koji-init.go
+++ b/cmd/osbuild-worker/jobimpl-koji-init.go
@@ -12,7 +12,7 @@ import (
 )
 
 type KojiInitJobImpl struct {
-	KojiServers        map[string]koji.GSSAPICredentials
+	KojiServers        map[string]KojiServer
 	relaxTimeoutFactor uint
 }
 
@@ -24,12 +24,12 @@ func (impl *KojiInitJobImpl) kojiInit(server, name, version, release string) (st
 		return "", 0, err
 	}
 
-	creds, exists := impl.KojiServers[serverURL.Hostname()]
+	kojiServer, exists := impl.KojiServers[serverURL.Hostname()]
 	if !exists {
 		return "", 0, fmt.Errorf("Koji server has not been configured: %s", serverURL.Hostname())
 	}
 
-	k, err := koji.NewFromGSSAPI(server, &creds, transport)
+	k, err := koji.NewFromGSSAPI(server, &kojiServer.KerberosCredentials, transport)
 	if err != nil {
 		return "", 0, err
 	}

--- a/cmd/osbuild-worker/jobimpl-osbuild-koji.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild-koji.go
@@ -19,7 +19,7 @@ import (
 type OSBuildKojiJobImpl struct {
 	Store              string
 	Output             string
-	KojiServers        map[string]koji.GSSAPICredentials
+	KojiServers        map[string]KojiServer
 	relaxTimeoutFactor uint
 }
 
@@ -31,12 +31,12 @@ func (impl *OSBuildKojiJobImpl) kojiUpload(file *os.File, server, directory, fil
 		return "", 0, err
 	}
 
-	creds, exists := impl.KojiServers[serverURL.Hostname()]
+	kojiServer, exists := impl.KojiServers[serverURL.Hostname()]
 	if !exists {
 		return "", 0, fmt.Errorf("Koji server has not been configured: %s", serverURL.Hostname())
 	}
 
-	k, err := koji.NewFromGSSAPI(server, &creds, transport)
+	k, err := koji.NewFromGSSAPI(server, &kojiServer.KerberosCredentials, transport)
 	if err != nil {
 		return "", 0, err
 	}

--- a/cmd/osbuild-worker/jobimpl-osbuild-koji.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild-koji.go
@@ -24,8 +24,6 @@ type OSBuildKojiJobImpl struct {
 }
 
 func (impl *OSBuildKojiJobImpl) kojiUpload(file *os.File, server, directory, filename string) (string, uint64, error) {
-	transport := koji.CreateKojiTransport(impl.relaxTimeoutFactor)
-
 	serverURL, err := url.Parse(server)
 	if err != nil {
 		return "", 0, err
@@ -35,6 +33,8 @@ func (impl *OSBuildKojiJobImpl) kojiUpload(file *os.File, server, directory, fil
 	if !exists {
 		return "", 0, fmt.Errorf("Koji server has not been configured: %s", serverURL.Hostname())
 	}
+
+	transport := koji.CreateKojiTransport(impl.relaxTimeoutFactor, kojiServer.Proxy)
 
 	k, err := koji.NewFromGSSAPI(server, &kojiServer.KerberosCredentials, transport)
 	if err != nil {

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -23,20 +23,18 @@ import (
 	osbuild "github.com/osbuild/osbuild-composer/internal/osbuild2"
 	"github.com/osbuild/osbuild-composer/internal/target"
 	"github.com/osbuild/osbuild-composer/internal/upload/azure"
-	"github.com/osbuild/osbuild-composer/internal/upload/koji"
 	"github.com/osbuild/osbuild-composer/internal/upload/vmware"
 	"github.com/osbuild/osbuild-composer/internal/worker"
 	"github.com/osbuild/osbuild-composer/internal/worker/clienterrors"
 )
 
 type OSBuildJobImpl struct {
-	Store       string
-	Output      string
-	KojiServers map[string]koji.GSSAPICredentials
-	GCPCreds    []byte
-	AzureCreds  *azure.Credentials
-	AWSCreds    string
-	AWSBucket   string
+	Store      string
+	Output     string
+	GCPCreds   []byte
+	AzureCreds *azure.Credentials
+	AWSCreds   string
+	AWSBucket  string
 }
 
 // Returns an *awscloud.AWS object with the credentials of the request. If they

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -123,7 +123,7 @@ func RequestAndRunJob(client *worker.Client, acceptedJobTypes []string, jobImpls
 
 func main() {
 	var config struct {
-		KojiServers map[string]struct {
+		Koji map[string]struct {
 			Kerberos *struct {
 				Principal string `toml:"principal"`
 				KeyTab    string `toml:"keytab"`
@@ -190,7 +190,7 @@ func main() {
 	_ = os.Mkdir(output, os.ModeDir)
 
 	kojiServers := make(map[string]koji.GSSAPICredentials)
-	for server, creds := range config.KojiServers {
+	for server, creds := range config.Koji {
 		if creds.Kerberos == nil {
 			// For now we only support Kerberos authentication.
 			continue

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -340,13 +340,12 @@ func main() {
 	// non-depsolve job
 	jobImpls := map[string]JobImplementation{
 		"osbuild": &OSBuildJobImpl{
-			Store:       store,
-			Output:      output,
-			KojiServers: kojiServers,
-			GCPCreds:    gcpCredentials,
-			AzureCreds:  azureCredentials,
-			AWSCreds:    awsCredentials,
-			AWSBucket:   awsBucket,
+			Store:      store,
+			Output:     output,
+			GCPCreds:   gcpCredentials,
+			AzureCreds: azureCredentials,
+			AWSCreds:   awsCredentials,
+			AWSBucket:  awsBucket,
 		},
 		"osbuild-koji": &OSBuildKojiJobImpl{
 			Store:              store,


### PR DESCRIPTION
We want to have a koji-specific proxy support for our internal workers in order to access api.openshift.com. This PR implements this.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
