### PR TITLE
test: Clean up and improve ostree-simplified-installer.sh

### DIFF
--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -4,6 +4,7 @@
   vars:
     workspace: "{{ lookup('env', 'WORKSPACE') }}"
     skip_rollback_test: "false"
+    fdo_credential: "false"
     total_counter: "0"
     failed_counter: "0"
 
@@ -43,6 +44,29 @@
 
     - set_fact:
         checking_stage: "{{ result_stage.stdout }}"
+
+    # case: check /boot/device-credentials exists
+    # simplified installer installed Edge system ONLY
+    - name: check /boot/device-credentials exists
+      stat:
+        path: /boot/device-credentials
+      register: stat_result
+
+    - name: check commit deployed and built
+      block:
+        - assert:
+            that:
+              - stat_result.stat.exists
+            fail_msg: "/boot/device-credentials does not exist"
+            success_msg: "/boot/device-credentials exists"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when: fdo_credential == "true"
 
     # case: check ostree commit correctly updated
     - name: get deployed ostree commit


### PR DESCRIPTION
1. Remove comment out code
2. Use three different IP address for different test scenarios
3. Move /boot/device-credentials file checking into playbook
4. Some shell script improvements