### PR TITLE
Worker dependency errors

### DIFF
--- a/internal/cloudapi/v2/errors.go
+++ b/internal/cloudapi/v2/errors.go
@@ -61,6 +61,7 @@ const (
 	ErrorGettingDepsolveJobStatus                 ServiceErrorCode = 1013
 	ErrorDepsolveJobCanceled                      ServiceErrorCode = 1014
 	ErrorUnexpectedNumberOfImageBuilds            ServiceErrorCode = 1015
+	ErrorGettingBuildDependencyStatus             ServiceErrorCode = 1016
 
 	// Errors contained within this file
 	ErrorUnspecified          ServiceErrorCode = 10000
@@ -126,6 +127,7 @@ func getServiceErrors() serviceErrors {
 		serviceError{ErrorGettingDepsolveJobStatus, http.StatusInternalServerError, "Unable to get depsolve job status"},
 		serviceError{ErrorDepsolveJobCanceled, http.StatusInternalServerError, "Depsolve job was cancelled"},
 		serviceError{ErrorUnexpectedNumberOfImageBuilds, http.StatusInternalServerError, "Compose has unexpected number of image builds"},
+		serviceError{ErrorGettingBuildDependencyStatus, http.StatusInternalServerError, "Error checking status of build job dependencies"},
 
 		serviceError{ErrorUnspecified, http.StatusInternalServerError, "Unspecified internal error "},
 		serviceError{ErrorNotHTTPError, http.StatusInternalServerError, "Error is not an instance of HTTPError"},

--- a/internal/cloudapi/v2/handler.go
+++ b/internal/cloudapi/v2/handler.go
@@ -605,7 +605,7 @@ func (h *apiHandlers) GetComposeStatus(ctx echo.Context, id string) error {
 			buildJobResults = append(buildJobResults, buildJobResult)
 			buildJobStatuses = append(buildJobStatuses, ImageStatus{
 				Status: imageStatusFromKojiJobStatus(buildJobStatus, &initResult, &buildJobResult),
-				Error:  composeStatusErrorFromJobError(result.JobError),
+				Error:  composeStatusErrorFromJobError(buildJobResult.JobError),
 			})
 		}
 		response := ComposeStatus{

--- a/internal/worker/clienterrors/errors.go
+++ b/internal/worker/clienterrors/errors.go
@@ -33,7 +33,7 @@ type ClientErrorCode int
 type Error struct {
 	ID      ClientErrorCode `json:"id"`
 	Reason  string          `json:"reason"`
-	Details interface{}     `json:"details"`
+	Details interface{}     `json:"details,omitempty"`
 }
 
 const (

--- a/internal/worker/clienterrors/errors.go
+++ b/internal/worker/clienterrors/errors.go
@@ -78,6 +78,17 @@ func GetStatusCode(err *Error) StatusCode {
 	}
 }
 
+func (e *Error) HasDependencyError() bool {
+	switch e.ID {
+	case ErrorDepsolveDependency:
+		return true
+	case ErrorManifestDependency:
+		return true
+	default:
+		return false
+	}
+}
+
 func WorkerClientError(code ClientErrorCode, reason string, details ...interface{}) *Error {
 	return &Error{
 		ID:      code,


### PR DESCRIPTION
This pull request includes:
- empty manifest error case for osbuild jobs
- empty packagespec error case for depsolve jobs with `4xx`
- query dependencies for errors if/when a build job fails and report failed dependencies
in build job result.

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
