### PR TITLE
Dependency joberrors

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild-koji.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild-koji.go
@@ -124,12 +124,12 @@ func (impl *OSBuildKojiJobImpl) Run(job worker.Job) error {
 			args.Manifest = manifestJR.Manifest
 			if len(args.Manifest) == 0 {
 				err := fmt.Errorf("Received empty manifest")
-				result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorManifestDependency, err.Error())
+				result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorEmptyManifest, err.Error())
 				return err
 			}
 		} else {
 			err := fmt.Errorf("Job has no manifest")
-			result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorManifestDependency, err.Error())
+			result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorEmptyManifest, err.Error())
 			return err
 		}
 	}

--- a/internal/worker/clienterrors/errors.go
+++ b/internal/worker/clienterrors/errors.go
@@ -64,8 +64,12 @@ func GetStatusCode(err *Error) StatusCode {
 		return JobStatusUserInputError
 	case ErrorInvalidTarget:
 		return JobStatusUserInputError
+	case ErrorDepsolveDependency:
+		return JobStatusUserInputError
+	case ErrorManifestDependency:
+		return JobStatusUserInputError
 	case ErrorEmptyManifest:
-		return JobStatusInternalError
+		return JobStatusUserInputError
 	default:
 		return JobStatusInternalError
 	}

--- a/internal/worker/clienterrors/errors.go
+++ b/internal/worker/clienterrors/errors.go
@@ -19,6 +19,7 @@ const (
 	ErrorKojiFinalize         ClientErrorCode = 16
 	ErrorInvalidConfig        ClientErrorCode = 17
 	ErrorOldResultCompatible  ClientErrorCode = 18
+	ErrorEmptyManifest        ClientErrorCode = 19
 
 	ErrorDNFDepsolveError ClientErrorCode = 20
 	ErrorDNFMarkingErrors ClientErrorCode = 21
@@ -63,6 +64,8 @@ func GetStatusCode(err *Error) StatusCode {
 		return JobStatusUserInputError
 	case ErrorInvalidTarget:
 		return JobStatusUserInputError
+	case ErrorEmptyManifest:
+		return JobStatusInternalError
 	default:
 		return JobStatusInternalError
 	}


### PR DESCRIPTION
This pull request includes:
Reporting that there has been an issue with a dependency job does not provide enough information about the dependency
failure. It makes more sense to bubble up the original error since this will tell us the information we need. It also has the added benefit of ensuring consistency of the status codes for metrics.

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
