### PR TITLE
cmd: add `osbuild-package-sets` for printing package sets of an image

### DIFF
--- a/cmd/osbuild-package-sets/main.go
+++ b/cmd/osbuild-package-sets/main.go
@@ -1,0 +1,46 @@
+// Simple tool to dump a JSON object containing all package sets for a specific
+// distro x arch x image type.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/distroregistry"
+)
+
+func main() {
+	var distroName string
+	var archName string
+	var imageName string
+
+	flag.StringVar(&distroName, "distro", "", "Distribution name")
+	flag.StringVar(&archName, "arch", "", "Architecture name")
+	flag.StringVar(&imageName, "image", "", "Image name")
+	flag.Parse()
+
+	dr := distroregistry.NewDefault()
+
+	distro := dr.GetDistro(distroName)
+	if distro == nil {
+		panic(fmt.Errorf("Distro %q does not exist", distro))
+	}
+
+	arch, err := distro.GetArch(archName)
+	if err != nil {
+		panic(err)
+	}
+
+	image, err := arch.GetImageType(imageName)
+	if err != nil {
+		panic(err)
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	pkgset := image.PackageSets(blueprint.Blueprint{})
+	_ = encoder.Encode(pkgset)
+}


### PR DESCRIPTION
Add a new debugging / development tool `osbuild-package-sets` for
printing JSON object with all package sets of a specific distro x arch x
image type combination.

This is useful, since due to the way package sets are implemented in
composer, the actual package set of a vanilla image type is very
difficult to determine just by looking at the code.

Example usage:
`go run cmd/osbuild-package-sets/main.go -distro rhel-90 -arch x86_64
-image qcow2`


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
