### PR TITLE
ci/tests: Change the way artifacts are collected

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,21 +8,18 @@ stages:
 
 .base:
   before_script:
-    - schutzbot/ci_details.sh > ci-details-before-run
+    - schutzbot/ci_details.sh > ci-details-before-run.txt
     - cat schutzbot/team_ssh_keys.txt | tee -a ~/.ssh/authorized_keys > /dev/null
   after_script:
-    - schutzbot/ci_details.sh > ci-details-after-run || true
+    - schutzbot/ci_details.sh > ci-details-after-run.txt || true
     - schutzbot/update_github_status.sh update || true
     - schutzbot/save_journal.sh || true
+    - schutzbot/upload_artifacts.sh
   interruptible: true
   tags:
     - terraform
   artifacts:
     paths:
-      - journal-log.gpg
-      - ci-artifacts
-      - ci-details-before-run
-      - ci-details-after-run
       - "*.repo"
       - COMPOSER_NVR
     when: always
@@ -446,17 +443,7 @@ aws.sh:
   extends: .integration
   variables:
     SCRIPT: aws.sh
-  artifacts:
-    paths:
-      - cloud-image-val/report.html
-      - journal-log.gpg
-      - ci-artifacts
-      - ci-details-before-run
-      - ci-details-after-run
-      - "*.repo"
-      - COMPOSER_NVR
-    when: always
-
+    
 azure.sh:
   extends: .integration
   variables:
@@ -595,18 +582,6 @@ Upgrade:
     - /usr/libexec/tests/osbuild-composer/upgrade8to9.sh
   variables:
     RUNNER: rhos-01/rhel-9.1-nightly-x86_64
-  artifacts:
-    paths:
-      - journal-log.gpg
-      - ci-artifacts
-      - install_console.log
-      - upgrade_console.log
-      - leapp-preupgrade.log
-      - leapp-upgrade.log
-      - leapp-report.txt
-      - osbuild-upgrade8to9.log
-      - osbuild-upgrade8to9.json
-    when: always
 
 NIGHTLY_FAIL:
   stage: finish

--- a/schutzbot/ci_details.sh
+++ b/schutzbot/ci_details.sh
@@ -34,7 +34,7 @@ EOF
 echo -e "\033[0m"
 
 echo "List of system repositories:"
-yum repolist -v
+sudo yum repolist -v
 
 echo "------------------------------------------------------------------------------"
 

--- a/schutzbot/save_journal.sh
+++ b/schutzbot/save_journal.sh
@@ -3,7 +3,5 @@
 # use tee, otherwise shellcheck complains
 sudo journalctl --boot | tee journal-log >/dev/null
 
-# As it might contain sensitive information and is important for debugging
-# purposes, encrypt journal-log with a symmetric passphrase.
-gpg --batch --yes --passphrase "$GPG_SYMMETRIC_PASSPHRASE" -o journal-log.gpg --symmetric journal-log
-rm journal-log
+# copy journal to artifacts folder which is then uploaded to secure S3 location
+cp journal-log "${ARTIFACTS:-/tmp/artifacts}"

