### PR TITLE
create-tag: Fix bash typo

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Even or odd week
-        run: if [ `expr \`date +\%s\` / 86400 \% 2` -eq 0 ]; then echo "WEEK='odd'" >> $GITHUB_ENV; else echo "WEEK='even'" >> $GITHUB_ENV; fi
+        run: if [ `expr \`date +\%s\` / 86400 \% 2` -eq 0 ]; then echo "WEEK=odd" >> $GITHUB_ENV; else echo "WEEK=even" >> $GITHUB_ENV; fi
         shell: bash
 
       - name: Upstream tag

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -4,7 +4,7 @@ name: "Create and push release tag"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 11 * * 3"
+    - cron: "0 13 * * 3"
 
 jobs:
   tag-and-push:

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Upstream tag
         uses: osbuild/release-action@create-tag
-        if: ${{ env.WEEK == 'odd' }}
+        if: ${{ env.WEEK == 'odd' || github.event_name != 'schedule' }}
         with:
           token: "${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}"
           username: "imagebuilder-bot"


### PR DESCRIPTION
This PR contains two fixes for the 'create-tag (scheduled releases) action.

1. With the `'` the environment variable is not properly stored.
2. When a release is manually triggered we want to ignore whether it is odd or even week but allow the release in any case.