### PR TITLE
gitlab: split integration tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -330,16 +330,7 @@ Rebase OSTree:
           - rhos-01/rhel-9.0-nightly-x86_64-large
           - rhos-01/centos-stream-8-x86_64-large
 
-.INTEGRATION_TESTS: &INTEGRATION_TESTS
-  SCRIPT:
-    - koji.sh
-    - aws.sh
-    - azure.sh
-    - vmware.sh
-    - filesystem.sh
-    - cross-distro.sh
-
-Integration:
+.integration:
   stage: test
   extends: .terraform
   rules:
@@ -350,8 +341,7 @@ Integration:
     - /usr/libexec/tests/osbuild-composer/${SCRIPT}
   parallel:
     matrix:
-      - <<: *INTEGRATION_TESTS
-        RUNNER:
+      - RUNNER:
           - aws/fedora-34-x86_64
           - aws/fedora-35-x86_64
           - aws/centos-stream-8-x86_64
@@ -360,11 +350,36 @@ Integration:
           - aws/rhel-9.0-nightly-x86_64
           - aws/centos-stream-9-x86_64
         INTERNAL_NETWORK: ["true"]
-      - SCRIPT:
-          - azure_hyperv_gen2.sh
-        RUNNER:
-          - aws/rhel-8.6-nightly-x86_64
-        INTERNAL_NETWORK: ["true"]
+
+koji.sh:
+  extends: .integration
+  variables:
+    SCRIPT: koji.sh
+
+aws.sh:
+  extends: .integration
+  variables:
+    SCRIPT: aws.sh
+
+azure.sh:
+  extends: .integration
+  variables:
+    SCRIPT: azure.sh
+
+vmware.sh:
+  extends: .integration
+  variables:
+    SCRIPT: vmware.sh
+
+filesystem.sh:
+  extends: .integration
+  variables:
+    SCRIPT: filesystem.sh
+
+cross-distro.sh:
+  extends: .integration
+  variables:
+    SCRIPT: cross-distro.sh
 
 .API_TESTS: &API_TESTS
   IMAGE_TYPE:


### PR DESCRIPTION
We are running into a GitLab CI limitation:

jobs:integration:parallel:matrix config generates too many jobs (maximum is 50)

Let's split these jobs into separate ones.

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