--- a/schutzbot/upload_artifacts.sh
+++ b/schutzbot/upload_artifacts.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script uploads all files from ARTIFACTS folder to S3
+
+S3_URL="s3://image-builder-ci-artifacts/osbuild-composer/$CI_COMMIT_BRANCH/$CI_JOB_ID/"
+BROWSER_URL="https://s3.console.aws.amazon.com/s3/buckets/image-builder-ci-artifacts?region=us-east-1&prefix=osbuild-composer/$CI_COMMIT_BRANCH/$CI_JOB_ID/&showversions=false"
+ARTIFACTS=${ARTIFACTS:-/tmp/artifacts}
+
+# Colorful output.
+function greenprint {
+  echo -e "\033[1;32m[$(date -Isecond)] ${1}\033[0m"
+}
+
+sudo dnf -y install s3cmd
+greenprint "Job artifacts will be uploaded to: $S3_URL"
+
+AWS_SECRET_ACCESS_KEY="$V2_AWS_SECRET_ACCESS_KEY" \
+AWS_ACCESS_KEY_ID="$V2_AWS_ACCESS_KEY_ID" \
+s3cmd --acl-private put "$ARTIFACTS"/* "$S3_URL"
+
+greenprint "Please login to 438669297788 AWS account and visit $BROWSER_URL to access job artifacts."

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -80,8 +80,7 @@ function greenprint {
     echo -e "\033[1;32m[$(date -Isecond)] ${1}\033[0m"
 }
 
-ARTIFACTS=ci-artifacts
-mkdir -p "${ARTIFACTS}"
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 
 source /usr/libexec/osbuild-composer-test/set-env-variables.sh
 
@@ -194,7 +193,7 @@ function dump_db() {
 
   # Save the result, including the manifest, for the job, straight from the db
   sudo ${CONTAINER_RUNTIME} exec "${DB_CONTAINER_NAME}" psql -U postgres -d osbuildcomposer -c "SELECT result FROM jobs WHERE type='manifest-id-only'" \
-    | gpg --batch --yes --passphrase "${GPG_SYMMETRIC_PASSPHRASE}" -o "${ARTIFACTS}/build-result.gpg" --symmetric -
+    | sudo tee "${ARTIFACTS}/build-result.txt"
   set -x
 }
 

--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -60,12 +60,7 @@ else
   TEST_ID=$(uuidgen);
 fi
 
-
-# Jenkins sets WORKSPACE to the job workspace, but if this script runs
-# outside of Jenkins, we can set up a temporary directory instead.
-if [[ ${WORKSPACE:-empty} == empty ]]; then
-    WORKSPACE=$(mktemp -d)
-fi
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 
 # Set up temporary files.
 AWS_CONFIG=${TEMPDIR}/aws.toml
@@ -93,7 +88,7 @@ $AWS_CMD --version
 # Get the compose log.
 get_compose_log () {
     COMPOSE_ID=$1
-    LOG_FILE=${WORKSPACE}/osbuild-${ID}-${VERSION_ID}-aws.log
+    LOG_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-aws.log
 
     # Download the logs.
     sudo composer-cli compose log "$COMPOSE_ID" | tee "$LOG_FILE" > /dev/null
@@ -102,7 +97,7 @@ get_compose_log () {
 # Get the compose metadata.
 get_compose_metadata () {
     COMPOSE_ID=$1
-    METADATA_FILE=${WORKSPACE}/osbuild-${ID}-${VERSION_ID}-aws.json
+    METADATA_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-aws.json
 
     # Download the metadata.
     sudo composer-cli compose metadata "$COMPOSE_ID" > /dev/null
@@ -256,6 +251,9 @@ EOF
 AWS_ACCESS_KEY_ID=${V2_AWS_ACCESS_KEY_ID} \
 AWS_SECRET_ACCESS_KEY=${V2_AWS_SECRET_ACCESS_KEY} \
 python3 cloud-image-val.py -r resource-file.json -d -o report.xml -m 'not pub' && RESULTS=1 || RESULTS=0
+
+# copy the report to artifacts folder
+cp report.html "${ARTIFACTS}"
 
 popd
 

--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -94,11 +94,7 @@ ARCH=$(uname -m)
 TEST_ID="$DISTRO_CODE-$ARCH-$BRANCH_NAME-$BUILD_ID"
 IMAGE_KEY=image-${TEST_ID}
 
-# Jenkins sets WORKSPACE to the job workspace, but if this script runs
-# outside of Jenkins, we can set up a temporary directory instead.
-if [[ ${WORKSPACE:-empty} == empty ]]; then
-    WORKSPACE=$(mktemp -d)
-fi
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 
 # Set up temporary files.
 AZURE_CONFIG=${TEMPDIR}/azure.toml
@@ -119,7 +115,7 @@ smoke_test_check () {
 # Get the compose log.
 get_compose_log () {
     COMPOSE_ID=$1
-    LOG_FILE=${WORKSPACE}/osbuild-${ID}-${VERSION_ID}-azure.log
+    LOG_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-azure.log
 
     # Download the logs.
     sudo composer-cli compose log "$COMPOSE_ID" | tee "$LOG_FILE" > /dev/null
@@ -128,7 +124,7 @@ get_compose_log () {
 # Get the compose metadata.
 get_compose_metadata () {
     COMPOSE_ID=$1
-    METADATA_FILE=${WORKSPACE}/osbuild-${ID}-${VERSION_ID}-azure.json
+    METADATA_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-azure.json
 
     # Download the metadata.
     sudo composer-cli compose metadata "$COMPOSE_ID" > /dev/null

--- a/test/cases/container-upload.sh
+++ b/test/cases/container-upload.sh
@@ -23,6 +23,7 @@ source /usr/libexec/osbuild-composer-test/set-env-variables.sh
 
 /usr/libexec/osbuild-composer-test/provision.sh
 
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 TEMPDIR=$(mktemp -d)
 function cleanup() {
     greenprint "== Script execution stopped or finished - Cleaning up =="
@@ -33,7 +34,7 @@ trap cleanup EXIT
 # Get the compose log.
 get_compose_log () {
     COMPOSE_ID=$1
-    LOG_FILE=${TEMPDIR}/osbuild-${ID}-${VERSION_ID}-azure.log
+    LOG_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-azure.log
 
     # Download the logs.
     sudo composer-cli compose log "$COMPOSE_ID" | tee "$LOG_FILE" > /dev/null
@@ -42,7 +43,7 @@ get_compose_log () {
 # Get the compose metadata.
 get_compose_metadata () {
     COMPOSE_ID=$1
-    METADATA_FILE=${TEMPDIR}/osbuild-${ID}-${VERSION_ID}-azure.json
+    METADATA_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-azure.json
 
     # Download the metadata.
     sudo composer-cli compose metadata "$COMPOSE_ID" > /dev/null

--- a/test/cases/gcp.sh
+++ b/test/cases/gcp.sh
@@ -85,12 +85,7 @@ else
     TEST_ID=$(uuidgen);
 fi
 
-
-# Jenkins sets WORKSPACE to the job workspace, but if this script runs
-# outside of Jenkins, we can set up a temporary directory instead.
-if [[ ${WORKSPACE:-empty} == empty ]]; then
-    WORKSPACE=$(mktemp -d)
-fi
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 
 # Set up temporary files.
 GCP_CONFIG=${TEMPDIR}/gcp.toml
@@ -199,7 +194,7 @@ function _instanceCheck() {
 # Get the compose log.
 get_compose_log () {
     COMPOSE_ID=$1
-    LOG_FILE=${WORKSPACE}/osbuild-${ID}-${VERSION_ID}-gcp.log
+    LOG_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-gcp.log
 
     # Download the logs.
     sudo composer-cli compose log "$COMPOSE_ID" | tee "$LOG_FILE" > /dev/null
@@ -208,7 +203,7 @@ get_compose_log () {
 # Get the compose metadata.
 get_compose_metadata () {
     COMPOSE_ID=$1
-    METADATA_FILE=${WORKSPACE}/osbuild-${ID}-${VERSION_ID}-gcp.json
+    METADATA_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-gcp.json
 
     # Download the metadata.
     sudo composer-cli compose metadata "$COMPOSE_ID" > /dev/null

--- a/test/cases/installers.sh
+++ b/test/cases/installers.sh
@@ -138,9 +138,7 @@ SSH_USER="admin"
 IMAGE_KEY="osbuild-composer-installer-test-${TEST_UUID}"
 GUEST_ADDRESS=192.168.100.50
 
-if [[ ${WORKSPACE:-empty} == empty ]]; then
-    WORKSPACE=$(mktemp -d)
-fi
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 
 # Set up temporary files.
 TEMPDIR=$(mktemp -d)
@@ -154,8 +152,6 @@ SSH_DATA_DIR=$(/usr/libexec/osbuild-composer-test/gen-ssh.sh)
 SSH_KEY=${SSH_DATA_DIR}/id_rsa
 SSH_KEY_PUB=$(cat "${SSH_KEY}".pub)
 
-ARTIFACTS="ci-artifacts"
-mkdir -p "${ARTIFACTS}"
 # Get the compose log.
 get_compose_log () {
     COMPOSE_ID=$1
@@ -169,8 +165,8 @@ get_compose_log () {
 # Get the compose metadata.
 get_compose_metadata () {
     COMPOSE_ID=$1
-    METADATA_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-${COMPOSE_ID}.json
     greenprint "Saving manifest for ${COMPOSE_ID}"
+    METADATA_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-${COMPOSE_ID}.json
 
     # Download the metadata.
     sudo composer-cli compose metadata "$COMPOSE_ID" > /dev/null

--- a/test/cases/manifest_tests.sh
+++ b/test/cases/manifest_tests.sh
@@ -6,8 +6,7 @@ DNF_JSON_PATH="/usr/libexec/osbuild-composer/dnf-json"
 IMAGE_TEST_CASES_PATH="/usr/share/tests/osbuild-composer/manifests"
 
 WORKING_DIRECTORY=/usr/libexec/osbuild-composer
-mkdir --parents /tmp/logs
-LOGS_DIRECTORY=$(mktemp --directory --tmpdir=/tmp/logs)
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 
 # Print out a nice test divider so we know when tests stop and start.
 test_divider () {
@@ -27,7 +26,7 @@ test_divider
 echo "🏃🏻 Running test: ${TEST_NAME}"
 test_divider
 
-if sudo "$MANIFEST_TESTS_RUNNER" -test.v -manifests-path "$IMAGE_TEST_CASES_PATH" -dnf-json-path "$DNF_JSON_PATH" | tee "${LOGS_DIRECTORY}"/"${TEST_NAME}".log; then
+if sudo "$MANIFEST_TESTS_RUNNER" -test.v -manifests-path "$IMAGE_TEST_CASES_PATH" -dnf-json-path "$DNF_JSON_PATH" | tee "${ARTIFACTS}"/"${TEST_NAME}".log; then
     echo "🎉  Test passed."
     exit 0
 else

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -84,13 +84,12 @@ QUAY_REPO_URL="docker://quay.io/osbuild/testing-rhel-edge-push"
 QUAY_REPO_TAG=$(tr -dc a-z0-9 < /dev/urandom | head -c 4 ; echo '')
 STAGE_OCP4_SERVER_NAME="edge-stage-server"
 STAGE_OCP4_REPO_URL="http://${STAGE_OCP4_SERVER_NAME}-${QUAY_REPO_TAG}-frontdoor.apps.ocp.ci.centos.org/repo/"
-ARTIFACTS="ci-artifacts"
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 # For CS8, CS9, RHEL 8.5 and above
 CONTAINER_TYPE=edge-container
 CONTAINER_FILENAME=container.tar
 INSTALLER_TYPE=edge-installer
 INSTALLER_FILENAME=installer.iso
-mkdir -p "${ARTIFACTS}"
 ANSIBLE_USER_FOR_BIOS="installeruser"
 OSTREE_OSNAME=rhel
 

--- a/test/cases/ostree-raw-image.sh
+++ b/test/cases/ostree-raw-image.sh
@@ -76,12 +76,11 @@ PROD_REPO_URL=http://192.168.100.1/repo
 PROD_REPO=/var/www/html/repo
 STAGE_REPO_ADDRESS=192.168.200.1
 STAGE_REPO_URL="http://${STAGE_REPO_ADDRESS}:8080/repo/"
-ARTIFACTS="ci-artifacts"
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 CONTAINER_TYPE=edge-container
 CONTAINER_FILENAME=container.tar
 INSTALLER_TYPE=edge-raw-image
 INSTALLER_FILENAME=image.raw.xz
-mkdir -p "${ARTIFACTS}"
 
 # Set up temporary files.
 TEMPDIR=$(mktemp -d)

--- a/test/cases/ostree-rebase.sh
+++ b/test/cases/ostree-rebase.sh
@@ -78,10 +78,9 @@ BIOS_GUEST_ADDRESS=192.168.100.50
 UEFI_GUEST_ADDRESS=192.168.100.51
 PROD_REPO_ADDRESS=192.168.200.1
 PROD_REPO_URL="http://${PROD_REPO_ADDRESS}:8080/repo/"
-ARTIFACTS="ci-artifacts"
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 CONTAINER_TYPE=edge-container
 CONTAINER_FILENAME=container.tar
-mkdir -p "${ARTIFACTS}"
 
 # Set up temporary files.
 TEMPDIR=$(mktemp -d)

--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -94,12 +94,11 @@ FDO_SERVER_ADDRESS=192.168.200.2
 FDO_ADMIN_CLI_VERSION=0.4.0
 # FDO Manualfacture server image version
 FDO_MF_SERVER_VERSION=0.4.0
-ARTIFACTS="ci-artifacts"
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 CONTAINER_TYPE=edge-container
 CONTAINER_FILENAME=container.tar
 INSTALLER_TYPE=edge-simplified-installer
 INSTALLER_FILENAME=simplified-installer.iso
-mkdir -p "${ARTIFACTS}"
 
 # Set up temporary files.
 TEMPDIR=$(mktemp -d)

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -151,8 +151,7 @@ TEST_UUID=$(uuidgen)
 IMAGE_KEY="osbuild-composer-ostree-test-${TEST_UUID}"
 GUEST_ADDRESS=192.168.100.50
 SSH_USER="admin"
-ARTIFACTS="ci-artifacts"
-mkdir -p "${ARTIFACTS}"
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 
 # Set up temporary files.
 TEMPDIR=$(mktemp -d)

--- a/test/cases/regression-old-worker-new-composer.sh
+++ b/test/cases/regression-old-worker-new-composer.sh
@@ -12,8 +12,7 @@ function greenprint {
     echo -e "\033[1;32m[$(date -Isecond)] ${1}\033[0m"
 }
 
-ARTIFACTS=ci-artifacts
-mkdir -p "${ARTIFACTS}"
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 
 source /usr/libexec/osbuild-composer-test/set-env-variables.sh
 

--- a/test/cases/upgrade8to9.sh
+++ b/test/cases/upgrade8to9.sh
@@ -4,6 +4,8 @@ set -uxo pipefail
 # Get OS data.
 source /usr/libexec/osbuild-composer-test/set-env-variables.sh
 
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
+
 # Colorful output.
 function greenprint {
     echo -e "\033[1;32m[$(date -Isecond)] ${1}\033[0m"
@@ -123,9 +125,9 @@ sudo scp "${SSH_OPTIONS[@]}" -q -i "${SSH_KEY}" /usr/share/tests/osbuild-compose
 sudo ssh "${SSH_OPTIONS[@]}" -q -i "${SSH_KEY}" root@"$INSTANCE_ADDRESS" 'sed -i "s/PermitRootLogin yes/PermitRootLogin yes #for sure/" /etc/ssh/sshd_config'
 set +e
 sudo ssh "${SSH_OPTIONS[@]}" -q -i "${SSH_KEY}" root@"$INSTANCE_ADDRESS" 'source /root/upgrade_prepare.sh'
-sudo scp "${SSH_OPTIONS[@]}" -q -i "${SSH_KEY}" root@"$INSTANCE_ADDRESS":/var/log/leapp/leapp-preupgrade.log .
-sudo scp "${SSH_OPTIONS[@]}" -q -i "${SSH_KEY}" root@"$INSTANCE_ADDRESS":/var/log/leapp/leapp-upgrade.log .
-sudo scp "${SSH_OPTIONS[@]}" -q -i "${SSH_KEY}" root@"$INSTANCE_ADDRESS":/var/log/leapp/leapp-report.txt .
+sudo scp "${SSH_OPTIONS[@]}" -q -i "${SSH_KEY}" root@"$INSTANCE_ADDRESS":/var/log/leapp/leapp-preupgrade.log "$ARTIFACTS"
+sudo scp "${SSH_OPTIONS[@]}" -q -i "${SSH_KEY}" root@"$INSTANCE_ADDRESS":/var/log/leapp/leapp-upgrade.log "$ARTIFACTS"
+sudo scp "${SSH_OPTIONS[@]}" -q -i "${SSH_KEY}" root@"$INSTANCE_ADDRESS":/var/log/leapp/leapp-report.txt "$ARTIFACTS"
 set -e
 
 # watch and log the console during upgrade
@@ -143,7 +145,7 @@ RESULT="$?"
 set -e
 
 # copy over osbuild-composer logs
-sudo scp "${SSH_OPTIONS[@]}" -q -i "${SSH_KEY}" root@"$INSTANCE_ADDRESS":logs/* .
+sudo scp "${SSH_OPTIONS[@]}" -q -i "${SSH_KEY}" root@"$INSTANCE_ADDRESS":logs/* "$ARTIFACTS"
 
 if [[ "$RESULT" == 0 ]]; then
   greenprint "💚 Success"

--- a/test/cases/vmware.sh
+++ b/test/cases/vmware.sh
@@ -59,11 +59,7 @@ fi
 TEST_UUID=$(uuidgen)
 IMAGE_KEY=osbuild-composer-vmware-test-${TEST_UUID}
 
-# Jenkins sets WORKSPACE to the job workspace, but if this script runs
-# outside of Jenkins, we can set up a temporary directory instead.
-if [[ ${WORKSPACE:-empty} == empty ]]; then
-    WORKSPACE=$(mktemp -d)
-fi
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 
 # Set up temporary files
 TEMPDIR=$(mktemp -d)
@@ -89,7 +85,7 @@ running_test_check () {
 # Get the compose log.
 get_compose_log () {
     COMPOSE_ID=$1
-    LOG_FILE=${WORKSPACE}/osbuild-${ID}-${VERSION_ID}-vmware.log
+    LOG_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-vmware.log
 
     # Download the logs.
     sudo composer-cli compose log "$COMPOSE_ID" | tee "$LOG_FILE" > /dev/null
@@ -98,7 +94,7 @@ get_compose_log () {
 # Get the compose metadata.
 get_compose_metadata () {
     COMPOSE_ID=$1
-    METADATA_FILE=${WORKSPACE}/osbuild-${ID}-${VERSION_ID}-vmware.json
+    METADATA_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-vmware.json
 
     # Download the metadata.
     sudo composer-cli compose metadata "$COMPOSE_ID" > /dev/null

--- a/tools/libvirt_test.sh
+++ b/tools/libvirt_test.sh
@@ -90,10 +90,7 @@ BLUEPRINT_FILE=${TEMPDIR}/blueprint.toml
 COMPOSE_START=${TEMPDIR}/compose-start-${IMAGE_KEY}.json
 COMPOSE_INFO=${TEMPDIR}/compose-info-${IMAGE_KEY}.json
 
-if [[ ${WORKSPACE:-empty} == empty ]]; then
-    WORKSPACE=$(mktemp -d)
-fi
-
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 SSH_DATA_DIR=$(/usr/libexec/osbuild-composer-test/gen-ssh.sh)
 SSH_KEY=${SSH_DATA_DIR}/id_rsa
 
@@ -112,7 +109,7 @@ smoke_test_check () {
 # Get the compose log.
 get_compose_log () {
     COMPOSE_ID=$1
-    LOG_FILE=${WORKSPACE}/osbuild-${ID}-${VERSION_ID}-${IMAGE_TYPE}.log
+    LOG_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-${IMAGE_TYPE}.log
 
     # Download the logs.
     sudo composer-cli compose log "$COMPOSE_ID" | tee "$LOG_FILE" > /dev/null
@@ -121,7 +118,7 @@ get_compose_log () {
 # Get the compose metadata.
 get_compose_metadata () {
     COMPOSE_ID=$1
-    METADATA_FILE=${WORKSPACE}/osbuild-${ID}-${VERSION_ID}-${IMAGE_TYPE}.json
+    METADATA_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-${IMAGE_TYPE}.json
 
     # Download the metadata.
     sudo composer-cli compose metadata "$COMPOSE_ID" > /dev/null

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -3,6 +3,10 @@ set -euxo pipefail
 
 source /usr/libexec/osbuild-composer-test/set-env-variables.sh
 
+# create artifacts folder
+ARTIFACTS="${ARTIFACTS:=/tmp/artifacts}"
+mkdir -p "${ARTIFACTS}"
+
 # koji and ansible are not in RHEL repositories. Depending on them in the spec
 # file breaks RHEL gating (see OSCI-1541). Therefore, we need to enable epel
 # and install koji and ansible here.

--- a/tools/s3_test.sh
+++ b/tools/s3_test.sh
@@ -29,11 +29,7 @@ function cleanup() {
 }
 trap cleanup EXIT
 
-# Jenkins sets WORKSPACE to the job workspace, but if this script runs
-# outside of Jenkins, we can set up a temporary directory instead.
-if [[ ${WORKSPACE:-empty} == empty ]]; then
-    WORKSPACE=$(mktemp -d)
-fi
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 
 # Set up temporary files.
 BLUEPRINT_FILE=${TEMPDIR}/blueprint.toml
@@ -44,7 +40,7 @@ COMPOSE_INFO=${TEMPDIR}/compose-info-${TEST_ID}.json
 # Get the compose log.
 get_compose_log () {
     COMPOSE_ID=$1
-    LOG_FILE=${WORKSPACE}/osbuild-${ID}-${VERSION_ID}-aws.log
+    LOG_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-aws.log
 
     # Download the logs.
     sudo composer-cli compose log "$COMPOSE_ID" | tee "$LOG_FILE" > /dev/null
@@ -53,7 +49,7 @@ get_compose_log () {
 # Get the compose metadata.
 get_compose_metadata () {
     COMPOSE_ID=$1
-    METADATA_FILE=${WORKSPACE}/osbuild-${ID}-${VERSION_ID}-aws.json
+    METADATA_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-aws.json
 
     # Download the metadata.
     sudo composer-cli compose metadata "$COMPOSE_ID" > /dev/null


### PR DESCRIPTION
We want to be able to safely gather any artifacts without worrying about
any possible secrets leaking. Every artifacts that we want to upload
will now have to be placed in /tmp/artifacts which will then be uploaded
to S3 by the executor and link to the artifacts will be provided in the
logs. Only people with access to our AWS account will be able to see the artifacts.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
