### PR TITLE
rhel85: specify a minimum root file system size

### DIFF
--- a/internal/distro/rhel85/partition_tables.go
+++ b/internal/distro/rhel85/partition_tables.go
@@ -41,6 +41,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
+				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -73,6 +74,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
+				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -97,6 +99,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 				Bootable: true,
 			},
 			{
+				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
 				Payload: &disk.Filesystem{
 					Type:         "xfs",
 					Mountpoint:   "/",
@@ -113,6 +116,7 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 		ExtraPadding: ExtraPaddingMBR,
 		Partitions: []disk.Partition{
 			{
+				Size:     2 * 1024 * 1024 * 1024, // 2 GiB
 				Bootable: true,
 				Payload: &disk.Filesystem{
 					Type:         "xfs",
@@ -139,6 +143,7 @@ var ec2BasePartitionTables = distro.BasePartitionTableMap{
 				UUID:     disk.BIOSBootPartitionUUID,
 			},
 			{
+				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -183,6 +188,7 @@ var ec2BasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
+				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -238,6 +244,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
+				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{
@@ -284,6 +291,7 @@ var edgeBasePartitionTables = distro.BasePartitionTableMap{
 				},
 			},
 			{
+				Size: 2 * 1024 * 1024 * 1024, // 2 GiB
 				Type: disk.FilesystemDataGUID,
 				UUID: disk.RootPartitionUUID,
 				Payload: &disk.Filesystem{


### PR DESCRIPTION
Specify a size for the root filesystem in the partition table, which basically equates to a minimum size. In reality all image types specify a larger image size and thus we enlarge the root file system to more than the specified size for plain layouts.

Does not change any existing manifests.

This also prepares the enablement of auto-LVM conversion, since in that case we need to have a size for the root file system specified.

Should fix the failing 8.5 test in #2412
