### PR TITLE
create-tag: Fix upstream release schedule

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -4,7 +4,7 @@ name: "Create and push release tag"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 10 * * 3"
+    - cron: "0 11 * * 3"
 
 jobs:
   tag-and-push:
@@ -17,7 +17,7 @@ jobs:
 
       - name: Upstream tag
         uses: osbuild/release-action@create-tag
-        if: ${{ env.WEEK == 'even' }}
+        if: ${{ env.WEEK == 'odd' }}
         with:
           token: "${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}"
           username: "imagebuilder-bot"


### PR DESCRIPTION
We're counting the even and odd weeks since the Unix epoch, so this
doesn't match the odd/even calendar weeks. Consequently let's switch to
odd weeks for composer.