### PR TITLE
Empty manifest check for osbuild jobs

### DIFF
--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -283,6 +283,11 @@ func generateManifest(ctx context.Context, workers *worker.Server, depsolveJobID
 		return
 	}
 
+	if len(depsolveResults.PackageSpecs) == 0 {
+		jobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorEmptyPackageSpecs, "Received empty package specs")
+		return
+	}
+
 	manifest, err := imageType.Manifest(b, options, repos, depsolveResults.PackageSpecs, seed)
 	if err != nil {
 		reason := "Error generating manifest"

--- a/internal/worker/clienterrors/errors.go
+++ b/internal/worker/clienterrors/errors.go
@@ -21,10 +21,11 @@ const (
 	ErrorOldResultCompatible  ClientErrorCode = 18
 	ErrorEmptyManifest        ClientErrorCode = 19
 
-	ErrorDNFDepsolveError ClientErrorCode = 20
-	ErrorDNFMarkingErrors ClientErrorCode = 21
-	ErrorDNFOtherError    ClientErrorCode = 22
-	ErrorRPMMDError       ClientErrorCode = 23
+	ErrorDNFDepsolveError  ClientErrorCode = 20
+	ErrorDNFMarkingErrors  ClientErrorCode = 21
+	ErrorDNFOtherError     ClientErrorCode = 22
+	ErrorRPMMDError        ClientErrorCode = 23
+	ErrorEmptyPackageSpecs ClientErrorCode = 24
 )
 
 type ClientErrorCode int
@@ -67,6 +68,8 @@ func GetStatusCode(err *Error) StatusCode {
 	case ErrorDepsolveDependency:
 		return JobStatusUserInputError
 	case ErrorManifestDependency:
+		return JobStatusUserInputError
+	case ErrorEmptyPackageSpecs:
 		return JobStatusUserInputError
 	case ErrorEmptyManifest:
 		return JobStatusUserInputError

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -243,23 +243,6 @@ func (s *Server) DepsolveJobStatus(id uuid.UUID, result *DepsolveJobResult) (*Jo
 	return status, deps, nil
 }
 
-func (s *Server) ManifestByIdJobStatus(id uuid.UUID, result *ManifestJobByIDResult) (*JobStatus, []uuid.UUID, error) {
-	jobType, status, deps, err := s.jobStatus(id, result)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if jobType != "manifest-by-id" {
-		return nil, nil, fmt.Errorf("expected \"koji-init\", found %q job instead", jobType)
-	}
-
-	if result.JobError == nil && result.Error != "" {
-		result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorOldResultCompatible, result.Error)
-	}
-
-	return status, deps, nil
-}
-
 func (s *Server) ManifestJobStatus(id uuid.UUID, result *ManifestJobByIDResult) (*JobStatus, []uuid.UUID, error) {
 	jobType, status, deps, err := s.jobStatus(id, result)
 	if err != nil {

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -249,8 +249,8 @@ func (s *Server) ManifestJobStatus(id uuid.UUID, result *ManifestJobByIDResult) 
 		return nil, nil, err
 	}
 
-	if jobType != "manifest-job-by-id" {
-		return nil, nil, fmt.Errorf("expected \"manifest-job-by-id\", found %q job instead", jobType)
+	if jobType != "manifest-id-only" {
+		return nil, nil, fmt.Errorf("expected \"manifest-id-only\", found %q job instead", jobType)
 	}
 
 	return status, deps, nil


### PR DESCRIPTION
This pull request includes:
- empty manifest error case for osbuild jobs
- empty packagespec error case for depsolve jobs with `4xx`

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
