### PR TITLE
Pin fedora repositories in Schutzfile + override mock templates with rpmrepo snapshots

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@ stages:
 .base:
   before_script:
     - schutzbot/ci_details.sh > ci-details-before-run
+    - cat schutzbot/team_ssh_keys.txt | tee -a ~/.ssh/authorized_keys > /dev/null
   after_script:
     - schutzbot/ci_details.sh > ci-details-after-run
     - schutzbot/update_github_status.sh update

--- a/Schutzfile
+++ b/Schutzfile
@@ -4,14 +4,154 @@
       "osbuild": {
         "commit": "d8f36b55fa043002c6650a75fbeba5165cc0824b"
       }
-    }
+    },
+    "repos": [
+      {
+        "file": "/etc/yum.repos.d/fedora.repo",
+        "x86_64": [
+          {
+            "title": "fedora",
+            "name": "fedora",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "fedora",
+            "name": "fedora",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512"
+          }
+        ]
+      },
+      {
+        "file": "/etc/yum.repos.d/fedora-modular.repo",
+        "x86_64": [
+          {
+            "title": "fedora-modular",
+            "name": "fedora-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-modular-20210512"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "fedora-modular",
+            "name": "fedora-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-modular-20210512"
+          }
+        ]
+      },
+      {
+        "file": "/etc/yum.repos.d/fedora-updates.repo",
+        "x86_64": [
+          {
+            "title": "updates",
+            "name": "updates",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220330"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "updates",
+            "name": "updates",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220330"
+          }
+        ]
+      },
+      {
+        "file": "/etc/yum.repos.d/fedora-updates-modular.repo",
+        "x86_64": [
+          {
+            "title": "updates-modular",
+            "name": "updates-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-modular-20220330"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "updates-modular",
+            "name": "updates-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-modular-20220330"
+          }
+        ]
+      }
+    ]
   },
   "fedora-35": {
     "dependencies": {
       "osbuild": {
         "commit": "d8f36b55fa043002c6650a75fbeba5165cc0824b"
       }
-    }
+    },
+    "repos": [
+      {
+        "file": "/etc/yum.repos.d/fedora.repo",
+        "x86_64": [
+          {
+            "title": "fedora",
+            "name": "fedora",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "fedora",
+            "name": "fedora",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106"
+          }
+        ]
+      },
+      {
+        "file": "/etc/yum.repos.d/fedora-modular.repo",
+        "x86_64": [
+          {
+            "title": "fedora-modular",
+            "name": "fedora-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-modular-20220106"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "fedora-modular",
+            "name": "fedora-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-modular-20220106"
+          }
+        ]
+      },
+      {
+        "file": "/etc/yum.repos.d/fedora-updates.repo",
+        "x86_64": [
+          {
+            "title": "updates",
+            "name": "updates",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220330"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "updates",
+            "name": "updates",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220330"
+          }
+        ]
+      },
+      {
+        "file": "/etc/yum.repos.d/fedora-updates-modular.repo",
+        "x86_64": [
+          {
+            "title": "updates-modular",
+            "name": "updates-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-modular-20220330"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "updates-modular",
+            "name": "updates-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-modular-20220330"
+          }
+        ]
+      }
+    ]
   },
   "rhel-8.4": {
     "dependencies": {

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -90,9 +90,6 @@ fi
 greenprint "Enabling fastestmirror to speed up dnf 🏎️"
 echo -e "fastestmirror=1" | sudo tee -a /etc/dnf/dnf.conf
 
-greenprint "Adding osbuild team ssh keys"
-cat schutzbot/team_ssh_keys.txt | tee -a ~/.ssh/authorized_keys > /dev/null
-
 # TODO: include this in the jenkins runner (and split test/target machines out)
 sudo dnf -y install jq
 

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -6,6 +6,36 @@ function greenprint {
   echo -e "\033[1;32m[$(date -Isecond)] ${1}\033[0m"
 }
 
+# function to override template respositores with system repositories which contain rpmrepos snapshots
+function template_override {
+    sudo dnf -y install jq
+    if sudo subscription-manager status; then
+        greenprint "📋 Running on subscribed RHEL machine, no mock template override done."
+        return 0
+    fi
+    if [[ "$ID" == rhel ]]; then
+        TEMPLATE=${ID}-${VERSION_ID%.*}.tpl
+        if [[ ${VERSION_ID%.*} == 8 ]]; then
+            sudo sed -i "s/config_opts\['redhat_subscription_required'\] = True/config_opts['redhat_subscription_required'] = False/" /etc/mock/templates/rhel-8.tpl
+        elif [[ ${VERSION_ID%.*} == 9 ]]; then
+            greenprint "📋 Inserting $ID-$VERSION_ID mock template"
+            sudo cp -r schutzbot/el9-mock-configs/* /etc/mock/
+        fi
+    elif [[ "$ID" == fedora ]]; then
+        TEMPLATE=fedora-branched.tpl
+    elif [[ "$ID" == centos ]]; then
+        TEMPLATE=${ID}-stream-${VERSION_ID}.tpl
+        STREAM=-stream
+    fi
+    greenprint "📋 Updating $ID-$VERSION_ID mock template with rpmrepo snapshot repositories"
+    REPOS=$(jq -r ."\"${ID}${STREAM:-}-${VERSION_ID}\".repos[].file" Schutzfile)
+    sudo sed -i '/user_agent/q' /etc/mock/templates/"$TEMPLATE"
+    for REPO in $REPOS; do
+        sudo cat "$REPO" | sudo tee -a /etc/mock/templates/"$TEMPLATE"
+    done
+    echo '"""' | sudo tee -a /etc/mock/templates/"$TEMPLATE"
+}
+
 # Get OS and architecture details.
 source tools/set-env-variables.sh
 
@@ -72,20 +102,8 @@ greenprint "🧬 Using mock config: ${MOCK_CONFIG}"
 greenprint "📦 SHA: ${COMMIT}"
 greenprint "📤 RPMS will be uploaded to: ${REPO_URL}"
 
-if [[ "$ID" == rhel && ${VERSION_ID%.*} == 8 ]] && ! sudo subscription-manager status; then
-    greenprint "📋 Updating RHEL 8 mock template with the latest nightly repositories"
-    # strip everything after line with # repos
-    sudo sed -i '/# repos/q' /etc/mock/templates/rhel-8.tpl
-    # remove the subscription check
-    sudo sed -i "s/config_opts\['redhat_subscription_required'\] = True/config_opts['redhat_subscription_required'] = False/" /etc/mock/templates/rhel-8.tpl
-    # reuse redhat.repo
-    cat /etc/yum.repos.d/rhel8internal.repo | sudo tee -a /etc/mock/templates/rhel-8.tpl > /dev/null
-    # We need triple quotes at the end of the template to mark the end of the repo list.
-    echo '"""' | sudo tee -a /etc/mock/templates/rhel-8.tpl
-elif [[ ${VERSION_ID%.*} == 9 ]]; then
-    greenprint "📋 Inserting EL9 mock templates"
-    sudo cp -r schutzbot/el9-mock-configs/* /etc/mock/
-fi
+# override template repositories
+template_override
 
 greenprint "🔧 Building source RPM"
 git archive --prefix "osbuild-composer-${COMMIT}/" --output "osbuild-composer-${COMMIT}.tar.gz" HEAD


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
