### PR TITLE
templates/packer: Rely on instance metadata to set region

### DIFF
--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/vector.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/vector.sh
@@ -4,6 +4,8 @@ source /tmp/cloud_init_vars
 
 echo "Writing vector config."
 
+REGION=$(curl -Ls http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
+
 sudo mkdir -p /etc/vector
 sudo tee /etc/vector/vector.toml > /dev/null << EOF
 [sources.journald]
@@ -13,6 +15,7 @@ exclude_units = ["vector.service"]
 [sinks.out]
 type = "aws_cloudwatch_logs"
 inputs = [ "journald" ]
+region = "${REGION}"
 endpoint = "${CLOUDWATCH_LOGS_ENDPOINT_URL}"
 group_name = "${CLOUDWATCH_LOG_GROUP}"
 stream_name = "worker_syslog_{{ host }}"


### PR DESCRIPTION
Vector 0.21 needs region set otherwise the healthcheck will
fail. Instead of explicitly setting the aws cloudwatch endpoint, just
set the region.

