### PR TITLE
worker: add proxy support to worker

### DIFF
--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -123,7 +123,7 @@ func RequestAndRunJob(client *worker.Client, acceptedJobTypes []string, jobImpls
 
 func main() {
 	var config struct {
-		KojiServers map[string]struct {
+		Koji map[string]struct {
 			Kerberos *struct {
 				Principal string `toml:"principal"`
 				KeyTab    string `toml:"keytab"`
@@ -193,7 +193,7 @@ func main() {
 	_ = os.Mkdir(output, os.ModeDir)
 
 	kojiServers := make(map[string]koji.GSSAPICredentials)
-	for server, creds := range config.KojiServers {
+	for server, creds := range config.Koji {
 		if creds.Kerberos == nil {
 			// For now we only support Kerberos authentication.
 			continue

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -123,6 +123,9 @@ func RequestAndRunJob(client *worker.Client, acceptedJobTypes []string, jobImpls
 
 func main() {
 	var config struct {
+		Composer *struct {
+			Proxy string `toml:"proxy"`
+		}
 		Koji map[string]struct {
 			Kerberos *struct {
 				Principal string `toml:"principal"`
@@ -240,6 +243,11 @@ func main() {
 			clientSecret = strings.TrimSpace(string(cs))
 		}
 
+		proxy := ""
+		if config.Composer != nil && config.Composer.Proxy != "" {
+			proxy = config.Composer.Proxy
+		}
+
 		client, err = worker.NewClient(worker.ClientConfig{
 			BaseURL:      fmt.Sprintf("https://%s", address),
 			TlsConfig:    conf,
@@ -248,6 +256,7 @@ func main() {
 			ClientId:     config.Authentication.ClientId,
 			ClientSecret: clientSecret,
 			BasePath:     config.BasePath,
+			ProxyURL:     proxy,
 		})
 		if err != nil {
 			logrus.Fatalf("Error creating worker client: %v", err)
@@ -266,10 +275,16 @@ func main() {
 			}
 		}
 
+		proxy := ""
+		if config.Composer != nil && config.Composer.Proxy != "" {
+			proxy = config.Composer.Proxy
+		}
+
 		client, err = worker.NewClient(worker.ClientConfig{
 			BaseURL:   fmt.Sprintf("https://%s", address),
 			TlsConfig: conf,
 			BasePath:  config.BasePath,
+			ProxyURL:  proxy,
 		})
 		if err != nil {
 			logrus.Fatalf("Error creating worker client: %v", err)

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -157,7 +157,6 @@ func main() {
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [-unix] address\n", os.Args[0])
 		flag.PrintDefaults()
-		os.Exit(0)
 	}
 
 	flag.Parse()
@@ -165,6 +164,7 @@ func main() {
 	address := flag.Arg(0)
 	if address == "" {
 		flag.Usage()
+		os.Exit(2)
 	}
 
 	_, err := toml.DecodeFile(configFile, &config)

--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -149,7 +149,7 @@ func (c *Client) refreshAccessToken() error {
 		data.Set("client_secret", c.clientSecret)
 	}
 
-	resp, err := http.PostForm(c.oAuthURL, data)
+	resp, err := c.requester.PostForm(c.oAuthURL, data)
 	if err != nil {
 		return err
 	}

--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -38,6 +38,7 @@ type ClientConfig struct {
 	ClientId     string
 	ClientSecret string
 	BasePath     string
+	ProxyURL     string
 }
 
 type Job interface {
@@ -91,6 +92,17 @@ func NewClient(conf ClientConfig) (*Client, error) {
 
 	requester := &http.Client{}
 	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if conf.ProxyURL != "" {
+		proxyURL, err := url.Parse(conf.ProxyURL)
+		if err != nil {
+			return nil, err
+		}
+
+		transport.Proxy = func(request *http.Request) (*url.URL, error) {
+			return proxyURL, nil
+		}
+	}
+
 	if conf.TlsConfig != nil {
 		transport.TLSClientConfig = conf.TlsConfig
 	}

--- a/internal/worker/client_test.go
+++ b/internal/worker/client_test.go
@@ -1,0 +1,107 @@
+package worker_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/osbuild-composer/internal/distro"
+	"github.com/osbuild/osbuild-composer/internal/distro/test_distro"
+	"github.com/osbuild/osbuild-composer/internal/jobqueue/fsjobqueue"
+	"github.com/osbuild/osbuild-composer/internal/worker"
+)
+
+func TestOAuth(t *testing.T) {
+	tempdir, err := ioutil.TempDir("", "worker-tests-")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempdir)
+
+	q, err := fsjobqueue.New(tempdir)
+	require.NoError(t, err)
+	config := worker.Config{
+		ArtifactsDir: tempdir,
+		BasePath:     "/api/image-builder-worker/v1",
+	}
+	workerServer := worker.NewServer(nil, q, config)
+	handler := workerServer.Handler()
+
+	workSrv := httptest.NewServer(handler)
+	defer workSrv.Close()
+
+	/* Check that the worker supplies the access token  */
+	calls := 0
+	proxySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls == 0 {
+			require.Equal(t, "Bearer", r.Header.Get("Authorization"))
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		require.Equal(t, "Bearer accessToken!", r.Header.Get("Authorization"))
+		handler.ServeHTTP(w, r)
+	}))
+	defer proxySrv.Close()
+
+	offlineToken := "someOfflineToken"
+	/* Start oauth srv supplying the bearer token */
+	oauthSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls += 1
+		require.Equal(t, "POST", r.Method)
+		err = r.ParseForm()
+		require.NoError(t, err)
+
+		require.Equal(t, "refresh_token", r.FormValue("grant_type"))
+		require.Equal(t, "rhsm-api", r.FormValue("client_id"))
+		require.Equal(t, offlineToken, r.FormValue("refresh_token"))
+
+		bt := struct {
+			AccessToken string `json:"access_token"`
+		}{
+			"accessToken!",
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(bt)
+		require.NoError(t, err)
+	}))
+	defer oauthSrv.Close()
+
+	distroStruct := test_distro.New()
+	arch, err := distroStruct.GetArch(test_distro.TestArchName)
+	if err != nil {
+		t.Fatalf("error getting arch from distro: %v", err)
+	}
+	imageType, err := arch.GetImageType(test_distro.TestImageTypeName)
+	if err != nil {
+		t.Fatalf("error getting image type from arch: %v", err)
+	}
+	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, 0)
+	if err != nil {
+		t.Fatalf("error creating osbuild manifest: %v", err)
+	}
+
+	_, err = workerServer.EnqueueOSBuild(arch.Name(), &worker.OSBuildJob{Manifest: manifest}, "")
+	require.NoError(t, err)
+
+	client, err := worker.NewClient(worker.ClientConfig{
+		BaseURL:      proxySrv.URL,
+		TlsConfig:    nil,
+		ClientId:     "rhsm-api",
+		OfflineToken: offlineToken,
+		OAuthURL:     oauthSrv.URL,
+		BasePath:     "/api/image-builder-worker/v1",
+	})
+	require.NoError(t, err)
+	job, err := client.RequestJob([]string{"osbuild"}, arch.Name())
+	require.NoError(t, err)
+	r := strings.NewReader("artifact contents")
+	require.NoError(t, job.UploadArtifact("some-artifact", r))
+	c, err := job.Canceled()
+	require.False(t, c)
+}

--- a/internal/worker/proxy_test.go
+++ b/internal/worker/proxy_test.go
@@ -1,0 +1,86 @@
+package worker_test
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// Hop-by-hop headers. These are removed when sent to the backend.
+// http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
+var hopHeaders = []string{
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Te", // canonicalized version of "TE"
+	"Trailers",
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
+func delHopHeaders(header http.Header) {
+	for _, h := range hopHeaders {
+		header.Del(h)
+	}
+}
+
+func appendHostToXForwardHeader(header http.Header, host string) {
+	// If we aren't the first proxy retain prior
+	// X-Forwarded-For information as a comma+space
+	// separated list and fold multiple headers into one.
+	if prior, ok := header["X-Forwarded-For"]; ok {
+		host = strings.Join(prior, ", ") + ", " + host
+	}
+	header.Set("X-Forwarded-For", host)
+}
+
+// proxy is a simple http-only proxy implementation.
+// Don't use it in production. Also don't use it for https.
+type proxy struct {
+	// number of calls that were made through the proxy
+	calls int
+}
+
+func (p *proxy) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
+	p.calls++
+
+	if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
+		msg := "unsupported protocol scheme " + req.URL.Scheme
+		http.Error(wr, msg, http.StatusBadRequest)
+		return
+	}
+
+	client := &http.Client{}
+
+	//http: Request.RequestURI can't be set in client requests.
+	//http://golang.org/src/pkg/net/http/client.go
+	req.RequestURI = ""
+
+	delHopHeaders(req.Header)
+
+	if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+		appendHostToXForwardHeader(req.Header, clientIP)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		http.Error(wr, "Server Error", http.StatusInternalServerError)
+	}
+	defer resp.Body.Close()
+
+	delHopHeaders(resp.Header)
+
+	copyHeader(wr.Header(), resp.Header)
+	wr.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(wr, resp.Body)
+}

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -289,93 +287,6 @@ func TestUploadAlteredBasePath(t *testing.T) {
 	require.Nil(t, dynamicArgs)
 
 	test.TestRoute(t, handler, false, "PUT", fmt.Sprintf("/api/image-builder-worker/v1/jobs/%s/artifacts/foobar", token), `this is my artifact`, http.StatusOK, `?`)
-}
-
-func TestOAuth(t *testing.T) {
-	tempdir := t.TempDir()
-
-	q, err := fsjobqueue.New(tempdir)
-	require.NoError(t, err)
-	config := worker.Config{
-		ArtifactsDir: tempdir,
-		BasePath:     "/api/image-builder-worker/v1",
-	}
-	workerServer := worker.NewServer(nil, q, config)
-	handler := workerServer.Handler()
-
-	workSrv := httptest.NewServer(handler)
-	defer workSrv.Close()
-
-	/* Check that the worker supplies the access token  */
-	calls := 0
-	proxySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if calls == 0 {
-			require.Equal(t, "Bearer", r.Header.Get("Authorization"))
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-		require.Equal(t, "Bearer accessToken!", r.Header.Get("Authorization"))
-		handler.ServeHTTP(w, r)
-	}))
-	defer proxySrv.Close()
-
-	offlineToken := "someOfflineToken"
-	/* Start oauth srv supplying the bearer token */
-	oauthSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls += 1
-		require.Equal(t, "POST", r.Method)
-		err = r.ParseForm()
-		require.NoError(t, err)
-
-		require.Equal(t, "refresh_token", r.FormValue("grant_type"))
-		require.Equal(t, "rhsm-api", r.FormValue("client_id"))
-		require.Equal(t, offlineToken, r.FormValue("refresh_token"))
-
-		bt := struct {
-			AccessToken string `json:"access_token"`
-		}{
-			"accessToken!",
-		}
-
-		w.WriteHeader(http.StatusOK)
-		w.Header().Set("Content-Type", "application/json")
-		err = json.NewEncoder(w).Encode(bt)
-		require.NoError(t, err)
-	}))
-	defer oauthSrv.Close()
-
-	distroStruct := test_distro.New()
-	arch, err := distroStruct.GetArch(test_distro.TestArchName)
-	if err != nil {
-		t.Fatalf("error getting arch from distro: %v", err)
-	}
-	imageType, err := arch.GetImageType(test_distro.TestImageTypeName)
-	if err != nil {
-		t.Fatalf("error getting image type from arch: %v", err)
-	}
-	manifest, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, nil, 0)
-	if err != nil {
-		t.Fatalf("error creating osbuild manifest: %v", err)
-	}
-
-	_, err = workerServer.EnqueueOSBuild(arch.Name(), &worker.OSBuildJob{Manifest: manifest}, "")
-	require.NoError(t, err)
-
-	client, err := worker.NewClient(worker.ClientConfig{
-		BaseURL:      proxySrv.URL,
-		TlsConfig:    nil,
-		ClientId:     "rhsm-api",
-		OfflineToken: offlineToken,
-		OAuthURL:     oauthSrv.URL,
-		BasePath:     "/api/image-builder-worker/v1",
-	})
-	require.NoError(t, err)
-	job, err := client.RequestJob([]string{"osbuild"}, arch.Name())
-	require.NoError(t, err)
-	r := strings.NewReader("artifact contents")
-	require.NoError(t, job.UploadArtifact("some-artifact", r))
-	c, err := job.Canceled()
-	require.False(t, c)
 }
 
 func TestTimeout(t *testing.T) {


### PR DESCRIPTION
In the internal deployment, we want to talk with composer over a http/https proxy. This proxy adds new composer.proxy field to the worker config that causes the worker to connect to composer and the oauth server using a specified proxy.

NB: The proxy is not supported when connection to composer via unix sockets.

This PR also includes random improvements to the worker code but nothing major, just some things that I stumbled upon.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
