### PR TITLE
Don't run unsupported tests on 8.6 and 9.0

### DIFF
--- a/test/cases/aws_s3.sh
+++ b/test/cases/aws_s3.sh
@@ -1,7 +1,19 @@
 #!/bin/bash
-set -euo pipefail
 
 source /usr/libexec/osbuild-composer-test/set-env-variables.sh
+
+if [ "${NIGHTLY:=false}" == "true" ]; then
+    case "${ID}-${VERSION_ID}" in
+        "rhel-8.6" | "rhel-9.0" )
+            echo "$0 is not enabled for ${ID}-${VERSION_ID} skipping..."
+            exit 0
+            ;;
+        *)
+            ;;
+    esac
+fi
+
+set -euo pipefail
 
 # Container image used for cloud provider CLI tools
 CONTAINER_IMAGE_CLOUD_TOOLS="quay.io/osbuild/cloud-tools:latest"

--- a/test/cases/gcp.sh
+++ b/test/cases/gcp.sh
@@ -7,9 +7,20 @@
 # that the package from blueprint was installed.
 #
 
-set -euo pipefail
-
 source /usr/libexec/osbuild-composer-test/set-env-variables.sh
+
+if [ "${NIGHTLY:=false}" == "true" ]; then
+    case "${ID}-${VERSION_ID}" in
+        "rhel-8.6" | "rhel-9.0" )
+            echo "$0 is not enabled for ${ID}-${VERSION_ID} skipping..."
+            exit 0
+            ;;
+        *)
+            ;;
+    esac
+fi
+
+set -euo pipefail
 
 # Colorful output.
 function greenprint {

--- a/test/cases/generic_s3.sh
+++ b/test/cases/generic_s3.sh
@@ -1,7 +1,19 @@
 #!/bin/bash
-set -euo pipefail
 
 source /usr/libexec/osbuild-composer-test/set-env-variables.sh
+
+if [ "${NIGHTLY:=false}" == "true" ]; then
+    case "${ID}-${VERSION_ID}" in
+        "rhel-8.6" | "rhel-9.0")
+            echo "$0 is not enabled for ${ID}-${VERSION_ID} skipping..."
+            exit 0
+            ;;
+        *)
+            ;;
+    esac
+fi
+
+set -euo pipefail
 
 # Container images for MinIO Server and Client
 CONTAINER_MINIO_CLIENT="quay.io/minio/mc:latest"


### PR DESCRIPTION
https://coreos.slack.com/archives/C0235DZB0DT/p1650536467098679?thread_ts=1650512166.141439&cid=C0235DZB0DT


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
