### PR TITLE
disk: fix ensureLVM for partition tables without /boot

### DIFF
--- a/internal/disk/disk_test.go
+++ b/internal/disk/disk_test.go
@@ -363,25 +363,26 @@ var testPartitionTables = map[string]PartitionTable{
 	},
 }
 
-var bp = []blueprint.FilesystemCustomization{
-	{
-		Mountpoint: "/",
-		MinSize:    10 * GiB,
+var testBlueprints = map[string][]blueprint.FilesystemCustomization{
+	"bp1": {
+		{
+			Mountpoint: "/",
+			MinSize:    10 * GiB,
+		},
+		{
+			Mountpoint: "/home",
+			MinSize:    20 * GiB,
+		},
+		{
+			Mountpoint: "/opt",
+			MinSize:    7 * GiB,
+		},
 	},
-	{
-		Mountpoint: "/home",
-		MinSize:    20 * GiB,
-	},
-	{
-		Mountpoint: "/opt",
-		MinSize:    7 * GiB,
-	},
-}
-
-var bp2 = []blueprint.FilesystemCustomization{
-	{
-		Mountpoint: "/opt",
-		MinSize:    7 * GiB,
+	"bp2": {
+		{
+			Mountpoint: "/opt",
+			MinSize:    7 * GiB,
+		},
 	},
 }
 
@@ -411,7 +412,7 @@ func TestCreatePartitionTable(t *testing.T) {
 	rng := rand.New(rand.NewSource(13))
 	for name := range testPartitionTables {
 		pt := testPartitionTables[name]
-		mpt, err := NewPartitionTable(&pt, bp, uint64(13*MiB), false, rng)
+		mpt, err := NewPartitionTable(&pt, testBlueprints["bp1"], uint64(13*MiB), false, rng)
 		assert.NoError(err, "Partition table generation failed: %s (%s)", name, err)
 		assert.NotNil(mpt, "Partition table generation failed: %s (nil partition table)", name)
 		assert.Greater(mpt.GetSize(), uint64(37*GiB))
@@ -428,8 +429,7 @@ func TestCreatePartitionTableLVMify(t *testing.T) {
 	// math/rand is good enough in this case
 	/* #nosec G404 */
 	rng := rand.New(rand.NewSource(13))
-	blueprints := [][]blueprint.FilesystemCustomization{bp, bp2}
-	for _, tbp := range blueprints {
+	for _, tbp := range testBlueprints {
 		for name := range testPartitionTables {
 			pt := testPartitionTables[name]
 

--- a/internal/disk/disk_test.go
+++ b/internal/disk/disk_test.go
@@ -9,6 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	KiB = 1024
+	MiB = 1024 * KiB
+	GiB = 1024 * MiB
+)
+
 func TestDisk_AlignUp(t *testing.T) {
 
 	pt := PartitionTable{}
@@ -35,7 +41,7 @@ func TestDisk_AlignUp(t *testing.T) {
 func TestDisk_DynamicallyResizePartitionTable(t *testing.T) {
 	mountpoints := []blueprint.FilesystemCustomization{
 		{
-			MinSize:    2147483648,
+			MinSize:    2 * GiB,
 			Mountpoint: "/usr",
 		},
 	}
@@ -63,7 +69,7 @@ func TestDisk_DynamicallyResizePartitionTable(t *testing.T) {
 			},
 		},
 	}
-	var expectedSize uint64 = 2147483648
+	var expectedSize uint64 = 2 * GiB
 	// math/rand is good enough in this case
 	/* #nosec G404 */
 	rng := rand.New(rand.NewSource(0))
@@ -78,13 +84,13 @@ var testPartitionTables = map[string]PartitionTable{
 		Type: "gpt",
 		Partitions: []Partition{
 			{
-				Size:     1048576, // 1MB
+				Size:     1 * MiB,
 				Bootable: true,
 				Type:     BIOSBootPartitionGUID,
 				UUID:     BIOSBootPartitionUUID,
 			},
 			{
-				Size: 209715200, // 200 MB
+				Size: 200 * MiB,
 				Type: EFISystemPartitionGUID,
 				UUID: EFISystemPartitionUUID,
 				Payload: &Filesystem{
@@ -98,7 +104,7 @@ var testPartitionTables = map[string]PartitionTable{
 				},
 			},
 			{
-				Size: 1024000, // 500 MB
+				Size: 500 * MiB,
 				Type: FilesystemDataGUID,
 				UUID: FilesystemDataUUID,
 				Payload: &Filesystem{
@@ -130,13 +136,13 @@ var testPartitionTables = map[string]PartitionTable{
 		Type: "gpt",
 		Partitions: []Partition{
 			{
-				Size:     1048576, // 1MB
+				Size:     1 * MiB,
 				Bootable: true,
 				Type:     BIOSBootPartitionGUID,
 				UUID:     BIOSBootPartitionUUID,
 			},
 			{
-				Size: 209715200, // 200 MB
+				Size: 200 * MiB,
 				Type: EFISystemPartitionGUID,
 				UUID: EFISystemPartitionUUID,
 				Payload: &Filesystem{
@@ -169,13 +175,13 @@ var testPartitionTables = map[string]PartitionTable{
 		Type: "gpt",
 		Partitions: []Partition{
 			{
-				Size:     1048576, // 1MB
+				Size:     1 * MiB,
 				Bootable: true,
 				Type:     BIOSBootPartitionGUID,
 				UUID:     BIOSBootPartitionUUID,
 			},
 			{
-				Size: 209715200, // 200 MB
+				Size: 200 * MiB,
 				Type: EFISystemPartitionGUID,
 				UUID: EFISystemPartitionUUID,
 				Payload: &Filesystem{
@@ -189,7 +195,7 @@ var testPartitionTables = map[string]PartitionTable{
 				},
 			},
 			{
-				Size: 1024000, // 500 MB
+				Size: 500 * MiB,
 				Type: FilesystemDataGUID,
 				UUID: FilesystemDataUUID,
 				Payload: &Filesystem{
@@ -224,13 +230,13 @@ var testPartitionTables = map[string]PartitionTable{
 		Type: "gpt",
 		Partitions: []Partition{
 			{
-				Size:     1048576, // 1MB
+				Size:     1 * MiB,
 				Bootable: true,
 				Type:     BIOSBootPartitionGUID,
 				UUID:     BIOSBootPartitionUUID,
 			},
 			{
-				Size: 209715200, // 200 MB
+				Size: 200 * MiB,
 				Type: EFISystemPartitionGUID,
 				UUID: EFISystemPartitionUUID,
 				Payload: &Filesystem{
@@ -244,7 +250,7 @@ var testPartitionTables = map[string]PartitionTable{
 				},
 			},
 			{
-				Size: 1024000, // 500 MB
+				Size: 500 * MiB,
 				Type: FilesystemDataGUID,
 				UUID: FilesystemDataUUID,
 				Payload: &Filesystem{
@@ -259,7 +265,7 @@ var testPartitionTables = map[string]PartitionTable{
 			{
 				Type: FilesystemDataGUID,
 				UUID: RootPartitionUUID,
-				Size: 5 * 1024 * 1024 * 1024,
+				Size: 5 * GiB,
 				Payload: &LUKSContainer{
 					UUID: "",
 					Payload: &LVMVolumeGroup{
@@ -267,7 +273,7 @@ var testPartitionTables = map[string]PartitionTable{
 						Description: "",
 						LogicalVolumes: []LVMLogicalVolume{
 							{
-								Size: 2 * 1024 * 1024 * 1024,
+								Size: 2 * GiB,
 								Payload: &Filesystem{
 									Type:         "xfs",
 									Label:        "root",
@@ -278,7 +284,7 @@ var testPartitionTables = map[string]PartitionTable{
 								},
 							},
 							{
-								Size: 2 * 1024 * 1024 * 1024,
+								Size: 2 * GiB,
 								Payload: &Filesystem{
 									Type:         "xfs",
 									Label:        "root",
@@ -299,13 +305,13 @@ var testPartitionTables = map[string]PartitionTable{
 		Type: "gpt",
 		Partitions: []Partition{
 			{
-				Size:     1048576, // 1MB
+				Size:     1 * MiB,
 				Bootable: true,
 				Type:     BIOSBootPartitionGUID,
 				UUID:     BIOSBootPartitionUUID,
 			},
 			{
-				Size: 209715200, // 200 MB
+				Size: 200 * MiB,
 				Type: EFISystemPartitionGUID,
 				UUID: EFISystemPartitionUUID,
 				Payload: &Filesystem{
@@ -319,7 +325,7 @@ var testPartitionTables = map[string]PartitionTable{
 				},
 			},
 			{
-				Size: 1024000, // 500 MB
+				Size: 500 * MiB,
 				Type: FilesystemDataGUID,
 				UUID: FilesystemDataUUID,
 				Payload: &Filesystem{
@@ -334,7 +340,7 @@ var testPartitionTables = map[string]PartitionTable{
 			{
 				Type: FilesystemDataGUID,
 				UUID: RootPartitionUUID,
-				Size: 10 * 1024 * 1024 * 1024,
+				Size: 10 * GiB,
 				Payload: &Btrfs{
 					UUID:       "",
 					Label:      "",
@@ -346,7 +352,7 @@ var testPartitionTables = map[string]PartitionTable{
 							GroupID:    0,
 						},
 						{
-							Size:       5 * 1024 * 1024 * 1024,
+							Size:       5 * GiB,
 							Mountpoint: "/var",
 							GroupID:    0,
 						},
@@ -360,22 +366,22 @@ var testPartitionTables = map[string]PartitionTable{
 var bp = []blueprint.FilesystemCustomization{
 	{
 		Mountpoint: "/",
-		MinSize:    10 * 1024 * 1024 * 1024,
+		MinSize:    10 * GiB,
 	},
 	{
 		Mountpoint: "/home",
-		MinSize:    20 * 1024 * 1024 * 1024,
+		MinSize:    20 * GiB,
 	},
 	{
 		Mountpoint: "/opt",
-		MinSize:    7 * 1024 * 1024 * 1024,
+		MinSize:    7 * GiB,
 	},
 }
 
 var bp2 = []blueprint.FilesystemCustomization{
 	{
 		Mountpoint: "/opt",
-		MinSize:    7 * 1024 * 1024 * 1024,
+		MinSize:    7 * GiB,
 	},
 }
 
@@ -405,10 +411,10 @@ func TestCreatePartitionTable(t *testing.T) {
 	rng := rand.New(rand.NewSource(13))
 	for name := range testPartitionTables {
 		pt := testPartitionTables[name]
-		mpt, err := NewPartitionTable(&pt, bp, uint64(13*1024*1024), false, rng)
+		mpt, err := NewPartitionTable(&pt, bp, uint64(13*MiB), false, rng)
 		assert.NoError(err, "Partition table generation failed: %s (%s)", name, err)
 		assert.NotNil(mpt, "Partition table generation failed: %s (nil partition table)", name)
-		assert.Greater(mpt.GetSize(), uint64(37*1024*1024*1024))
+		assert.Greater(mpt.GetSize(), uint64(37*GiB))
 
 		assert.NotNil(mpt.Type, "Partition table generation failed: %s (nil partition table type)", name)
 
@@ -429,12 +435,12 @@ func TestCreatePartitionTableLVMify(t *testing.T) {
 
 			if name == "btrfs" || name == "luks" {
 				assert.Panics(func() {
-					_, _ = NewPartitionTable(&pt, tbp, uint64(13*1024*1024), true, rng)
+					_, _ = NewPartitionTable(&pt, tbp, uint64(13*MiB), true, rng)
 				})
 				continue
 			}
 
-			mpt, err := NewPartitionTable(&pt, tbp, uint64(13*1024*1024), true, rng)
+			mpt, err := NewPartitionTable(&pt, tbp, uint64(13*MiB), true, rng)
 			assert.NoError(err, "Partition table generation failed: %s (%s)", name, err)
 
 			rootPath := entityPath(mpt, "/")
@@ -587,7 +593,6 @@ func TestFindDirectoryPartition(t *testing.T) {
 func TestEnsureDirectorySizes(t *testing.T) {
 	assert := assert.New(t)
 
-	GiB := 1024 * 1024 * 1024
 	varSizes := map[string]uint64{
 		"/var/lib":         uint64(3 * GiB),
 		"/var/cache":       uint64(2 * GiB),

--- a/internal/disk/partition_table.go
+++ b/internal/disk/partition_table.go
@@ -38,6 +38,12 @@ func NewPartitionTable(basePT *PartitionTable, mountpoints []blueprint.Filesyste
 		}
 	}
 
+	// TODO: make these overrideable for each image type
+	newPT.EnsureDirectorySizes(map[string]uint64{
+		"/":    1073741824,
+		"/usr": 2147483648,
+	})
+
 	// Calculate partition table offsets and sizes
 	newPT.relayout(imageSize)
 

--- a/internal/disk/partition_table.go
+++ b/internal/disk/partition_table.go
@@ -529,7 +529,12 @@ func (pt *PartitionTable) ensureLVM() error {
 	bootPath := entityPath(pt, "/boot")
 	if bootPath == nil {
 		_, err := pt.CreateMountpoint("/boot", 512*1024*1024)
-		return err
+
+		if err != nil {
+			return err
+		}
+
+		rootPath = entityPath(pt, "/")
 	}
 
 	parent := rootPath[1] // NB: entityPath has reversed order

--- a/internal/disk/partition_table.go
+++ b/internal/disk/partition_table.go
@@ -468,12 +468,6 @@ func (pt *PartitionTable) FindMountable(mountpoint string) Mountable {
 func clampFSSize(mountpoint string, size uint64) uint64 {
 	// set a minimum size of 1GB for all mountpoints
 	var minSize uint64 = 1073741824
-	if mountpoint == "/usr" {
-		// set a minimum size of 2GB for `/usr` mountpoint
-		// since this is current behaviour and the minimum
-		// required to create a bootable image
-		minSize = 2147483648
-	}
 	if minSize > size {
 		return minSize
 	}

--- a/test/cases/generation.sh
+++ b/test/cases/generation.sh
@@ -37,4 +37,5 @@ sudo ./tools/test-case-generators/generate-test-cases\
     --arch x86_64\
     --distro rhel-8\
     --image-type qcow2\
-    --store "$WORKDIR"
+    --store "$WORKDIR"\
+    --keep-image-info

--- a/test/data/manifests/centos_8-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-aarch64-qcow2_customize-boot.json
@@ -88,7 +88,13 @@
           "disabled": [
             "bluetooth.service"
           ]
-        }
+        },
+        "filesystem": [
+          {
+            "mountpoint": "/opt",
+            "minsize": 1073741824
+          }
+        ]
       }
     }
   },
@@ -2452,7 +2458,31 @@
                     }
                   },
                   {
+                    "id": "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3380,6 +3410,14 @@
                     }
                   },
                   {
+                    "id": "sha256:3bcb1ade26c217ead2da81c92b7ef78026c4a78383d28b6e825a7b840cae97fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:791e9574c613eed49b92680ff89cf786f7f3d7bac52bc5427b72b2ea5058dfab",
                     "options": {
                       "metadata": {
@@ -4181,6 +4219,22 @@
                   },
                   {
                     "id": "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5759,7 +5813,9 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {}
+            "options": {
+              "prefix": ""
+            }
           },
           {
             "type": "org.osbuild.locale",
@@ -5864,6 +5920,18 @@
                   "options": "defaults"
                 },
                 {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
                   "uuid": "7B77-95E7",
                   "vfs_type": "vfat",
                   "path": "/boot/efi",
@@ -5877,6 +5945,7 @@
             "type": "org.osbuild.grub2",
             "options": {
               "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "boot_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug",
               "uefi": {
                 "vendor": "centos"
@@ -5919,10 +5988,16 @@
                   "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
                 },
                 {
-                  "size": 20764639,
-                  "start": 206848,
-                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "size": 19716063,
+                  "start": 1255424,
+                  "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                },
+                {
+                  "size": 1048576,
+                  "start": 206848,
+                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                  "uuid": "a178892e-e285-4ce1-9114-55780875d64e"
                 }
               ]
             },
@@ -5931,6 +6006,32 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.lvm2.create",
+            "options": {
+              "volumes": [
+                {
+                  "name": "rootlv",
+                  "size": "3221225472B"
+                },
+                {
+                  "name": "optlv",
+                  "size": "1073741824B"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1255424,
+                  "size": 19716063,
                   "lock": true
                 }
               }
@@ -5961,11 +6062,59 @@
             },
             "devices": {
               "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1255424,
+                  "size": 19716063,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1255424,
+                  "size": 19716063,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+            },
+            "devices": {
+              "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
                   "start": 206848,
-                  "size": 20764639,
+                  "size": 1048576,
                   "lock": true
                 }
               }
@@ -5991,6 +6140,14 @@
               ]
             },
             "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 206848,
+                  "size": 1048576
+                }
+              },
               "boot.efi": {
                 "type": "org.osbuild.loopback",
                 "options": {
@@ -5999,12 +6156,26 @@
                   "size": 204800
                 }
               },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
               "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 206848,
-                  "size": 20764639
+                  "start": 1255424,
+                  "size": 19716063
                 }
               }
             },
@@ -6016,12 +6187,41 @@
                 "target": "/"
               },
               {
+                "name": "boot",
+                "type": "org.osbuild.xfs",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
                 "name": "boot.efi",
                 "type": "org.osbuild.fat",
                 "source": "boot.efi",
                 "target": "/boot/efi"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
+          },
+          {
+            "type": "org.osbuild.lvm2.metadata",
+            "options": {
+              "vg_name": "rootvg"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1255424,
+                  "size": 19716063,
+                  "lock": true
+                }
+              }
+            }
           }
         ]
       },
@@ -10404,6 +10604,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:f8f8ef964d4ec1a1658495c03e7e20e646f1b31f1783d9df3fe907b0be608eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:2421200cebe64b29ac142e2205ca2bac748b67db60d1a96518aa40484f1a67a4",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -10411,6 +10631,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:6caee334370e41d5b836663ceb6167c12f6278063a3b4d663a0fe43abbaa4dbd",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:feafe31bdf5b647d4fe5bbbd1a8e55c750be2f966b20931ad3eda95649897113",
         "check_gpg": true
       },
       {
@@ -11564,6 +11794,16 @@
         "check_gpg": true
       },
       {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.112",
+        "release": "1.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/libaio-0.3.112-1.el8.aarch64.rpm",
+        "checksum": "sha256:3bcb1ade26c217ead2da81c92b7ef78026c4a78383d28b6e825a7b840cae97fa",
+        "check_gpg": true
+      },
+      {
         "name": "libappstream-glib",
         "epoch": 0,
         "version": "0.7.14",
@@ -12571,6 +12811,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:2ef9801e4453de316429be284d4f6cb12f4d7662e7c6224dbf2341e3cfc5fab6",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:31395864c2794678b8a118e8b3ec9752df2fa57240ae8d27f857f7a55ce0d2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:545cc4c983498d5e98041123fc478a3ed37133df1b1191182c9038ec4e3ac539",
         "check_gpg": true
       },
       {
@@ -14538,8 +14798,8 @@
         "grub_class": "kernel",
         "grub_users": "$grub_users",
         "id": "centos-20220110131320-0-rescue-ffffffffffffffffffffffffffffffff",
-        "initrd": "/boot/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
-        "linux": "/boot/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff",
+        "initrd": "/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
+        "linux": "/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff",
         "options": "$kernelopts",
         "title": "CentOS Stream (0-rescue-ffffffffffffffffffffffffffffffff) 8",
         "version": "0-rescue-ffffffffffffffffffffffffffffffff"
@@ -14549,8 +14809,8 @@
         "grub_class": "kernel",
         "grub_users": "$grub_users",
         "id": "centos-20220110131320-4.18.0-358.el8.aarch64",
-        "initrd": "/boot/initramfs-4.18.0-358.el8.aarch64.img $tuned_initrd",
-        "linux": "/boot/vmlinuz-4.18.0-358.el8.aarch64",
+        "initrd": "/initramfs-4.18.0-358.el8.aarch64.img $tuned_initrd",
+        "linux": "/vmlinuz-4.18.0-358.el8.aarch64",
         "options": "$kernelopts $tuned_params",
         "title": "CentOS Stream (4.18.0-358.el8.aarch64) 8",
         "version": "4.18.0-358.el8.aarch64"
@@ -14732,12 +14992,28 @@
         "0"
       ],
       [
+        "UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+        "/opt",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
+      ],
+      [
         "UUID=7B77-95E7",
         "/boot/efi",
         "vfat",
         "defaults,uid=0,gid=0,umask=077,shortname=winnt",
         "0",
         "2"
+      ],
+      [
+        "UUID=fb180daf-48a7-4ee0-b10d-394651850fd4",
+        "/boot",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
       ]
     ],
     "groups": [
@@ -14892,7 +15168,10 @@
       "dejavu-fonts-common-2.35-7.el8.noarch",
       "dejavu-sans-mono-fonts-2.35-7.el8.noarch",
       "device-mapper-1.02.181-3.el8.aarch64",
+      "device-mapper-event-1.02.181-3.el8.aarch64",
+      "device-mapper-event-libs-1.02.181-3.el8.aarch64",
       "device-mapper-libs-1.02.181-3.el8.aarch64",
+      "device-mapper-persistent-data-0.9.0-6.el8.aarch64",
       "dhcp-client-4.3.6-47.el8.0.1.aarch64",
       "dhcp-common-4.3.6-47.el8.0.1.noarch",
       "dhcp-libs-4.3.6-47.el8.0.1.aarch64",
@@ -15017,6 +15296,7 @@
       "libXext-1.3.4-1.el8.aarch64",
       "libXrender-0.9.10-7.el8.aarch64",
       "libacl-2.2.53-1.el8.aarch64",
+      "libaio-0.3.112-1.el8.aarch64",
       "libappstream-glib-0.7.14-3.el8.aarch64",
       "libarchive-3.3.3-3.el8_5.aarch64",
       "libassuan-2.5.1-3.el8.aarch64",
@@ -15123,6 +15403,8 @@
       "lshw-B.02.19.2-6.el8.aarch64",
       "lsscsi-0.32-3.el8.aarch64",
       "lua-libs-5.3.4-12.el8.aarch64",
+      "lvm2-2.03.14-3.el8.aarch64",
+      "lvm2-libs-2.03.14-3.el8.aarch64",
       "lz4-libs-1.8.3-3.el8_4.aarch64",
       "lzo-2.08-14.el8.aarch64",
       "man-db-2.7.6.1-18.el8.aarch64",
@@ -15302,13 +15584,27 @@
     "partitions": [
       {
         "bootable": false,
-        "fstype": "xfs",
-        "label": "root",
+        "fstype": "LVM2_member",
+        "label": null,
+        "lvm": true,
+        "lvm.vg": "rootvg",
+        "lvm.volumes": {
+          "optlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+          },
+          "rootlv": {
+            "fstype": "xfs",
+            "label": "root",
+            "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+          }
+        },
         "partuuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
-        "size": 10631495168,
-        "start": 105906176,
-        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-        "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+        "size": 10094624256,
+        "start": 642777088,
+        "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+        "uuid": "CPBxYA-Ffa5-41wc-eWnn-Nggm-VN0A-6GNpa9"
       },
       {
         "bootable": false,
@@ -15319,6 +15615,16 @@
         "start": 1048576,
         "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
         "uuid": "7B77-95E7"
+      },
+      {
+        "bootable": false,
+        "fstype": "xfs",
+        "label": null,
+        "partuuid": "A178892E-E285-4CE1-9114-55780875D64E",
+        "size": 536870912,
+        "start": 105906176,
+        "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+        "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
       }
     ],
     "passwd": [
@@ -15381,6 +15687,7 @@
     },
     "services-disabled": [
       "arp-ethers.service",
+      "blk-availability.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
       "cockpit.socket",
@@ -15439,6 +15746,7 @@
       "dbus-org.fedoraproject.FirewallD1.service",
       "dbus-org.freedesktop.nm-dispatcher.service",
       "dbus-org.freedesktop.timedate1.service",
+      "dm-event.socket",
       "dnf-makecache.timer",
       "firewalld.service",
       "getty@.service",
@@ -15446,6 +15754,8 @@
       "irqbalance.service",
       "kdump.service",
       "loadmodules.service",
+      "lvm2-lvmpolld.socket",
+      "lvm2-monitor.service",
       "nfs-client.target",
       "nis-domainname.service",
       "qemu-guest-agent.service",
@@ -15624,6 +15934,10 @@
         ],
         "libselinux.conf": [
           "d /run/setrans 0755 root root"
+        ],
+        "lvm2.conf": [
+          "d /run/lock/lvm 0700 root root -",
+          "d /run/lvm 0700 root root -"
         ],
         "man-db.conf": [
           "d /var/cache/man 0755 root root 1w"

--- a/test/data/manifests/centos_8-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-ppc64le-qcow2_customize-boot.json
@@ -88,7 +88,13 @@
           "disabled": [
             "bluetooth.service"
           ]
-        }
+        },
+        "filesystem": [
+          {
+            "mountpoint": "/opt",
+            "minsize": 1073741824
+          }
+        ]
       }
     }
   },
@@ -2500,7 +2506,31 @@
                     }
                   },
                   {
+                    "id": "sha256:6b897357e022602a5a5c15910ee7b6f9acb7a100ea3e11fbe63552215109b862",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:136916d6ce7b0320af5b5f7e4f60b7b8878097a928c062b09632783432887019",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3c1e923ff80b166ff14022502aeeec2125160495961e50e349e610f8282fe63d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:565fcd17f9a518079f39a9dbad051efd12a69d2f83a06dabab666ee610597fb1",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3396,6 +3426,14 @@
                     }
                   },
                   {
+                    "id": "sha256:3303f41952491bad2b31ee507eaabaf13dabe5ec9624c4b58a4a8301c4cd89dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:e778fc7e5d62fe488e250a1916cdb7f692e98e23d0c2b4264672b2574ff416e5",
                     "options": {
                       "metadata": {
@@ -4229,6 +4267,22 @@
                   },
                   {
                     "id": "sha256:e25d8b411317be99b4db057a6eb1a536866458cb16a51dec1b8eea550bbc2e8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cffdd3a0187e37f64f4d8f7e94ea55f17029cf89988d9bf4303590b168075d74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc1db576d1c7580fcbb40d0c58d5d0b6c684cf85acaa0beb30786f4efa5dff6d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6167,7 +6221,9 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {}
+            "options": {
+              "prefix": ""
+            }
           },
           {
             "type": "org.osbuild.locale",
@@ -6270,6 +6326,18 @@
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
+                },
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
+                  "options": "defaults"
                 }
               ]
             }
@@ -6278,6 +6346,7 @@
             "type": "org.osbuild.grub2",
             "options": {
               "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "boot_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug",
               "legacy": "powerpc-ieee1275",
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-358.el8.ppc64le",
@@ -6318,7 +6387,12 @@
                   "type": "41"
                 },
                 {
-                  "size": 20961280,
+                  "size": 19912704,
+                  "start": 1058816,
+                  "type": "8e"
+                },
+                {
+                  "size": 1048576,
                   "start": 10240
                 }
               ]
@@ -6334,9 +6408,83 @@
             }
           },
           {
+            "type": "org.osbuild.lvm2.create",
+            "options": {
+              "volumes": [
+                {
+                  "name": "rootlv",
+                  "size": "3221225472B"
+                },
+                {
+                  "name": "optlv",
+                  "size": "1073741824B"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1058816,
+                  "size": 19912704,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1058816,
+                  "size": 19912704,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1058816,
+                  "size": 19912704,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
             },
             "devices": {
               "device": {
@@ -6344,7 +6492,7 @@
                 "options": {
                   "filename": "disk.img",
                   "start": 10240,
-                  "size": 20961280,
+                  "size": 1048576,
                   "lock": true
                 }
               }
@@ -6370,12 +6518,34 @@
               ]
             },
             "devices": {
-              "root": {
+              "boot": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
                   "start": 10240,
-                  "size": 20961280
+                  "size": 1048576
+                }
+              },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1058816,
+                  "size": 19912704
                 }
               }
             },
@@ -6385,8 +6555,37 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.xfs",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
+          },
+          {
+            "type": "org.osbuild.lvm2.metadata",
+            "options": {
+              "vg_name": "rootvg"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1058816,
+                  "size": 19912704,
+                  "lock": true
+                }
+              }
+            }
           },
           {
             "type": "org.osbuild.grub2.inst",
@@ -6402,8 +6601,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "dos",
-                "number": 1,
-                "path": "/boot/grub2"
+                "number": 2,
+                "path": "/grub2"
               }
             }
           }
@@ -10983,6 +11182,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.ppc64le.rpm",
+        "checksum": "sha256:6b897357e022602a5a5c15910ee7b6f9acb7a100ea3e11fbe63552215109b862",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.ppc64le.rpm",
+        "checksum": "sha256:136916d6ce7b0320af5b5f7e4f60b7b8878097a928c062b09632783432887019",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -10990,6 +11209,16 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.ppc64le.rpm",
         "checksum": "sha256:3c1e923ff80b166ff14022502aeeec2125160495961e50e349e610f8282fe63d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.ppc64le.rpm",
+        "checksum": "sha256:565fcd17f9a518079f39a9dbad051efd12a69d2f83a06dabab666ee610597fb1",
         "check_gpg": true
       },
       {
@@ -12103,6 +12332,16 @@
         "check_gpg": true
       },
       {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.112",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/libaio-0.3.112-1.el8.ppc64le.rpm",
+        "checksum": "sha256:3303f41952491bad2b31ee507eaabaf13dabe5ec9624c4b58a4a8301c4cd89dd",
+        "check_gpg": true
+      },
+      {
         "name": "libappstream-glib",
         "epoch": 0,
         "version": "0.7.14",
@@ -13150,6 +13389,26 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.ppc64le.rpm",
         "checksum": "sha256:e25d8b411317be99b4db057a6eb1a536866458cb16a51dec1b8eea550bbc2e8b",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lvm2-2.03.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:cffdd3a0187e37f64f4d8f7e94ea55f17029cf89988d9bf4303590b168075d74",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-ppc64le-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:fc1db576d1c7580fcbb40d0c58d5d0b6c684cf85acaa0beb30786f4efa5dff6d",
         "check_gpg": true
       },
       {
@@ -15593,8 +15852,8 @@
         "grub_class": "kernel",
         "grub_users": "$grub_users",
         "id": "centos-20220110135343-0-rescue-ffffffffffffffffffffffffffffffff",
-        "initrd": "/boot/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
-        "linux": "/boot/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff",
+        "initrd": "/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
+        "linux": "/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff",
         "options": "$kernelopts",
         "title": "CentOS Stream (0-rescue-ffffffffffffffffffffffffffffffff) 8",
         "version": "0-rescue-ffffffffffffffffffffffffffffffff"
@@ -15604,8 +15863,8 @@
         "grub_class": "kernel",
         "grub_users": "$grub_users",
         "id": "centos-20220110135343-4.18.0-358.el8.ppc64le",
-        "initrd": "/boot/initramfs-4.18.0-358.el8.ppc64le.img $tuned_initrd",
-        "linux": "/boot/vmlinuz-4.18.0-358.el8.ppc64le",
+        "initrd": "/initramfs-4.18.0-358.el8.ppc64le.img $tuned_initrd",
+        "linux": "/vmlinuz-4.18.0-358.el8.ppc64le",
         "options": "$kernelopts $tuned_params",
         "title": "CentOS Stream (4.18.0-358.el8.ppc64le) 8",
         "version": "4.18.0-358.el8.ppc64le"
@@ -15785,6 +16044,22 @@
         "defaults",
         "0",
         "0"
+      ],
+      [
+        "UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+        "/opt",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
+      ],
+      [
+        "UUID=fb180daf-48a7-4ee0-b10d-394651850fd4",
+        "/boot",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
       ]
     ],
     "groups": [
@@ -15940,7 +16215,10 @@
       "dejavu-fonts-common-2.35-7.el8.noarch",
       "dejavu-sans-mono-fonts-2.35-7.el8.noarch",
       "device-mapper-1.02.181-3.el8.ppc64le",
+      "device-mapper-event-1.02.181-3.el8.ppc64le",
+      "device-mapper-event-libs-1.02.181-3.el8.ppc64le",
       "device-mapper-libs-1.02.181-3.el8.ppc64le",
+      "device-mapper-persistent-data-0.9.0-6.el8.ppc64le",
       "dhcp-client-4.3.6-47.el8.0.1.ppc64le",
       "dhcp-common-4.3.6-47.el8.0.1.noarch",
       "dhcp-libs-4.3.6-47.el8.0.1.ppc64le",
@@ -16061,6 +16339,7 @@
       "libXext-1.3.4-1.el8.ppc64le",
       "libXrender-0.9.10-7.el8.ppc64le",
       "libacl-2.2.53-1.el8.ppc64le",
+      "libaio-0.3.112-1.el8.ppc64le",
       "libappstream-glib-0.7.14-3.el8.ppc64le",
       "libarchive-3.3.3-3.el8_5.ppc64le",
       "libassuan-2.5.1-3.el8.ppc64le",
@@ -16171,6 +16450,8 @@
       "lsscsi-0.32-3.el8.ppc64le",
       "lsvpd-1.7.13-1.el8.ppc64le",
       "lua-libs-5.3.4-12.el8.ppc64le",
+      "lvm2-2.03.14-3.el8.ppc64le",
+      "lvm2-libs-2.03.14-3.el8.ppc64le",
       "lz4-libs-1.8.3-3.el8_4.ppc64le",
       "lzo-2.08-14.el8.ppc64le",
       "man-db-2.7.6.1-18.el8.ppc64le",
@@ -16405,13 +16686,37 @@
       },
       {
         "bootable": false,
+        "fstype": "LVM2_member",
+        "label": null,
+        "lvm": true,
+        "lvm.vg": "rootvg",
+        "lvm.volumes": {
+          "optlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+          },
+          "rootlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+          }
+        },
+        "partuuid": "14fc63d2-02",
+        "size": 10195304448,
+        "start": 542113792,
+        "type": "8e",
+        "uuid": "eKvFzA-Ojwe-gR2X-plM6-2kb5-OHCe-Ya3tQ3"
+      },
+      {
+        "bootable": false,
         "fstype": "xfs",
         "label": null,
-        "partuuid": "14fc63d2-02",
-        "size": 10732175360,
+        "partuuid": "14fc63d2-03",
+        "size": 536870912,
         "start": 5242880,
         "type": "83",
-        "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+        "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
       }
     ],
     "passwd": [
@@ -16467,6 +16772,7 @@
     },
     "services-disabled": [
       "arp-ethers.service",
+      "blk-availability.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
       "cockpit.socket",
@@ -16526,6 +16832,7 @@
       "dbus-org.fedoraproject.FirewallD1.service",
       "dbus-org.freedesktop.nm-dispatcher.service",
       "dbus-org.freedesktop.timedate1.service",
+      "dm-event.socket",
       "dnf-makecache.timer",
       "firewalld.service",
       "getty@.service",
@@ -16534,6 +16841,8 @@
       "irqbalance.service",
       "kdump.service",
       "loadmodules.service",
+      "lvm2-lvmpolld.socket",
+      "lvm2-monitor.service",
       "nfs-client.target",
       "nis-domainname.service",
       "opal-prd.service",
@@ -16715,6 +17024,10 @@
         ],
         "libselinux.conf": [
           "d /run/setrans 0755 root root"
+        ],
+        "lvm2.conf": [
+          "d /run/lock/lvm 0700 root root -",
+          "d /run/lvm 0700 root root -"
         ],
         "man-db.conf": [
           "d /var/cache/man 0755 root root 1w"

--- a/test/data/manifests/centos_8-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_8-x86_64-qcow2_customize-boot.json
@@ -88,7 +88,13 @@
           "disabled": [
             "bluetooth.service"
           ]
-        }
+        },
+        "filesystem": [
+          {
+            "mountpoint": "/opt",
+            "minsize": 1073741824
+          }
+        ]
       }
     }
   },
@@ -2524,7 +2530,31 @@
                     }
                   },
                   {
+                    "id": "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3468,6 +3498,14 @@
                     }
                   },
                   {
+                    "id": "sha256:2c63399bee449fb6e921671a9bbf3356fda73f890b578820f7d926202e98a479",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:230820d3f9dbaa9dcd013836f4ba56d0514946bc05cac7727ef2aaff3a3dde26",
                     "options": {
                       "metadata": {
@@ -4269,6 +4307,22 @@
                   },
                   {
                     "id": "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5855,7 +5909,9 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {}
+            "options": {
+              "prefix": ""
+            }
           },
           {
             "type": "org.osbuild.locale",
@@ -5960,6 +6016,18 @@
                   "options": "defaults"
                 },
                 {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
                   "uuid": "7B77-95E7",
                   "vfs_type": "vfat",
                   "path": "/boot/efi",
@@ -5973,6 +6041,7 @@
             "type": "org.osbuild.grub2",
             "options": {
               "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "boot_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug",
               "legacy": "i386-pc",
               "uefi": {
@@ -6023,10 +6092,16 @@
                   "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
                 },
                 {
-                  "size": 20762591,
-                  "start": 208896,
-                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "size": 19714015,
+                  "start": 1257472,
+                  "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                },
+                {
+                  "size": 1048576,
+                  "start": 208896,
+                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                  "uuid": "a178892e-e285-4ce1-9114-55780875d64e"
                 }
               ]
             },
@@ -6035,6 +6110,32 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.lvm2.create",
+            "options": {
+              "volumes": [
+                {
+                  "name": "rootlv",
+                  "size": "3221225472B"
+                },
+                {
+                  "name": "optlv",
+                  "size": "1073741824B"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1257472,
+                  "size": 19714015,
                   "lock": true
                 }
               }
@@ -6065,11 +6166,59 @@
             },
             "devices": {
               "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1257472,
+                  "size": 19714015,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1257472,
+                  "size": 19714015,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+            },
+            "devices": {
+              "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
                   "start": 208896,
-                  "size": 20762591,
+                  "size": 1048576,
                   "lock": true
                 }
               }
@@ -6095,6 +6244,14 @@
               ]
             },
             "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 208896,
+                  "size": 1048576
+                }
+              },
               "boot.efi": {
                 "type": "org.osbuild.loopback",
                 "options": {
@@ -6103,12 +6260,26 @@
                   "size": 204800
                 }
               },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
               "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 208896,
-                  "size": 20762591
+                  "start": 1257472,
+                  "size": 19714015
                 }
               }
             },
@@ -6120,12 +6291,41 @@
                 "target": "/"
               },
               {
+                "name": "boot",
+                "type": "org.osbuild.xfs",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
                 "name": "boot.efi",
                 "type": "org.osbuild.fat",
                 "source": "boot.efi",
                 "target": "/boot/efi"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
+          },
+          {
+            "type": "org.osbuild.lvm2.metadata",
+            "options": {
+              "vg_name": "rootvg"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1257472,
+                  "size": 19714015,
+                  "lock": true
+                }
+              }
+            }
           },
           {
             "type": "org.osbuild.grub2.inst",
@@ -6141,8 +6341,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/boot/grub2"
+                "number": 3,
+                "path": "/grub2"
               }
             }
           }
@@ -10638,6 +10838,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:0b49adba21bed320605b4c6eee6e624bd202c5048a10a682d586a0a78e83ea7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:30c703f6317c75856917578cf9f1f48635cd63e982cb48fddb227fbfabb36c12",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -10645,6 +10865,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:4b3118cfe0038768edbe25d4ad4322ed41bd63c7915edb67609cd6e34b577b4d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:09d84aeab48bdc6091b30f578a4d5d88e80467aac5dc1b1ac8454e4db77a8e58",
         "check_gpg": true
       },
       {
@@ -11818,6 +12048,16 @@
         "check_gpg": true
       },
       {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.112",
+        "release": "1.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/libaio-0.3.112-1.el8.x86_64.rpm",
+        "checksum": "sha256:2c63399bee449fb6e921671a9bbf3356fda73f890b578820f7d926202e98a479",
+        "check_gpg": true
+      },
+      {
         "name": "libappstream-glib",
         "epoch": 0,
         "version": "0.7.14",
@@ -12825,6 +13065,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:0268af0ee5754fb90fcf71b00fb737f1bf5b3c54c9ff312f13df8c2201311cfe",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:51146493afbdd053e51e8f930f85572bbfc4f4cd12aad2ba19dec06df6b0ec07",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:7b3b5723d789421fe8af20e5dd6a0ba1344eb5fbfddd02ffeed6ea0b3f8d0111",
         "check_gpg": true
       },
       {
@@ -14802,8 +15062,8 @@
         "grub_class": "kernel",
         "grub_users": "$grub_users",
         "id": "centos-20220110132047-0-rescue-ffffffffffffffffffffffffffffffff",
-        "initrd": "/boot/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
-        "linux": "/boot/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff",
+        "initrd": "/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
+        "linux": "/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff",
         "options": "$kernelopts",
         "title": "CentOS Stream (0-rescue-ffffffffffffffffffffffffffffffff) 8",
         "version": "0-rescue-ffffffffffffffffffffffffffffffff"
@@ -14813,8 +15073,8 @@
         "grub_class": "kernel",
         "grub_users": "$grub_users",
         "id": "centos-20220110132047-4.18.0-358.el8.x86_64",
-        "initrd": "/boot/initramfs-4.18.0-358.el8.x86_64.img $tuned_initrd",
-        "linux": "/boot/vmlinuz-4.18.0-358.el8.x86_64",
+        "initrd": "/initramfs-4.18.0-358.el8.x86_64.img $tuned_initrd",
+        "linux": "/vmlinuz-4.18.0-358.el8.x86_64",
         "options": "$kernelopts $tuned_params",
         "title": "CentOS Stream (4.18.0-358.el8.x86_64) 8",
         "version": "4.18.0-358.el8.x86_64"
@@ -14999,12 +15259,28 @@
         "0"
       ],
       [
+        "UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+        "/opt",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
+      ],
+      [
         "UUID=7B77-95E7",
         "/boot/efi",
         "vfat",
         "defaults,uid=0,gid=0,umask=077,shortname=winnt",
         "0",
         "2"
+      ],
+      [
+        "UUID=fb180daf-48a7-4ee0-b10d-394651850fd4",
+        "/boot",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
       ]
     ],
     "groups": [
@@ -15160,7 +15436,10 @@
       "dejavu-fonts-common-2.35-7.el8.noarch",
       "dejavu-sans-mono-fonts-2.35-7.el8.noarch",
       "device-mapper-1.02.181-3.el8.x86_64",
+      "device-mapper-event-1.02.181-3.el8.x86_64",
+      "device-mapper-event-libs-1.02.181-3.el8.x86_64",
       "device-mapper-libs-1.02.181-3.el8.x86_64",
+      "device-mapper-persistent-data-0.9.0-6.el8.x86_64",
       "dhcp-client-4.3.6-47.el8.0.1.x86_64",
       "dhcp-common-4.3.6-47.el8.0.1.noarch",
       "dhcp-libs-4.3.6-47.el8.0.1.x86_64",
@@ -15287,6 +15566,7 @@
       "libXext-1.3.4-1.el8.x86_64",
       "libXrender-0.9.10-7.el8.x86_64",
       "libacl-2.2.53-1.el8.x86_64",
+      "libaio-0.3.112-1.el8.x86_64",
       "libappstream-glib-0.7.14-3.el8.x86_64",
       "libarchive-3.3.3-3.el8_5.x86_64",
       "libassuan-2.5.1-3.el8.x86_64",
@@ -15393,6 +15673,8 @@
       "lshw-B.02.19.2-6.el8.x86_64",
       "lsscsi-0.32-3.el8.x86_64",
       "lua-libs-5.3.4-12.el8.x86_64",
+      "lvm2-2.03.14-3.el8.x86_64",
+      "lvm2-libs-2.03.14-3.el8.x86_64",
       "lz4-libs-1.8.3-3.el8_4.x86_64",
       "lzo-2.08-14.el8.x86_64",
       "man-db-2.7.6.1-18.el8.x86_64",
@@ -15573,13 +15855,27 @@
     "partitions": [
       {
         "bootable": false,
-        "fstype": "xfs",
-        "label": "root",
+        "fstype": "LVM2_member",
+        "label": null,
+        "lvm": true,
+        "lvm.vg": "rootvg",
+        "lvm.volumes": {
+          "optlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+          },
+          "rootlv": {
+            "fstype": "xfs",
+            "label": "root",
+            "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+          }
+        },
         "partuuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
-        "size": 10630446592,
-        "start": 106954752,
-        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-        "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+        "size": 10093575680,
+        "start": 643825664,
+        "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+        "uuid": "nXShZT-bD7B-2044-MBHQ-gNta-MNNZ-pFodug"
       },
       {
         "bootable": false,
@@ -15590,6 +15886,16 @@
         "start": 2097152,
         "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
         "uuid": "7B77-95E7"
+      },
+      {
+        "bootable": false,
+        "fstype": "xfs",
+        "label": null,
+        "partuuid": "A178892E-E285-4CE1-9114-55780875D64E",
+        "size": 536870912,
+        "start": 106954752,
+        "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+        "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
       },
       {
         "bootable": false,
@@ -15655,6 +15961,7 @@
     },
     "services-disabled": [
       "arp-ethers.service",
+      "blk-availability.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
       "cockpit.socket",
@@ -15713,6 +16020,7 @@
       "dbus-org.fedoraproject.FirewallD1.service",
       "dbus-org.freedesktop.nm-dispatcher.service",
       "dbus-org.freedesktop.timedate1.service",
+      "dm-event.socket",
       "dnf-makecache.timer",
       "firewalld.service",
       "getty@.service",
@@ -15720,6 +16028,8 @@
       "irqbalance.service",
       "kdump.service",
       "loadmodules.service",
+      "lvm2-lvmpolld.socket",
+      "lvm2-monitor.service",
       "microcode.service",
       "nfs-client.target",
       "nis-domainname.service",
@@ -15899,6 +16209,10 @@
         ],
         "libselinux.conf": [
           "d /run/setrans 0755 root root"
+        ],
+        "lvm2.conf": [
+          "d /run/lock/lvm 0700 root root -",
+          "d /run/lvm 0700 root root -"
         ],
         "man-db.conf": [
           "d /var/cache/man 0755 root root 1w"

--- a/test/data/manifests/centos_9-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-aarch64-qcow2_customize-boot.json
@@ -88,7 +88,13 @@
           "disabled": [
             "bluetooth.service"
           ]
-        }
+        },
+        "filesystem": [
+          {
+            "mountpoint": "/opt",
+            "minsize": 1073741824
+          }
+        ]
       }
     }
   },
@@ -2651,7 +2657,31 @@
                     }
                   },
                   {
+                    "id": "sha256:8d939d108db3027a46d974234f4f039607ae3b315efe9b3a5c5227acecf59811",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1d53f3a60601c16d1768c17792df11f04afa8658bc3bd90360a84e9a2dcc1ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:46336dd1493c952285e17a4c2e43ff69061540e75c9e5b3131d0d1a35866e315",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbcabcbffd264fb1a8403d29c2351b17d28ce6e7a810d65e8ca2bf8dbfd4e2d3",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3380,6 +3410,14 @@
                   },
                   {
                     "id": "sha256:4975593414dfa1e822cd108e988d18453c2ff036b03e4cdbf38db0afb45e0c92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1730d732818fa2471b5cd461175ceda18e909410db8a32185d8db2aa7461130c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4196,6 +4234,22 @@
                   },
                   {
                     "id": "sha256:a5924e224aa5941e9bb54bf00b40200e790454d78a4772906844bd45b823ccda",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbeddfad56d22de4f5417e0bb0232da80b36fbe21e99efd93226258ed6446baa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1cd3415ca78695265f4b48dfb03b664fe85bfc95b5975c58851b0094b630abd",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5327,6 +5381,12 @@
                   "options": "defaults"
                 },
                 {
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
+                  "options": "defaults"
+                },
+                {
                   "uuid": "7B77-95E7",
                   "vfs_type": "vfat",
                   "path": "/boot/efi",
@@ -5392,7 +5452,7 @@
                 {
                   "size": 19535839,
                   "start": 1435648,
-                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
               ]
@@ -5402,6 +5462,32 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.lvm2.create",
+            "options": {
+              "volumes": [
+                {
+                  "name": "rootlv",
+                  "size": "3221225472B"
+                },
+                {
+                  "name": "optlv",
+                  "size": "1073741824B"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1435648,
+                  "size": 19535839,
                   "lock": true
                 }
               }
@@ -5450,6 +5536,37 @@
             },
             "devices": {
               "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1435648,
+                  "size": 19535839,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -5496,7 +5613,21 @@
                   "size": 409600
                 }
               },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
               "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -5523,8 +5654,31 @@
                 "type": "org.osbuild.fat",
                 "source": "boot.efi",
                 "target": "/boot/efi"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
+          },
+          {
+            "type": "org.osbuild.lvm2.metadata",
+            "options": {
+              "vg_name": "rootvg"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1435648,
+                  "size": 19535839,
+                  "lock": true
+                }
+              }
+            }
           }
         ]
       },
@@ -10018,6 +10172,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 9,
+        "version": "1.02.181",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el9.aarch64.rpm",
+        "checksum": "sha256:8d939d108db3027a46d974234f4f039607ae3b315efe9b3a5c5227acecf59811",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 9,
+        "version": "1.02.181",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el9.aarch64.rpm",
+        "checksum": "sha256:e1d53f3a60601c16d1768c17792df11f04afa8658bc3bd90360a84e9a2dcc1ea",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 9,
         "version": "1.02.181",
@@ -10025,6 +10199,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el9.aarch64.rpm",
         "checksum": "sha256:46336dd1493c952285e17a4c2e43ff69061540e75c9e5b3131d0d1a35866e315",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "12.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-12.el9.aarch64.rpm",
+        "checksum": "sha256:bbcabcbffd264fb1a8403d29c2351b17d28ce6e7a810d65e8ca2bf8dbfd4e2d3",
         "check_gpg": true
       },
       {
@@ -10935,6 +11119,16 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/libacl-2.3.1-3.el9.aarch64.rpm",
         "checksum": "sha256:4975593414dfa1e822cd108e988d18453c2ff036b03e4cdbf38db0afb45e0c92",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "13.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/libaio-0.3.111-13.el9.aarch64.rpm",
+        "checksum": "sha256:1730d732818fa2471b5cd461175ceda18e909410db8a32185d8db2aa7461130c",
         "check_gpg": true
       },
       {
@@ -11955,6 +12149,26 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/lua-libs-5.4.2-4.el9.aarch64.rpm",
         "checksum": "sha256:a5924e224aa5941e9bb54bf00b40200e790454d78a4772906844bd45b823ccda",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 9,
+        "version": "2.03.14",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/lvm2-2.03.14-3.el9.aarch64.rpm",
+        "checksum": "sha256:dbeddfad56d22de4f5417e0bb0232da80b36fbe21e99efd93226258ed6446baa",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 9,
+        "version": "2.03.14",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el9.aarch64.rpm",
+        "checksum": "sha256:c1cd3415ca78695265f4b48dfb03b664fe85bfc95b5975c58851b0094b630abd",
         "check_gpg": true
       },
       {
@@ -13450,6 +13664,14 @@
         "defaults,uid=0,gid=0,umask=077,shortname=winnt",
         "0",
         "2"
+      ],
+      [
+        "UUID=fb180daf-48a7-4ee0-b10d-394651850fd4",
+        "/opt",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
       ]
     ],
     "groups": [
@@ -13469,7 +13691,7 @@
       "games:x:20:",
       "group1:x:1030:user2",
       "group2:x:1050:",
-      "input:x:998:",
+      "input:x:999:",
       "kmem:x:9:",
       "kvm:x:36:",
       "lock:x:54:",
@@ -13478,17 +13700,17 @@
       "man:x:15:",
       "mem:x:8:",
       "nobody:x:65534:",
-      "polkitd:x:995:",
-      "render:x:997:",
+      "polkitd:x:996:",
+      "render:x:998:",
       "root:x:0:",
       "rpc:x:32:",
       "rpcuser:x:29:",
       "setroubleshoot:x:994:",
-      "ssh_keys:x:999:",
+      "ssh_keys:x:995:",
       "sshd:x:74:",
       "sssd:x:993:",
       "sys:x:3:",
-      "systemd-coredump:x:996:",
+      "systemd-coredump:x:997:",
       "systemd-journal:x:190:",
       "tape:x:33:",
       "tcpdump:x:72:",
@@ -13596,7 +13818,10 @@
       "dbus-libs-1.12.20-5.el9.aarch64",
       "dbus-tools-1.12.20-5.el9.aarch64",
       "device-mapper-1.02.181-3.el9.aarch64",
+      "device-mapper-event-1.02.181-3.el9.aarch64",
+      "device-mapper-event-libs-1.02.181-3.el9.aarch64",
       "device-mapper-libs-1.02.181-3.el9.aarch64",
+      "device-mapper-persistent-data-0.9.0-12.el9.aarch64",
       "dhcp-client-4.4.2-15.b1.el9.aarch64",
       "dhcp-common-4.4.2-15.b1.el9.noarch",
       "diffutils-3.7-12.el9.aarch64",
@@ -13696,6 +13921,7 @@
       "krb5-libs-1.19.1-13.el9.aarch64",
       "less-575-4.el9.aarch64",
       "libacl-2.3.1-3.el9.aarch64",
+      "libaio-0.3.111-13.el9.aarch64",
       "libappstream-glib-0.7.18-4.el9.aarch64",
       "libarchive-3.5.2-1.el9.aarch64",
       "libassuan-2.5.5-3.el9.aarch64",
@@ -13805,6 +14031,8 @@
       "lshw-B.02.19.2-6.el9.aarch64",
       "lsscsi-0.32-6.el9.aarch64",
       "lua-libs-5.4.2-4.el9.aarch64",
+      "lvm2-2.03.14-3.el9.aarch64",
+      "lvm2-libs-2.03.14-3.el9.aarch64",
       "lz4-libs-1.9.3-5.el9.aarch64",
       "lzo-2.10-7.el9.aarch64",
       "man-db-2.9.3-6.el9.aarch64",
@@ -13970,13 +14198,27 @@
     "partitions": [
       {
         "bootable": false,
-        "fstype": "xfs",
-        "label": "root",
+        "fstype": "LVM2_member",
+        "label": null,
+        "lvm": true,
+        "lvm.vg": "rootvg",
+        "lvm.volumes": {
+          "optlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+          },
+          "rootlv": {
+            "fstype": "xfs",
+            "label": "root",
+            "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+          }
+        },
         "partuuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
         "size": 10002349568,
         "start": 735051776,
-        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-        "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+        "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+        "uuid": "z9F2nL-0dU4-AaZ7-XMnR-IAe1-Gsmx-ulJcTT"
       },
       {
         "bootable": false,
@@ -14014,7 +14256,7 @@
       "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
       "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
       "operator:x:11:0:operator:/root:/sbin/nologin",
-      "polkitd:x:998:995:User for polkitd:/:/sbin/nologin",
+      "polkitd:x:998:996:User for polkitd:/:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin",
       "rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin",
@@ -14023,7 +14265,7 @@
       "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
       "sssd:x:996:993:User for sssd:/:/sbin/nologin",
       "sync:x:5:0:sync:/sbin:/bin/sync",
-      "systemd-coredump:x:999:996:systemd Core Dumper:/:/sbin/nologin",
+      "systemd-coredump:x:999:997:systemd Core Dumper:/:/sbin/nologin",
       "tcpdump:x:72:72::/:/sbin/nologin",
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
       "user1:x:1000:1000::/home/user1:/bin/bash",
@@ -14058,6 +14300,7 @@
       }
     },
     "services-disabled": [
+      "blk-availability.service",
       "chrony-wait.service",
       "cockpit.socket",
       "console-getty.service",
@@ -14116,11 +14359,14 @@
       "dbus-org.freedesktop.nm-dispatcher.service",
       "dbus.service",
       "dbus.socket",
+      "dm-event.socket",
       "dnf-makecache.timer",
       "firewalld.service",
       "getty@.service",
       "irqbalance.service",
       "kdump.service",
+      "lvm2-lvmpolld.socket",
+      "lvm2-monitor.service",
       "nfs-client.target",
       "nis-domainname.service",
       "qemu-guest-agent.service",
@@ -14316,6 +14562,10 @@
         ],
         "libselinux.conf": [
           "d /run/setrans 0755 root root"
+        ],
+        "lvm2.conf": [
+          "d /run/lock/lvm 0700 root root -",
+          "d /run/lvm 0700 root root -"
         ],
         "man-db.conf": [
           "d /var/cache/man 0755 root root 1w"

--- a/test/data/manifests/centos_9-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-ppc64le-qcow2_customize-boot.json
@@ -88,7 +88,13 @@
           "disabled": [
             "bluetooth.service"
           ]
-        }
+        },
+        "filesystem": [
+          {
+            "mountpoint": "/opt",
+            "minsize": 1073741824
+          }
+        ]
       }
     }
   },
@@ -3187,7 +3193,31 @@
                     }
                   },
                   {
+                    "id": "sha256:578ff455f9f95837e9b2e00153a20231ba2a682888d35933b5e8353ccaf7b41b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b95a1fb0917485e7e9eaad6286432e14603a12e322eb639b6543031907fa858b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:f924d24d0960179a856a9a173f5730f4c9033465ce0aa4e927a954fb4cc5315a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa8eb8281cb302c4bc75a6e86fab76ab6488e98106e34b7de2accc2bc4422c28",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3884,6 +3914,14 @@
                   },
                   {
                     "id": "sha256:95ac17dbef9a92a55bf6aeabb838f9bcb2f57f7d24291cf6c59f07ff02faa06f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b16adcd2ebfe177a455403ac5c3b6a1782dcee7d498372137042a34e64f69481",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4684,6 +4722,22 @@
                   },
                   {
                     "id": "sha256:240c28bea4cbef8e6ab85f075987b2611a53f4b85ce52f8cf3429431211d3c61",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cf4069a65419cb98e8c942645bb4100c090416b03d776c82c500df81d02192c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:111f115685a362fe475793340f42d5d58e37c8ef521baabe5cab987fbb4a2413",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5813,6 +5867,12 @@
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
+                },
+                {
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
+                  "options": "defaults"
                 }
               ]
             }
@@ -5867,7 +5927,8 @@
                 },
                 {
                   "size": 19937280,
-                  "start": 1034240
+                  "start": 1034240,
+                  "type": "8e"
                 }
               ]
             },
@@ -5876,6 +5937,32 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.lvm2.create",
+            "options": {
+              "volumes": [
+                {
+                  "name": "rootlv",
+                  "size": "3221225472B"
+                },
+                {
+                  "name": "optlv",
+                  "size": "1073741824B"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1034240,
+                  "size": 19937280,
                   "lock": true
                 }
               }
@@ -5906,6 +5993,37 @@
             },
             "devices": {
               "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1034240,
+                  "size": 19937280,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -5944,7 +6062,21 @@
                   "size": 1024000
                 }
               },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
               "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -5965,8 +6097,31 @@
                 "type": "org.osbuild.xfs",
                 "source": "boot",
                 "target": "/boot"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
+          },
+          {
+            "type": "org.osbuild.lvm2.metadata",
+            "options": {
+              "vg_name": "rootvg"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1034240,
+                  "size": 19937280,
+                  "lock": true
+                }
+              }
+            }
           },
           {
             "type": "org.osbuild.grub2.inst",
@@ -11299,6 +11454,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 9,
+        "version": "1.02.181",
+        "release": "3.el9",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-ppc64le-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el9.ppc64le.rpm",
+        "checksum": "sha256:578ff455f9f95837e9b2e00153a20231ba2a682888d35933b5e8353ccaf7b41b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 9,
+        "version": "1.02.181",
+        "release": "3.el9",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-ppc64le-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el9.ppc64le.rpm",
+        "checksum": "sha256:b95a1fb0917485e7e9eaad6286432e14603a12e322eb639b6543031907fa858b",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 9,
         "version": "1.02.181",
@@ -11306,6 +11481,16 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-ppc64le-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el9.ppc64le.rpm",
         "checksum": "sha256:f924d24d0960179a856a9a173f5730f4c9033465ce0aa4e927a954fb4cc5315a",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "12.el9",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-ppc64le-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-12.el9.ppc64le.rpm",
+        "checksum": "sha256:fa8eb8281cb302c4bc75a6e86fab76ab6488e98106e34b7de2accc2bc4422c28",
         "check_gpg": true
       },
       {
@@ -12176,6 +12361,16 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-ppc64le-baseos-20220208/Packages/libacl-2.3.1-3.el9.ppc64le.rpm",
         "checksum": "sha256:95ac17dbef9a92a55bf6aeabb838f9bcb2f57f7d24291cf6c59f07ff02faa06f",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "13.el9",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-ppc64le-baseos-20220208/Packages/libaio-0.3.111-13.el9.ppc64le.rpm",
+        "checksum": "sha256:b16adcd2ebfe177a455403ac5c3b6a1782dcee7d498372137042a34e64f69481",
         "check_gpg": true
       },
       {
@@ -13176,6 +13371,26 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-ppc64le-baseos-20220208/Packages/lua-libs-5.4.2-4.el9.ppc64le.rpm",
         "checksum": "sha256:240c28bea4cbef8e6ab85f075987b2611a53f4b85ce52f8cf3429431211d3c61",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 9,
+        "version": "2.03.14",
+        "release": "3.el9",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-ppc64le-baseos-20220208/Packages/lvm2-2.03.14-3.el9.ppc64le.rpm",
+        "checksum": "sha256:cf4069a65419cb98e8c942645bb4100c090416b03d776c82c500df81d02192c0",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 9,
+        "version": "2.03.14",
+        "release": "3.el9",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-ppc64le-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el9.ppc64le.rpm",
+        "checksum": "sha256:111f115685a362fe475793340f42d5d58e37c8ef521baabe5cab987fbb4a2413",
         "check_gpg": true
       },
       {
@@ -14689,6 +14904,14 @@
         "defaults",
         "0",
         "0"
+      ],
+      [
+        "UUID=fb180daf-48a7-4ee0-b10d-394651850fd4",
+        "/opt",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
       ]
     ],
     "groups": [
@@ -14708,7 +14931,7 @@
       "games:x:20:",
       "group1:x:1030:user2",
       "group2:x:1050:",
-      "input:x:997:",
+      "input:x:998:",
       "kmem:x:9:",
       "kvm:x:36:",
       "lock:x:54:",
@@ -14717,18 +14940,18 @@
       "man:x:15:",
       "mem:x:8:",
       "nobody:x:65534:",
-      "polkitd:x:994:",
-      "render:x:996:",
+      "polkitd:x:995:",
+      "render:x:997:",
       "root:x:0:",
       "rpc:x:32:",
       "rpcuser:x:29:",
       "service:x:999:",
       "setroubleshoot:x:993:",
-      "ssh_keys:x:998:",
+      "ssh_keys:x:994:",
       "sshd:x:74:",
       "sssd:x:992:",
       "sys:x:3:",
-      "systemd-coredump:x:995:",
+      "systemd-coredump:x:996:",
       "systemd-journal:x:190:",
       "tape:x:33:",
       "tcpdump:x:72:",
@@ -14836,7 +15059,10 @@
       "dbus-libs-1.12.20-5.el9.ppc64le",
       "dbus-tools-1.12.20-5.el9.ppc64le",
       "device-mapper-1.02.181-3.el9.ppc64le",
+      "device-mapper-event-1.02.181-3.el9.ppc64le",
+      "device-mapper-event-libs-1.02.181-3.el9.ppc64le",
       "device-mapper-libs-1.02.181-3.el9.ppc64le",
+      "device-mapper-persistent-data-0.9.0-12.el9.ppc64le",
       "dhcp-client-4.4.2-15.b1.el9.ppc64le",
       "dhcp-common-4.4.2-15.b1.el9.noarch",
       "diffutils-3.7-12.el9.ppc64le",
@@ -14930,6 +15156,7 @@
       "krb5-libs-1.19.1-13.el9.ppc64le",
       "less-575-4.el9.ppc64le",
       "libacl-2.3.1-3.el9.ppc64le",
+      "libaio-0.3.111-13.el9.ppc64le",
       "libappstream-glib-0.7.18-4.el9.ppc64le",
       "libarchive-3.5.2-1.el9.ppc64le",
       "libassuan-2.5.5-3.el9.ppc64le",
@@ -15037,6 +15264,8 @@
       "lsscsi-0.32-6.el9.ppc64le",
       "lsvpd-1.7.12-3.el9.ppc64le",
       "lua-libs-5.4.2-4.el9.ppc64le",
+      "lvm2-2.03.14-3.el9.ppc64le",
+      "lvm2-libs-2.03.14-3.el9.ppc64le",
       "lz4-libs-1.9.3-5.el9.ppc64le",
       "lzo-2.10-7.el9.ppc64le",
       "man-db-2.9.3-6.el9.ppc64le",
@@ -15280,13 +15509,27 @@
       },
       {
         "bootable": false,
-        "fstype": "xfs",
+        "fstype": "LVM2_member",
         "label": null,
+        "lvm": true,
+        "lvm.vg": "rootvg",
+        "lvm.volumes": {
+          "optlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+          },
+          "rootlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+          }
+        },
         "partuuid": "14fc63d2-03",
         "size": 10207887360,
         "start": 529530880,
-        "type": "83",
-        "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+        "type": "8e",
+        "uuid": "0waV2d-CMGd-2d9V-3vM1-9dKo-oGr8-Cl2Foi"
       }
     ],
     "passwd": [
@@ -15304,7 +15547,7 @@
       "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
       "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
       "operator:x:11:0:operator:/root:/sbin/nologin",
-      "polkitd:x:998:994:User for polkitd:/:/sbin/nologin",
+      "polkitd:x:998:995:User for polkitd:/:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin",
       "rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin",
@@ -15313,7 +15556,7 @@
       "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
       "sssd:x:996:992:User for sssd:/:/sbin/nologin",
       "sync:x:5:0:sync:/sbin:/bin/sync",
-      "systemd-coredump:x:999:995:systemd Core Dumper:/:/sbin/nologin",
+      "systemd-coredump:x:999:996:systemd Core Dumper:/:/sbin/nologin",
       "tcpdump:x:72:72::/:/sbin/nologin",
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
       "user1:x:1000:1000::/home/user1:/bin/bash",
@@ -15340,6 +15583,7 @@
       }
     },
     "services-disabled": [
+      "blk-availability.service",
       "chrony-wait.service",
       "cockpit.socket",
       "console-getty.service",
@@ -15399,12 +15643,15 @@
       "dbus-org.freedesktop.nm-dispatcher.service",
       "dbus.service",
       "dbus.socket",
+      "dm-event.socket",
       "dnf-makecache.timer",
       "firewalld.service",
       "getty@.service",
       "hcn-init.service",
       "irqbalance.service",
       "kdump.service",
+      "lvm2-lvmpolld.socket",
+      "lvm2-monitor.service",
       "nfs-client.target",
       "nis-domainname.service",
       "opal-prd.service",
@@ -15602,6 +15849,10 @@
         ],
         "libselinux.conf": [
           "d /run/setrans 0755 root root"
+        ],
+        "lvm2.conf": [
+          "d /run/lock/lvm 0700 root root -",
+          "d /run/lvm 0700 root root -"
         ],
         "man-db.conf": [
           "d /var/cache/man 0755 root root 1w"

--- a/test/data/manifests/centos_9-s390x-qcow2-boot.json
+++ b/test/data/manifests/centos_9-s390x-qcow2-boot.json
@@ -15772,7 +15772,7 @@
         "grub_arg": "--unrestricted",
         "grub_class": "kernel",
         "grub_users": "$grub_users",
-        "id": "-20220427115408-5.14.0-55.el9.s390x",
+        "id": "-20220428125618-5.14.0-55.el9.s390x",
         "initrd": "/boot/initramfs-5.14.0-55.el9.s390x.img",
         "linux": "/boot/vmlinuz-5.14.0-55.el9.s390x",
         "options": "root=UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",

--- a/test/data/manifests/centos_9-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-s390x-qcow2_customize-boot.json
@@ -88,7 +88,13 @@
           "disabled": [
             "bluetooth.service"
           ]
-        }
+        },
+        "filesystem": [
+          {
+            "mountpoint": "/opt",
+            "minsize": 1073741824
+          }
+        ]
       }
     }
   },
@@ -4019,7 +4025,31 @@
                     }
                   },
                   {
+                    "id": "sha256:89f5055df48c83f45ff459ca3448c1705f01c0207a311dc023ffa0458b3900bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9adfea92796e260f79aef3d38df76f636d19651406369062173c29656c5c3d47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:120df5a53b6f32c00cde78a12f7f1f8f37b4576dfe2da119ac018c5a1493af4f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:214b4cda548d358d312386430c4aac95b75841f437ec9475599bc9a0461111ab",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4644,6 +4674,14 @@
                   },
                   {
                     "id": "sha256:d292a6104efca3cd0814c7880458d16e0c656794f15b5c290d8401b5d2ca5ba5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4adecd95273b4ae7590b84ecbed5a7b4a1795066bab430d15f04eb82bb9dc1c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5404,6 +5442,22 @@
                   },
                   {
                     "id": "sha256:b922e6df9ae48f25aa50fff2a132c2ac5a96475c8b4e54430c9a183f6ec5f6b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9f93eb0104e5a57ad798ff2758a971fe26277179369d6278746cb9d02242ab3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a4ec8a12b98a64d926fc22eb5d2d5544eb6709edfd4b3787cb34f5d33ceb09f",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6509,6 +6563,12 @@
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
+                },
+                {
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
+                  "options": "defaults"
                 }
               ]
             }
@@ -6549,7 +6609,8 @@
                 {
                   "bootable": true,
                   "size": 19945472,
-                  "start": 1026048
+                  "start": 1026048,
+                  "type": "8e"
                 }
               ]
             },
@@ -6558,6 +6619,32 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.lvm2.create",
+            "options": {
+              "volumes": [
+                {
+                  "name": "rootlv",
+                  "size": "3221225472B"
+                },
+                {
+                  "name": "optlv",
+                  "size": "1073741824B"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1026048,
+                  "size": 19945472,
                   "lock": true
                 }
               }
@@ -6588,6 +6675,37 @@
             },
             "devices": {
               "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1026048,
+                  "size": 19945472,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -6632,7 +6750,21 @@
                   "filename": "disk.img"
                 }
               },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
               "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -6653,8 +6785,31 @@
                 "type": "org.osbuild.xfs",
                 "source": "boot",
                 "target": "/boot"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
+          },
+          {
+            "type": "org.osbuild.lvm2.metadata",
+            "options": {
+              "vg_name": "rootvg"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1026048,
+                  "size": 19945472,
+                  "lock": true
+                }
+              }
+            }
           },
           {
             "type": "org.osbuild.zipl.inst",
@@ -6677,7 +6832,21 @@
                   "filename": "disk.img"
                 }
               },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
               "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -6698,6 +6867,12 @@
                 "type": "org.osbuild.xfs",
                 "source": "boot",
                 "target": "/boot"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
           }
@@ -13122,6 +13297,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 9,
+        "version": "1.02.181",
+        "release": "3.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el9.s390x.rpm",
+        "checksum": "sha256:89f5055df48c83f45ff459ca3448c1705f01c0207a311dc023ffa0458b3900bf",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 9,
+        "version": "1.02.181",
+        "release": "3.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el9.s390x.rpm",
+        "checksum": "sha256:9adfea92796e260f79aef3d38df76f636d19651406369062173c29656c5c3d47",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 9,
         "version": "1.02.181",
@@ -13129,6 +13324,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el9.s390x.rpm",
         "checksum": "sha256:120df5a53b6f32c00cde78a12f7f1f8f37b4576dfe2da119ac018c5a1493af4f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "12.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-12.el9.s390x.rpm",
+        "checksum": "sha256:214b4cda548d358d312386430c4aac95b75841f437ec9475599bc9a0461111ab",
         "check_gpg": true
       },
       {
@@ -13909,6 +14114,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/libacl-2.3.1-3.el9.s390x.rpm",
         "checksum": "sha256:d292a6104efca3cd0814c7880458d16e0c656794f15b5c290d8401b5d2ca5ba5",
+        "check_gpg": true
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "13.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/libaio-0.3.111-13.el9.s390x.rpm",
+        "checksum": "sha256:b4adecd95273b4ae7590b84ecbed5a7b4a1795066bab430d15f04eb82bb9dc1c",
         "check_gpg": true
       },
       {
@@ -14859,6 +15074,26 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/lua-libs-5.4.2-4.el9.s390x.rpm",
         "checksum": "sha256:b922e6df9ae48f25aa50fff2a132c2ac5a96475c8b4e54430c9a183f6ec5f6b4",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 9,
+        "version": "2.03.14",
+        "release": "3.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/lvm2-2.03.14-3.el9.s390x.rpm",
+        "checksum": "sha256:e9f93eb0104e5a57ad798ff2758a971fe26277179369d6278746cb9d02242ab3",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 9,
+        "version": "2.03.14",
+        "release": "3.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el9.s390x.rpm",
+        "checksum": "sha256:1a4ec8a12b98a64d926fc22eb5d2d5544eb6709edfd4b3787cb34f5d33ceb09f",
         "check_gpg": true
       },
       {
@@ -16091,7 +16326,7 @@
         "grub_arg": "--unrestricted",
         "grub_class": "kernel",
         "grub_users": "$grub_users",
-        "id": "-20220427115626-0-rescue-ffffffffffffffffffffffffffffffff",
+        "id": "-20220428125834-0-rescue-ffffffffffffffffffffffffffffffff",
         "initrd": "/boot/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
         "linux": "/boot/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff",
         "options": "root=UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
@@ -16102,7 +16337,7 @@
         "grub_arg": "--unrestricted",
         "grub_class": "kernel",
         "grub_users": "$grub_users",
-        "id": "-20220427115626-5.14.0-55.el9.s390x",
+        "id": "-20220428125834-5.14.0-55.el9.s390x",
         "initrd": "/boot/initramfs-5.14.0-55.el9.s390x.img",
         "linux": "/boot/vmlinuz-5.14.0-55.el9.s390x",
         "options": "root=UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
@@ -16315,6 +16550,14 @@
         "defaults",
         "0",
         "0"
+      ],
+      [
+        "UUID=fb180daf-48a7-4ee0-b10d-394651850fd4",
+        "/opt",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
       ]
     ],
     "groups": [
@@ -16334,7 +16577,7 @@
       "games:x:20:",
       "group1:x:1030:user2",
       "group2:x:1050:",
-      "input:x:998:",
+      "input:x:999:",
       "kmem:x:9:",
       "kvm:x:36:",
       "lock:x:54:",
@@ -16343,17 +16586,17 @@
       "man:x:15:",
       "mem:x:8:",
       "nobody:x:65534:",
-      "polkitd:x:995:",
-      "render:x:997:",
+      "polkitd:x:996:",
+      "render:x:998:",
       "root:x:0:",
       "rpc:x:32:",
       "rpcuser:x:29:",
       "setroubleshoot:x:994:",
-      "ssh_keys:x:999:",
+      "ssh_keys:x:995:",
       "sshd:x:74:",
       "sssd:x:993:",
       "sys:x:3:",
-      "systemd-coredump:x:996:",
+      "systemd-coredump:x:997:",
       "systemd-journal:x:190:",
       "tape:x:33:",
       "tcpdump:x:72:",
@@ -16461,7 +16704,10 @@
       "dbus-libs-1.12.20-5.el9.s390x",
       "dbus-tools-1.12.20-5.el9.s390x",
       "device-mapper-1.02.181-3.el9.s390x",
+      "device-mapper-event-1.02.181-3.el9.s390x",
+      "device-mapper-event-libs-1.02.181-3.el9.s390x",
       "device-mapper-libs-1.02.181-3.el9.s390x",
+      "device-mapper-persistent-data-0.9.0-12.el9.s390x",
       "dhcp-client-4.4.2-15.b1.el9.s390x",
       "dhcp-common-4.4.2-15.b1.el9.noarch",
       "diffutils-3.7-12.el9.s390x",
@@ -16546,6 +16792,7 @@
       "krb5-libs-1.19.1-13.el9.s390x",
       "less-575-4.el9.s390x",
       "libacl-2.3.1-3.el9.s390x",
+      "libaio-0.3.111-13.el9.s390x",
       "libappstream-glib-0.7.18-4.el9.s390x",
       "libarchive-3.5.2-1.el9.s390x",
       "libassuan-2.5.5-3.el9.s390x",
@@ -16649,6 +16896,8 @@
       "lshw-B.02.19.2-6.el9.s390x",
       "lsscsi-0.32-6.el9.s390x",
       "lua-libs-5.4.2-4.el9.s390x",
+      "lvm2-2.03.14-3.el9.s390x",
+      "lvm2-libs-2.03.14-3.el9.s390x",
       "lz4-libs-1.9.3-5.el9.s390x",
       "lzo-2.10-7.el9.s390x",
       "man-db-2.9.3-6.el9.s390x",
@@ -16880,13 +17129,27 @@
       },
       {
         "bootable": true,
-        "fstype": "xfs",
+        "fstype": "LVM2_member",
         "label": null,
+        "lvm": true,
+        "lvm.vg": "rootvg",
+        "lvm.volumes": {
+          "optlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+          },
+          "rootlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+          }
+        },
         "partuuid": "14fc63d2-02",
         "size": 10212081664,
         "start": 525336576,
-        "type": "83",
-        "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+        "type": "8e",
+        "uuid": "gayYyd-Hqz1-XMbe-WRf6-X17t-0Mqe-5IPDwG"
       }
     ],
     "passwd": [
@@ -16904,7 +17167,7 @@
       "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
       "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
       "operator:x:11:0:operator:/root:/sbin/nologin",
-      "polkitd:x:998:995:User for polkitd:/:/sbin/nologin",
+      "polkitd:x:998:996:User for polkitd:/:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin",
       "rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin",
@@ -16913,7 +17176,7 @@
       "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
       "sssd:x:996:993:User for sssd:/:/sbin/nologin",
       "sync:x:5:0:sync:/sbin:/bin/sync",
-      "systemd-coredump:x:999:996:systemd Core Dumper:/:/sbin/nologin",
+      "systemd-coredump:x:999:997:systemd Core Dumper:/:/sbin/nologin",
       "tcpdump:x:72:72::/:/sbin/nologin",
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
       "user1:x:1000:1000::/home/user1:/bin/bash",
@@ -16940,6 +17203,7 @@
       }
     },
     "services-disabled": [
+      "blk-availability.service",
       "chrony-wait.service",
       "cockpit.socket",
       "console-getty.service",
@@ -16999,10 +17263,13 @@
       "dbus.service",
       "dbus.socket",
       "device_cio_free.service",
+      "dm-event.socket",
       "dnf-makecache.timer",
       "firewalld.service",
       "getty@.service",
       "kdump.service",
+      "lvm2-lvmpolld.socket",
+      "lvm2-monitor.service",
       "nfs-client.target",
       "nis-domainname.service",
       "qemu-guest-agent.service",
@@ -17193,6 +17460,10 @@
         ],
         "libselinux.conf": [
           "d /run/setrans 0755 root root"
+        ],
+        "lvm2.conf": [
+          "d /run/lock/lvm 0700 root root -",
+          "d /run/lvm 0700 root root -"
         ],
         "man-db.conf": [
           "d /var/cache/man 0755 root root 1w"

--- a/test/data/manifests/centos_9-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-x86_64-qcow2_customize-boot.json
@@ -94,7 +94,13 @@
           "disabled": [
             "bluetooth.service"
           ]
-        }
+        },
+        "filesystem": [
+          {
+            "mountpoint": "/opt",
+            "minsize": 1073741824
+          }
+        ]
       }
     }
   },
@@ -2778,7 +2784,31 @@
                     }
                   },
                   {
+                    "id": "sha256:80457a20d0dea8c9b2901e98257ec82cce4e771ff3a8004ef5345e7acdf58bd8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23fd0185b511665ee4d036752f1f819e8db9c92c438c36bcbb8a8cd52b4eb47f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:a716ccca85fad2885af4d099f8c213eb4617d637d8ca6cf7d2b483b9de88a5d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e38a233da605c9c18dd28a9d5a4414a1db7c3837e5c2148b5fe83e31aba081f5",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3626,6 +3656,14 @@
                     }
                   },
                   {
+                    "id": "sha256:7d9d4d37e86ba94bb941e2dad40c90a157aaa0602f02f3f90e76086515f439be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:0104a8af31e4670ad0a4f0f4f1217ca953477f3c7d87ad9d2d6ea40ca1104ad6",
                     "options": {
                       "metadata": {
@@ -4443,6 +4481,22 @@
                   },
                   {
                     "id": "sha256:59342315ee1c9589ae36bde722a66d718cc7cb5b750521aa31dc7704e2d0c0f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:87e0088b783bfc5bb767c6f8df9a53002d90d14ca724fd55d48ec12f0187756a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67f8fb5acbe05fbf6ffade5a0b0844f1ade930c4471e63f8950764168dc3e16d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -5583,6 +5637,12 @@
                   "options": "defaults"
                 },
                 {
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
+                  "options": "defaults"
+                },
+                {
                   "uuid": "7B77-95E7",
                   "vfs_type": "vfat",
                   "path": "/boot/efi",
@@ -5656,7 +5716,7 @@
                 {
                   "size": 19533791,
                   "start": 1437696,
-                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
               ]
@@ -5666,6 +5726,32 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.lvm2.create",
+            "options": {
+              "volumes": [
+                {
+                  "name": "rootlv",
+                  "size": "3221225472B"
+                },
+                {
+                  "name": "optlv",
+                  "size": "1073741824B"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1437696,
+                  "size": 19533791,
                   "lock": true
                 }
               }
@@ -5714,6 +5800,37 @@
             },
             "devices": {
               "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1437696,
+                  "size": 19533791,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -5760,7 +5877,21 @@
                   "size": 409600
                 }
               },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
               "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -5787,8 +5918,31 @@
                 "type": "org.osbuild.fat",
                 "source": "boot.efi",
                 "target": "/boot/efi"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
+          },
+          {
+            "type": "org.osbuild.lvm2.metadata",
+            "options": {
+              "vg_name": "rootvg"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1437696,
+                  "size": 19533791,
+                  "lock": true
+                }
+              }
+            }
           },
           {
             "type": "org.osbuild.grub2.inst",
@@ -10511,6 +10665,26 @@
         "check_gpg": true
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 9,
+        "version": "1.02.181",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/device-mapper-event-1.02.181-3.el9.x86_64.rpm",
+        "checksum": "sha256:80457a20d0dea8c9b2901e98257ec82cce4e771ff3a8004ef5345e7acdf58bd8",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 9,
+        "version": "1.02.181",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/device-mapper-event-libs-1.02.181-3.el9.x86_64.rpm",
+        "checksum": "sha256:23fd0185b511665ee4d036752f1f819e8db9c92c438c36bcbb8a8cd52b4eb47f",
+        "check_gpg": true
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 9,
         "version": "1.02.181",
@@ -10518,6 +10692,16 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/device-mapper-libs-1.02.181-3.el9.x86_64.rpm",
         "checksum": "sha256:a716ccca85fad2885af4d099f8c213eb4617d637d8ca6cf7d2b483b9de88a5d3",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "12.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/device-mapper-persistent-data-0.9.0-12.el9.x86_64.rpm",
+        "checksum": "sha256:e38a233da605c9c18dd28a9d5a4414a1db7c3837e5c2148b5fe83e31aba081f5",
         "check_gpg": true
       },
       {
@@ -11571,6 +11755,16 @@
         "check_gpg": true
       },
       {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "13.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/libaio-0.3.111-13.el9.x86_64.rpm",
+        "checksum": "sha256:7d9d4d37e86ba94bb941e2dad40c90a157aaa0602f02f3f90e76086515f439be",
+        "check_gpg": true
+      },
+      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.5.2",
@@ -12598,6 +12792,26 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/lua-libs-5.4.2-4.el9.x86_64.rpm",
         "checksum": "sha256:59342315ee1c9589ae36bde722a66d718cc7cb5b750521aa31dc7704e2d0c0f4",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2",
+        "epoch": 9,
+        "version": "2.03.14",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/lvm2-2.03.14-3.el9.x86_64.rpm",
+        "checksum": "sha256:87e0088b783bfc5bb767c6f8df9a53002d90d14ca724fd55d48ec12f0187756a",
+        "check_gpg": true
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 9,
+        "version": "2.03.14",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220208/Packages/lvm2-libs-2.03.14-3.el9.x86_64.rpm",
+        "checksum": "sha256:67f8fb5acbe05fbf6ffade5a0b0844f1ade930c4471e63f8950764168dc3e16d",
         "check_gpg": true
       },
       {
@@ -14106,6 +14320,14 @@
         "defaults,uid=0,gid=0,umask=077,shortname=winnt",
         "0",
         "2"
+      ],
+      [
+        "UUID=fb180daf-48a7-4ee0-b10d-394651850fd4",
+        "/opt",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
       ]
     ],
     "groups": [
@@ -14125,7 +14347,7 @@
       "games:x:20:",
       "group1:x:1030:user2",
       "group2:x:1050:",
-      "input:x:998:",
+      "input:x:999:",
       "kmem:x:9:",
       "kvm:x:36:",
       "lock:x:54:",
@@ -14134,17 +14356,17 @@
       "man:x:15:",
       "mem:x:8:",
       "nobody:x:65534:",
-      "polkitd:x:995:",
-      "render:x:997:",
+      "polkitd:x:996:",
+      "render:x:998:",
       "root:x:0:",
       "rpc:x:32:",
       "rpcuser:x:29:",
       "setroubleshoot:x:994:",
-      "ssh_keys:x:999:",
+      "ssh_keys:x:995:",
       "sshd:x:74:",
       "sssd:x:993:",
       "sys:x:3:",
-      "systemd-coredump:x:996:",
+      "systemd-coredump:x:997:",
       "systemd-journal:x:190:",
       "tape:x:33:",
       "tcpdump:x:72:",
@@ -14252,7 +14474,10 @@
       "dbus-libs-1.12.20-5.el9.x86_64",
       "dbus-tools-1.12.20-5.el9.x86_64",
       "device-mapper-1.02.181-3.el9.x86_64",
+      "device-mapper-event-1.02.181-3.el9.x86_64",
+      "device-mapper-event-libs-1.02.181-3.el9.x86_64",
       "device-mapper-libs-1.02.181-3.el9.x86_64",
+      "device-mapper-persistent-data-0.9.0-12.el9.x86_64",
       "dhcp-client-4.4.2-15.b1.el9.x86_64",
       "dhcp-common-4.4.2-15.b1.el9.noarch",
       "diffutils-3.7-12.el9.x86_64",
@@ -14366,6 +14591,7 @@
       "krb5-libs-1.19.1-13.el9.x86_64",
       "less-575-4.el9.x86_64",
       "libacl-2.3.1-3.el9.x86_64",
+      "libaio-0.3.111-13.el9.x86_64",
       "libappstream-glib-0.7.18-4.el9.x86_64",
       "libarchive-3.5.2-1.el9.x86_64",
       "libassuan-2.5.5-3.el9.x86_64",
@@ -14477,6 +14703,8 @@
       "lshw-B.02.19.2-6.el9.x86_64",
       "lsscsi-0.32-6.el9.x86_64",
       "lua-libs-5.4.2-4.el9.x86_64",
+      "lvm2-2.03.14-3.el9.x86_64",
+      "lvm2-libs-2.03.14-3.el9.x86_64",
       "lz4-libs-1.9.3-5.el9.x86_64",
       "lzo-2.10-7.el9.x86_64",
       "man-db-2.9.3-6.el9.x86_64",
@@ -14643,13 +14871,27 @@
     "partitions": [
       {
         "bootable": false,
-        "fstype": "xfs",
-        "label": "root",
+        "fstype": "LVM2_member",
+        "label": null,
+        "lvm": true,
+        "lvm.vg": "rootvg",
+        "lvm.volumes": {
+          "optlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+          },
+          "rootlv": {
+            "fstype": "xfs",
+            "label": "root",
+            "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+          }
+        },
         "partuuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
         "size": 10001300992,
         "start": 736100352,
-        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-        "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+        "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+        "uuid": "kz0dt1-W2l6-CQkF-D1WH-sCgi-UZgv-scUSJg"
       },
       {
         "bootable": false,
@@ -14697,7 +14939,7 @@
       "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
       "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
       "operator:x:11:0:operator:/root:/sbin/nologin",
-      "polkitd:x:998:995:User for polkitd:/:/sbin/nologin",
+      "polkitd:x:998:996:User for polkitd:/:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin",
       "rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin",
@@ -14706,7 +14948,7 @@
       "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
       "sssd:x:996:993:User for sssd:/:/sbin/nologin",
       "sync:x:5:0:sync:/sbin:/bin/sync",
-      "systemd-coredump:x:999:996:systemd Core Dumper:/:/sbin/nologin",
+      "systemd-coredump:x:999:997:systemd Core Dumper:/:/sbin/nologin",
       "tcpdump:x:72:72::/:/sbin/nologin",
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
       "user1:x:1000:1000::/home/user1:/bin/bash",
@@ -14735,6 +14977,7 @@
       }
     },
     "services-disabled": [
+      "blk-availability.service",
       "chrony-wait.service",
       "cockpit.socket",
       "console-getty.service",
@@ -14793,11 +15036,14 @@
       "dbus-org.freedesktop.nm-dispatcher.service",
       "dbus.service",
       "dbus.socket",
+      "dm-event.socket",
       "dnf-makecache.timer",
       "firewalld.service",
       "getty@.service",
       "irqbalance.service",
       "kdump.service",
+      "lvm2-lvmpolld.socket",
+      "lvm2-monitor.service",
       "microcode.service",
       "nfs-client.target",
       "nis-domainname.service",
@@ -14994,6 +15240,10 @@
         ],
         "libselinux.conf": [
           "d /run/setrans 0755 root root"
+        ],
+        "lvm2.conf": [
+          "d /run/lock/lvm 0700 root root -",
+          "d /run/lvm 0700 root root -"
         ],
         "man-db.conf": [
           "d /var/cache/man 0755 root root 1w"

--- a/test/data/manifests/rhel_86-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-qcow2_customize-boot.json
@@ -86,7 +86,13 @@
           "disabled": [
             "bluetooth.service"
           ]
-        }
+        },
+        "filesystem": [
+          {
+            "mountpoint": "/opt",
+            "minsize": 1073741824
+          }
+        ]
       }
     }
   },
@@ -999,7 +1005,16 @@
                     "id": "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c"
                   },
                   {
+                    "id": "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10"
+                  },
+                  {
+                    "id": "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b"
+                  },
+                  {
                     "id": "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190"
+                  },
+                  {
+                    "id": "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779"
                   },
                   {
                     "id": "sha256:97a64e70f2dcfd1f274e610f2d38edac0930c1cdba369ee8dce8fa052eeb77b5"
@@ -1350,6 +1365,9 @@
                     "id": "sha256:7c014b54f7929348f614f8f4eb7a1552b8565c0a57f3a75ff6471dc05f30cafe"
                   },
                   {
+                    "id": "sha256:98f838a9775269a0f796151bd54d52c7ac91d4bf1365186772f243bfafbb136a"
+                  },
+                  {
                     "id": "sha256:26725f2da31ba8cf58b34c70bdb763aa21fb9a9fe25ced46e70f071606ffbc94"
                   },
                   {
@@ -1657,6 +1675,12 @@
                   },
                   {
                     "id": "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f"
+                  },
+                  {
+                    "id": "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7"
+                  },
+                  {
+                    "id": "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b"
                   },
                   {
                     "id": "sha256:ab64a4ccc6b3f930aebb6413ece0031ceacdfba8ac7ee06c196b29df2f761ca1"
@@ -2315,7 +2339,9 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {}
+            "options": {
+              "prefix": ""
+            }
           },
           {
             "type": "org.osbuild.locale",
@@ -2433,6 +2459,18 @@
                   "options": "defaults"
                 },
                 {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
                   "uuid": "7B77-95E7",
                   "vfs_type": "vfat",
                   "path": "/boot/efi",
@@ -2446,6 +2484,7 @@
             "type": "org.osbuild.grub2",
             "options": {
               "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "boot_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug",
               "uefi": {
                 "vendor": "redhat"
@@ -2488,10 +2527,16 @@
                   "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
                 },
                 {
-                  "size": 20764639,
-                  "start": 206848,
-                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "size": 19716063,
+                  "start": 1255424,
+                  "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                },
+                {
+                  "size": 1048576,
+                  "start": 206848,
+                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                  "uuid": "a178892e-e285-4ce1-9114-55780875d64e"
                 }
               ]
             },
@@ -2500,6 +2545,32 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.lvm2.create",
+            "options": {
+              "volumes": [
+                {
+                  "name": "rootlv",
+                  "size": "3221225472B"
+                },
+                {
+                  "name": "optlv",
+                  "size": "1073741824B"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1255424,
+                  "size": 19716063,
                   "lock": true
                 }
               }
@@ -2530,11 +2601,59 @@
             },
             "devices": {
               "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1255424,
+                  "size": 19716063,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1255424,
+                  "size": 19716063,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+            },
+            "devices": {
+              "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
                   "start": 206848,
-                  "size": 20764639,
+                  "size": 1048576,
                   "lock": true
                 }
               }
@@ -2560,6 +2679,14 @@
               ]
             },
             "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 206848,
+                  "size": 1048576
+                }
+              },
               "boot.efi": {
                 "type": "org.osbuild.loopback",
                 "options": {
@@ -2568,12 +2695,26 @@
                   "size": 204800
                 }
               },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
               "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 206848,
-                  "size": 20764639
+                  "start": 1255424,
+                  "size": 19716063
                 }
               }
             },
@@ -2585,12 +2726,41 @@
                 "target": "/"
               },
               {
+                "name": "boot",
+                "type": "org.osbuild.xfs",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
                 "name": "boot.efi",
                 "type": "org.osbuild.fat",
                 "source": "boot.efi",
                 "target": "/boot/efi"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
+          },
+          {
+            "type": "org.osbuild.lvm2.metadata",
+            "options": {
+              "vg_name": "rootvg"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1255424,
+                  "size": 19716063,
+                  "lock": true
+                }
+              }
+            }
           }
         ]
       },
@@ -6720,6 +6890,24 @@
         "checksum": "sha256:2a420e856b68f3e1b3a8c188a1125dda9227e1ab8b35ca920cad89514b3df78c"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:6b962303647bb162c6a7286dacb9c83763566259d703730d0520f7e738378e10"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.aarch64.rpm",
+        "checksum": "sha256:fe04937e882a2b966755372bafbcb035341500a7a7dd147bc66e4cbe0200125b"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -6727,6 +6915,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.aarch64.rpm",
         "checksum": "sha256:4e114f5bb633c2f8edcb0bf7c81b8279e8d5f172bf3a4455873ee3cf6c0c0190"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.aarch64.rpm",
+        "checksum": "sha256:20419db9b1d55a27655c1889cac320179d90694d339fd4cd24e2decfcc601779"
       },
       {
         "name": "dhcp-client",
@@ -7773,6 +7970,15 @@
         "checksum": "sha256:7c014b54f7929348f614f8f4eb7a1552b8565c0a57f3a75ff6471dc05f30cafe"
       },
       {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.112",
+        "release": "1.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/libaio-0.3.112-1.el8.aarch64.rpm",
+        "checksum": "sha256:98f838a9775269a0f796151bd54d52c7ac91d4bf1365186772f243bfafbb136a"
+      },
+      {
         "name": "libappstream-glib",
         "epoch": 0,
         "version": "0.7.14",
@@ -8698,6 +8904,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.aarch64.rpm",
         "checksum": "sha256:907d81d7def024a4302b0f5d2eec4589a21f4e9d677cdaf10d76afc52a87cc8f"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:36349547732d801731f2693848900347658aca2cc550fb659d0e8d6f2a1ddba7"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.aarch64.rpm",
+        "checksum": "sha256:1513c7c513adac32c0ca93d629e67925d15d7a7dd355b8799ccde5ca5c2a6e7b"
       },
       {
         "name": "lz4-libs",
@@ -10649,8 +10873,8 @@
         "grub_class": "kernel",
         "grub_users": "$grub_users",
         "id": "rhel-20220124154203-0-rescue-ffffffffffffffffffffffffffffffff",
-        "initrd": "/boot/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
-        "linux": "/boot/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff",
+        "initrd": "/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
+        "linux": "/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff",
         "options": "$kernelopts",
         "title": "Red Hat Enterprise Linux (0-rescue-ffffffffffffffffffffffffffffffff) 8.6 (Ootpa)",
         "version": "0-rescue-ffffffffffffffffffffffffffffffff"
@@ -10660,8 +10884,8 @@
         "grub_class": "kernel",
         "grub_users": "$grub_users",
         "id": "rhel-20220124154203-4.18.0-361.el8.aarch64",
-        "initrd": "/boot/initramfs-4.18.0-361.el8.aarch64.img $tuned_initrd",
-        "linux": "/boot/vmlinuz-4.18.0-361.el8.aarch64",
+        "initrd": "/initramfs-4.18.0-361.el8.aarch64.img $tuned_initrd",
+        "linux": "/vmlinuz-4.18.0-361.el8.aarch64",
         "options": "$kernelopts $tuned_params",
         "title": "Red Hat Enterprise Linux (4.18.0-361.el8.aarch64) 8.6 (Ootpa)",
         "version": "4.18.0-361.el8.aarch64"
@@ -10838,12 +11062,28 @@
         "0"
       ],
       [
+        "UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+        "/opt",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
+      ],
+      [
         "UUID=7B77-95E7",
         "/boot/efi",
         "vfat",
         "defaults,uid=0,gid=0,umask=077,shortname=winnt",
         "0",
         "2"
+      ],
+      [
+        "UUID=fb180daf-48a7-4ee0-b10d-394651850fd4",
+        "/boot",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
       ]
     ],
     "groups": [
@@ -10997,7 +11237,10 @@
       "dejavu-fonts-common-2.35-7.el8.noarch",
       "dejavu-sans-mono-fonts-2.35-7.el8.noarch",
       "device-mapper-1.02.181-3.el8.aarch64",
+      "device-mapper-event-1.02.181-3.el8.aarch64",
+      "device-mapper-event-libs-1.02.181-3.el8.aarch64",
       "device-mapper-libs-1.02.181-3.el8.aarch64",
+      "device-mapper-persistent-data-0.9.0-6.el8.aarch64",
       "dhcp-client-4.3.6-47.el8.aarch64",
       "dhcp-common-4.3.6-47.el8.noarch",
       "dhcp-libs-4.3.6-47.el8.aarch64",
@@ -11125,6 +11368,7 @@
       "libXext-1.3.4-1.el8.aarch64",
       "libXrender-0.9.10-7.el8.aarch64",
       "libacl-2.2.53-1.el8.aarch64",
+      "libaio-0.3.112-1.el8.aarch64",
       "libappstream-glib-0.7.14-3.el8.aarch64",
       "libarchive-3.3.3-3.el8_5.aarch64",
       "libassuan-2.5.1-3.el8.aarch64",
@@ -11233,6 +11477,8 @@
       "lshw-B.02.19.2-6.el8.aarch64",
       "lsscsi-0.32-3.el8.aarch64",
       "lua-libs-5.3.4-12.el8.aarch64",
+      "lvm2-2.03.14-3.el8.aarch64",
+      "lvm2-libs-2.03.14-3.el8.aarch64",
       "lz4-libs-1.8.3-3.el8_4.aarch64",
       "lzo-2.08-14.el8.aarch64",
       "man-db-2.7.6.1-18.el8.aarch64",
@@ -11432,13 +11678,27 @@
     "partitions": [
       {
         "bootable": false,
-        "fstype": "xfs",
-        "label": "root",
+        "fstype": "LVM2_member",
+        "label": null,
+        "lvm": true,
+        "lvm.vg": "rootvg",
+        "lvm.volumes": {
+          "optlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+          },
+          "rootlv": {
+            "fstype": "xfs",
+            "label": "root",
+            "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+          }
+        },
         "partuuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
-        "size": 10631495168,
-        "start": 105906176,
-        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-        "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+        "size": 10094624256,
+        "start": 642777088,
+        "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+        "uuid": "2xY5nH-ghpH-8GFG-eDh6-ORrK-6T0B-FK1MnG"
       },
       {
         "bootable": false,
@@ -11449,6 +11709,16 @@
         "start": 1048576,
         "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
         "uuid": "7B77-95E7"
+      },
+      {
+        "bootable": false,
+        "fstype": "xfs",
+        "label": null,
+        "partuuid": "A178892E-E285-4CE1-9114-55780875D64E",
+        "size": 536870912,
+        "start": 105906176,
+        "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+        "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
       }
     ],
     "passwd": [
@@ -11559,6 +11829,7 @@
     },
     "services-disabled": [
       "arp-ethers.service",
+      "blk-availability.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
       "cockpit.socket",
@@ -11622,6 +11893,7 @@
       "dbus-org.fedoraproject.FirewallD1.service",
       "dbus-org.freedesktop.nm-dispatcher.service",
       "dbus-org.freedesktop.timedate1.service",
+      "dm-event.socket",
       "dnf-makecache.timer",
       "firewalld.service",
       "getty@.service",
@@ -11630,6 +11902,8 @@
       "irqbalance.service",
       "kdump.service",
       "loadmodules.service",
+      "lvm2-lvmpolld.socket",
+      "lvm2-monitor.service",
       "nfs-client.target",
       "nis-domainname.service",
       "qemu-guest-agent.service",
@@ -11809,6 +12083,10 @@
         ],
         "libselinux.conf": [
           "d /run/setrans 0755 root root"
+        ],
+        "lvm2.conf": [
+          "d /run/lock/lvm 0700 root root -",
+          "d /run/lvm 0700 root root -"
         ],
         "man-db.conf": [
           "d /var/cache/man 0755 root root 1w"

--- a/test/data/manifests/rhel_86-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-ppc64le-qcow2_customize-boot.json
@@ -86,7 +86,13 @@
           "disabled": [
             "bluetooth.service"
           ]
-        }
+        },
+        "filesystem": [
+          {
+            "mountpoint": "/opt",
+            "minsize": 1073741824
+          }
+        ]
       }
     }
   },
@@ -1017,7 +1023,16 @@
                     "id": "sha256:e66ce7c32295a681e3490622fb248b3d9051222b9823a3e3cb949f90bc0af52d"
                   },
                   {
+                    "id": "sha256:5d85a1597bf6f700cca5c04578ffb9e7b31ec12978037571451d9201f9cb7925"
+                  },
+                  {
+                    "id": "sha256:bf434762c1fd10027fadc23d1faf042b455c12b7d2a0482de35a1884a0459f5e"
+                  },
+                  {
                     "id": "sha256:937db0c8b6f98bb907bc302bc6386f01f25e9122c0f588dad9ab38e9f8315fe4"
+                  },
+                  {
+                    "id": "sha256:1b665ac7d65e2858875ffab4b613a864d3933a2c7e181f772f10de59669f1da5"
                   },
                   {
                     "id": "sha256:4025781d8a7bcc534fe06fe59f46cc648df9dd3d29c39253397cf1acee58f6f6"
@@ -1356,6 +1371,9 @@
                     "id": "sha256:68269d4f3588a15e94360c9d0f595d0ad7f1ece27968162ac42468acd462e526"
                   },
                   {
+                    "id": "sha256:3d425b214eeb598d59e4891ee3f5b0c941ff4755790907588309b431c1482195"
+                  },
+                  {
                     "id": "sha256:cd1ed33bd28c614fe79026826b697c6904a67bf979d2720c2632d0f20c69c457"
                   },
                   {
@@ -1675,6 +1693,12 @@
                   },
                   {
                     "id": "sha256:3fedcb5f53f536aef83384e91606ab2281393997095707ea723f2e9f80a3e417"
+                  },
+                  {
+                    "id": "sha256:eab3bbfcaa04c6e4f277410d71ab6f1da33e2a89f6b03dacc46e02929efc369d"
+                  },
+                  {
+                    "id": "sha256:a08aa2b7a53b18f540fb609dfcce1c8e70dd757e79a22cff74dae05a404f4a23"
                   },
                   {
                     "id": "sha256:eacfb3a0ad76aadb67c4103a188c35a69d69f91dcfd6272de238cbaa087bf264"
@@ -2468,7 +2492,9 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {}
+            "options": {
+              "prefix": ""
+            }
           },
           {
             "type": "org.osbuild.locale",
@@ -2584,6 +2610,18 @@
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
+                },
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
+                  "options": "defaults"
                 }
               ]
             }
@@ -2592,6 +2630,7 @@
             "type": "org.osbuild.grub2",
             "options": {
               "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "boot_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug",
               "legacy": "powerpc-ieee1275",
               "saved_entry": "ffffffffffffffffffffffffffffffff-4.18.0-361.el8.ppc64le",
@@ -2632,7 +2671,12 @@
                   "type": "41"
                 },
                 {
-                  "size": 20961280,
+                  "size": 19912704,
+                  "start": 1058816,
+                  "type": "8e"
+                },
+                {
+                  "size": 1048576,
                   "start": 10240
                 }
               ]
@@ -2648,9 +2692,83 @@
             }
           },
           {
+            "type": "org.osbuild.lvm2.create",
+            "options": {
+              "volumes": [
+                {
+                  "name": "rootlv",
+                  "size": "3221225472B"
+                },
+                {
+                  "name": "optlv",
+                  "size": "1073741824B"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1058816,
+                  "size": 19912704,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1058816,
+                  "size": 19912704,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1058816,
+                  "size": 19912704,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
             },
             "devices": {
               "device": {
@@ -2658,7 +2776,7 @@
                 "options": {
                   "filename": "disk.img",
                   "start": 10240,
-                  "size": 20961280,
+                  "size": 1048576,
                   "lock": true
                 }
               }
@@ -2684,12 +2802,34 @@
               ]
             },
             "devices": {
-              "root": {
+              "boot": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
                   "start": 10240,
-                  "size": 20961280
+                  "size": 1048576
+                }
+              },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1058816,
+                  "size": 19912704
                 }
               }
             },
@@ -2699,8 +2839,37 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.xfs",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
+          },
+          {
+            "type": "org.osbuild.lvm2.metadata",
+            "options": {
+              "vg_name": "rootvg"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1058816,
+                  "size": 19912704,
+                  "lock": true
+                }
+              }
+            }
           },
           {
             "type": "org.osbuild.grub2.inst",
@@ -2716,8 +2885,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "dos",
-                "number": 1,
-                "path": "/boot/grub2"
+                "number": 2,
+                "path": "/grub2"
               }
             }
           }
@@ -7038,6 +7207,24 @@
         "checksum": "sha256:e66ce7c32295a681e3490622fb248b3d9051222b9823a3e3cb949f90bc0af52d"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.ppc64le.rpm",
+        "checksum": "sha256:5d85a1597bf6f700cca5c04578ffb9e7b31ec12978037571451d9201f9cb7925"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.ppc64le.rpm",
+        "checksum": "sha256:bf434762c1fd10027fadc23d1faf042b455c12b7d2a0482de35a1884a0459f5e"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -7045,6 +7232,15 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.ppc64le.rpm",
         "checksum": "sha256:937db0c8b6f98bb907bc302bc6386f01f25e9122c0f588dad9ab38e9f8315fe4"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.ppc64le.rpm",
+        "checksum": "sha256:1b665ac7d65e2858875ffab4b613a864d3933a2c7e181f772f10de59669f1da5"
       },
       {
         "name": "dhcp-client",
@@ -8055,6 +8251,15 @@
         "checksum": "sha256:68269d4f3588a15e94360c9d0f595d0ad7f1ece27968162ac42468acd462e526"
       },
       {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.112",
+        "release": "1.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/libaio-0.3.112-1.el8.ppc64le.rpm",
+        "checksum": "sha256:3d425b214eeb598d59e4891ee3f5b0c941ff4755790907588309b431c1482195"
+      },
+      {
         "name": "libappstream-glib",
         "epoch": 0,
         "version": "0.7.14",
@@ -9016,6 +9221,24 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.ppc64le.rpm",
         "checksum": "sha256:3fedcb5f53f536aef83384e91606ab2281393997095707ea723f2e9f80a3e417"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:eab3bbfcaa04c6e4f277410d71ab6f1da33e2a89f6b03dacc46e02929efc369d"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-ppc64le-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.ppc64le.rpm",
+        "checksum": "sha256:a08aa2b7a53b18f540fb609dfcce1c8e70dd757e79a22cff74dae05a404f4a23"
       },
       {
         "name": "lz4-libs",
@@ -11398,8 +11621,8 @@
         "grub_class": "kernel",
         "grub_users": "$grub_users",
         "id": "rhel-20220124153344-0-rescue-ffffffffffffffffffffffffffffffff",
-        "initrd": "/boot/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
-        "linux": "/boot/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff",
+        "initrd": "/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
+        "linux": "/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff",
         "options": "$kernelopts",
         "title": "Red Hat Enterprise Linux (0-rescue-ffffffffffffffffffffffffffffffff) 8.6 (Ootpa)",
         "version": "0-rescue-ffffffffffffffffffffffffffffffff"
@@ -11409,8 +11632,8 @@
         "grub_class": "kernel",
         "grub_users": "$grub_users",
         "id": "rhel-20220124153344-4.18.0-361.el8.ppc64le",
-        "initrd": "/boot/initramfs-4.18.0-361.el8.ppc64le.img $tuned_initrd",
-        "linux": "/boot/vmlinuz-4.18.0-361.el8.ppc64le",
+        "initrd": "/initramfs-4.18.0-361.el8.ppc64le.img $tuned_initrd",
+        "linux": "/vmlinuz-4.18.0-361.el8.ppc64le",
         "options": "$kernelopts $tuned_params",
         "title": "Red Hat Enterprise Linux (4.18.0-361.el8.ppc64le) 8.6 (Ootpa)",
         "version": "4.18.0-361.el8.ppc64le"
@@ -11585,6 +11808,22 @@
         "defaults",
         "0",
         "0"
+      ],
+      [
+        "UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+        "/opt",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
+      ],
+      [
+        "UUID=fb180daf-48a7-4ee0-b10d-394651850fd4",
+        "/boot",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
       ]
     ],
     "groups": [
@@ -11739,7 +11978,10 @@
       "dejavu-fonts-common-2.35-7.el8.noarch",
       "dejavu-sans-mono-fonts-2.35-7.el8.noarch",
       "device-mapper-1.02.181-3.el8.ppc64le",
+      "device-mapper-event-1.02.181-3.el8.ppc64le",
+      "device-mapper-event-libs-1.02.181-3.el8.ppc64le",
       "device-mapper-libs-1.02.181-3.el8.ppc64le",
+      "device-mapper-persistent-data-0.9.0-6.el8.ppc64le",
       "dhcp-client-4.3.6-47.el8.ppc64le",
       "dhcp-common-4.3.6-47.el8.noarch",
       "dhcp-libs-4.3.6-47.el8.ppc64le",
@@ -11863,6 +12105,7 @@
       "libXext-1.3.4-1.el8.ppc64le",
       "libXrender-0.9.10-7.el8.ppc64le",
       "libacl-2.2.53-1.el8.ppc64le",
+      "libaio-0.3.112-1.el8.ppc64le",
       "libappstream-glib-0.7.14-3.el8.ppc64le",
       "libarchive-3.3.3-3.el8_5.ppc64le",
       "libassuan-2.5.1-3.el8.ppc64le",
@@ -11975,6 +12218,8 @@
       "lsscsi-0.32-3.el8.ppc64le",
       "lsvpd-1.7.13-1.el8.ppc64le",
       "lua-libs-5.3.4-12.el8.ppc64le",
+      "lvm2-2.03.14-3.el8.ppc64le",
+      "lvm2-libs-2.03.14-3.el8.ppc64le",
       "lz4-libs-1.8.3-3.el8_4.ppc64le",
       "lzo-2.08-14.el8.ppc64le",
       "man-db-2.7.6.1-18.el8.ppc64le",
@@ -12229,13 +12474,37 @@
       },
       {
         "bootable": false,
+        "fstype": "LVM2_member",
+        "label": null,
+        "lvm": true,
+        "lvm.vg": "rootvg",
+        "lvm.volumes": {
+          "optlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+          },
+          "rootlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+          }
+        },
+        "partuuid": "14fc63d2-02",
+        "size": 10195304448,
+        "start": 542113792,
+        "type": "8e",
+        "uuid": "8cJPit-0D87-AO82-u5nm-j1iU-j8NC-PpP4pW"
+      },
+      {
+        "bootable": false,
         "fstype": "xfs",
         "label": null,
-        "partuuid": "14fc63d2-02",
-        "size": 10732175360,
+        "partuuid": "14fc63d2-03",
+        "size": 536870912,
         "start": 5242880,
         "type": "83",
-        "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+        "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
       }
     ],
     "passwd": [
@@ -12346,6 +12615,7 @@
     },
     "services-disabled": [
       "arp-ethers.service",
+      "blk-availability.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
       "cockpit.socket",
@@ -12410,6 +12680,7 @@
       "dbus-org.fedoraproject.FirewallD1.service",
       "dbus-org.freedesktop.nm-dispatcher.service",
       "dbus-org.freedesktop.timedate1.service",
+      "dm-event.socket",
       "dnf-makecache.timer",
       "firewalld.service",
       "getty@.service",
@@ -12419,6 +12690,8 @@
       "irqbalance.service",
       "kdump.service",
       "loadmodules.service",
+      "lvm2-lvmpolld.socket",
+      "lvm2-monitor.service",
       "nfs-client.target",
       "nis-domainname.service",
       "opal-prd.service",
@@ -12601,6 +12874,10 @@
         ],
         "libselinux.conf": [
           "d /run/setrans 0755 root root"
+        ],
+        "lvm2.conf": [
+          "d /run/lock/lvm 0700 root root -",
+          "d /run/lvm 0700 root root -"
         ],
         "man-db.conf": [
           "d /var/cache/man 0755 root root 1w"

--- a/test/data/manifests/rhel_86-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-s390x-qcow2_customize-boot.json
@@ -86,7 +86,13 @@
           "disabled": [
             "bluetooth.service"
           ]
-        }
+        },
+        "filesystem": [
+          {
+            "mountpoint": "/opt",
+            "minsize": 1073741824
+          }
+        ]
       }
     }
   },
@@ -1177,7 +1183,16 @@
                     "id": "sha256:146bb65ce0209b7c9b66fcb9aebcab8026f76f64d1951c00ce69569d0323c00d"
                   },
                   {
+                    "id": "sha256:8ade9d97e56e637c419e7cffb75b791d68e643f1de119255810ceff0dd51bce5"
+                  },
+                  {
+                    "id": "sha256:23a5d79206aa634b2b5e7f4e1562c41c0d15790c99502b7d3504b81488fde2ec"
+                  },
+                  {
                     "id": "sha256:f946ed7843095bec3e9a92c1977268a669561b7c04025acd0045312d9ee12adc"
+                  },
+                  {
+                    "id": "sha256:fdf4cf3aec01335d5cfe309acfe1cb9befa4726de6724cd53bddf407e206f988"
                   },
                   {
                     "id": "sha256:bc567f22b2d2b82ead0aaddaed3af501378cdae0641d4ff06b2d02147d14ed5c"
@@ -1486,6 +1501,9 @@
                     "id": "sha256:18f6ad86cc7f681783183746576ba0cf5b9f0eee9ab18adb615bf6398404bb74"
                   },
                   {
+                    "id": "sha256:8ea5b21347e371f3f2e124f8ddaf38909485ec829767f936c3764e142c28093d"
+                  },
+                  {
                     "id": "sha256:78c646627263a41cd55eed285232115dec589954da8c18ac32f37b2fdd96c688"
                   },
                   {
@@ -1787,6 +1805,12 @@
                   },
                   {
                     "id": "sha256:ccdee478e3f7be0e7072a53ac12a718e96b341a96067cad49ba4d3bfea8b8df3"
+                  },
+                  {
+                    "id": "sha256:a6c6398e0ad2d90578d9c4fcab2528d455af63fd1b0e6eec413bd256c7df5537"
+                  },
+                  {
+                    "id": "sha256:f4394cdb3b9de902bb49315f58c27e9fc9c357a767ddd7e80ec66b7d199b2f74"
                   },
                   {
                     "id": "sha256:3cc27152e1f40c087ebdc8056f709d4fa2283e4950eff1cc1b2f5e7c34932a60"
@@ -2565,7 +2589,9 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {}
+            "options": {
+              "prefix": ""
+            }
           },
           {
             "type": "org.osbuild.locale",
@@ -2681,6 +2707,18 @@
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
+                },
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
+                  "options": "defaults"
                 }
               ]
             }
@@ -2716,7 +2754,12 @@
               "partitions": [
                 {
                   "bootable": true,
-                  "size": 20969472,
+                  "size": 19920896,
+                  "start": 1050624,
+                  "type": "8e"
+                },
+                {
+                  "size": 1048576,
                   "start": 2048
                 }
               ]
@@ -2732,9 +2775,83 @@
             }
           },
           {
+            "type": "org.osbuild.lvm2.create",
+            "options": {
+              "volumes": [
+                {
+                  "name": "rootlv",
+                  "size": "3221225472B"
+                },
+                {
+                  "name": "optlv",
+                  "size": "1073741824B"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1050624,
+                  "size": 19920896,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.mkfs.xfs",
             "options": {
               "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1050624,
+                  "size": 19920896,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1050624,
+                  "size": 19920896,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
             },
             "devices": {
               "device": {
@@ -2742,7 +2859,7 @@
                 "options": {
                   "filename": "disk.img",
                   "start": 2048,
-                  "size": 20969472,
+                  "size": 1048576,
                   "lock": true
                 }
               }
@@ -2768,18 +2885,40 @@
               ]
             },
             "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1048576
+                }
+              },
               "disk": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img"
                 }
               },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
               "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 2048,
-                  "size": 20969472
+                  "start": 1050624,
+                  "size": 19920896
                 }
               }
             },
@@ -2789,8 +2928,37 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.xfs",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
+          },
+          {
+            "type": "org.osbuild.lvm2.metadata",
+            "options": {
+              "vg_name": "rootvg"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1050624,
+                  "size": 19920896,
+                  "lock": true
+                }
+              }
+            }
           },
           {
             "type": "org.osbuild.zipl.inst",
@@ -2799,18 +2967,40 @@
               "location": 2048
             },
             "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 2048,
+                  "size": 1048576
+                }
+              },
               "disk": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img"
                 }
               },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
               "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 2048,
-                  "size": 20969472
+                  "start": 1050624,
+                  "size": 19920896
                 }
               }
             },
@@ -2820,6 +3010,18 @@
                 "type": "org.osbuild.xfs",
                 "source": "root",
                 "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.xfs",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
           }
@@ -7581,6 +7783,24 @@
         "checksum": "sha256:146bb65ce0209b7c9b66fcb9aebcab8026f76f64d1951c00ce69569d0323c00d"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.s390x.rpm",
+        "checksum": "sha256:8ade9d97e56e637c419e7cffb75b791d68e643f1de119255810ceff0dd51bce5"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.s390x.rpm",
+        "checksum": "sha256:23a5d79206aa634b2b5e7f4e1562c41c0d15790c99502b7d3504b81488fde2ec"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -7588,6 +7808,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.s390x.rpm",
         "checksum": "sha256:f946ed7843095bec3e9a92c1977268a669561b7c04025acd0045312d9ee12adc"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.s390x.rpm",
+        "checksum": "sha256:fdf4cf3aec01335d5cfe309acfe1cb9befa4726de6724cd53bddf407e206f988"
       },
       {
         "name": "dhcp-client",
@@ -8508,6 +8737,15 @@
         "checksum": "sha256:18f6ad86cc7f681783183746576ba0cf5b9f0eee9ab18adb615bf6398404bb74"
       },
       {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.112",
+        "release": "1.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/libaio-0.3.112-1.el8.s390x.rpm",
+        "checksum": "sha256:8ea5b21347e371f3f2e124f8ddaf38909485ec829767f936c3764e142c28093d"
+      },
+      {
         "name": "libappstream-glib",
         "epoch": 0,
         "version": "0.7.14",
@@ -9415,6 +9653,24 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.s390x.rpm",
         "checksum": "sha256:ccdee478e3f7be0e7072a53ac12a718e96b341a96067cad49ba4d3bfea8b8df3"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.s390x.rpm",
+        "checksum": "sha256:a6c6398e0ad2d90578d9c4fcab2528d455af63fd1b0e6eec413bd256c7df5537"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-s390x-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.s390x.rpm",
+        "checksum": "sha256:f4394cdb3b9de902bb49315f58c27e9fc9c357a767ddd7e80ec66b7d199b2f74"
       },
       {
         "name": "lz4-libs",
@@ -11909,6 +12165,22 @@
         "defaults",
         "0",
         "0"
+      ],
+      [
+        "UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+        "/opt",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
+      ],
+      [
+        "UUID=fb180daf-48a7-4ee0-b10d-394651850fd4",
+        "/boot",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
       ]
     ],
     "groups": [
@@ -12062,7 +12334,10 @@
       "dejavu-fonts-common-2.35-7.el8.noarch",
       "dejavu-sans-mono-fonts-2.35-7.el8.noarch",
       "device-mapper-1.02.181-3.el8.s390x",
+      "device-mapper-event-1.02.181-3.el8.s390x",
+      "device-mapper-event-libs-1.02.181-3.el8.s390x",
       "device-mapper-libs-1.02.181-3.el8.s390x",
+      "device-mapper-persistent-data-0.9.0-6.el8.s390x",
       "dhcp-client-4.3.6-47.el8.s390x",
       "dhcp-common-4.3.6-47.el8.noarch",
       "dhcp-libs-4.3.6-47.el8.s390x",
@@ -12176,6 +12451,7 @@
       "libXext-1.3.4-1.el8.s390x",
       "libXrender-0.9.10-7.el8.s390x",
       "libacl-2.2.53-1.el8.s390x",
+      "libaio-0.3.112-1.el8.s390x",
       "libappstream-glib-0.7.14-3.el8.s390x",
       "libarchive-3.3.3-3.el8_5.s390x",
       "libassuan-2.5.1-3.el8.s390x",
@@ -12282,6 +12558,8 @@
       "lshw-B.02.19.2-6.el8.s390x",
       "lsscsi-0.32-3.el8.s390x",
       "lua-libs-5.3.4-12.el8.s390x",
+      "lvm2-2.03.14-3.el8.s390x",
+      "lvm2-libs-2.03.14-3.el8.s390x",
       "lz4-libs-1.8.3-3.el8_4.s390x",
       "lzo-2.08-14.el8.s390x",
       "man-db-2.7.6.1-18.el8.s390x",
@@ -12521,13 +12799,37 @@
     "partitions": [
       {
         "bootable": true,
+        "fstype": "LVM2_member",
+        "label": null,
+        "lvm": true,
+        "lvm.vg": "rootvg",
+        "lvm.volumes": {
+          "optlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+          },
+          "rootlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+          }
+        },
+        "partuuid": "14fc63d2-01",
+        "size": 10199498752,
+        "start": 537919488,
+        "type": "8e",
+        "uuid": "4g5vE2-HlnQ-6tSo-xyKF-6nKa-POrr-f9WZMP"
+      },
+      {
+        "bootable": false,
         "fstype": "xfs",
         "label": null,
-        "partuuid": "14fc63d2-01",
-        "size": 10736369664,
+        "partuuid": "14fc63d2-02",
+        "size": 536870912,
         "start": 1048576,
         "type": "83",
-        "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+        "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
       }
     ],
     "passwd": [
@@ -12631,13 +12933,6 @@
       "missing": []
     },
     "selinux": {
-      "context-mismatch": [
-        {
-          "actual": "unconfined_u:object_r:boot_t:s0",
-          "expected": "system_u:object_r:boot_t:s0",
-          "filename": "/boot/bootmap"
-        }
-      ],
       "policy": {
         "SELINUX": "enforcing",
         "SELINUXTYPE": "targeted"
@@ -12645,6 +12940,7 @@
     },
     "services-disabled": [
       "arp-ethers.service",
+      "blk-availability.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
       "cockpit.socket",
@@ -12709,6 +13005,7 @@
       "dbus-org.freedesktop.nm-dispatcher.service",
       "dbus-org.freedesktop.timedate1.service",
       "device_cio_free.service",
+      "dm-event.socket",
       "dnf-makecache.timer",
       "firewalld.service",
       "getty@.service",
@@ -12716,6 +13013,8 @@
       "insights-client-boot.service",
       "kdump.service",
       "loadmodules.service",
+      "lvm2-lvmpolld.socket",
+      "lvm2-monitor.service",
       "nfs-client.target",
       "nis-domainname.service",
       "qemu-guest-agent.service",
@@ -12895,6 +13194,10 @@
         ],
         "libselinux.conf": [
           "d /run/setrans 0755 root root"
+        ],
+        "lvm2.conf": [
+          "d /run/lock/lvm 0700 root root -",
+          "d /run/lvm 0700 root root -"
         ],
         "man-db.conf": [
           "d /var/cache/man 0755 root root 1w"

--- a/test/data/manifests/rhel_86-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-qcow2_customize-boot.json
@@ -86,7 +86,13 @@
           "disabled": [
             "bluetooth.service"
           ]
-        }
+        },
+        "filesystem": [
+          {
+            "mountpoint": "/opt",
+            "minsize": 1073741824
+          }
+        ]
       }
     }
   },
@@ -1026,7 +1032,16 @@
                     "id": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
                   },
                   {
+                    "id": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+                  },
+                  {
+                    "id": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+                  },
+                  {
                     "id": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+                  },
+                  {
+                    "id": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
                   },
                   {
                     "id": "sha256:49c191045e168a303ba2bc655b5ecccf7fe19851db3d0563f52c50164a2ed8ba"
@@ -1383,6 +1398,9 @@
                     "id": "sha256:9461fa7a5e74bfd8d9e9961af9d3003d9d2b496830c2fd6b0641ae8b8bc8e178"
                   },
                   {
+                    "id": "sha256:d8f93540a6a7329a5158d3e543f77110104f30494f4d6f187427e5010d8df379"
+                  },
+                  {
                     "id": "sha256:c5d0c9a5acc6c2de5e52b38701d6cad5cc37d22c1cb518ca8bcac79bddffaaba"
                   },
                   {
@@ -1690,6 +1708,12 @@
                   },
                   {
                     "id": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+                  },
+                  {
+                    "id": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+                  },
+                  {
+                    "id": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
                   },
                   {
                     "id": "sha256:f0e3f336e2910f8282c39a5bce21ffa35d6037842d219761ed8c58b4208077cc"
@@ -2354,7 +2378,9 @@
           },
           {
             "type": "org.osbuild.fix-bls",
-            "options": {}
+            "options": {
+              "prefix": ""
+            }
           },
           {
             "type": "org.osbuild.locale",
@@ -2472,6 +2498,18 @@
                   "options": "defaults"
                 },
                 {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+                  "vfs_type": "xfs",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
                   "uuid": "7B77-95E7",
                   "vfs_type": "vfat",
                   "path": "/boot/efi",
@@ -2485,6 +2523,7 @@
             "type": "org.osbuild.grub2",
             "options": {
               "root_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "boot_fs_uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
               "kernel_opts": "console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto debug",
               "legacy": "i386-pc",
               "uefi": {
@@ -2535,10 +2574,16 @@
                   "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
                 },
                 {
-                  "size": 20762591,
-                  "start": 208896,
-                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "size": 19714015,
+                  "start": 1257472,
+                  "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                },
+                {
+                  "size": 1048576,
+                  "start": 208896,
+                  "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+                  "uuid": "a178892e-e285-4ce1-9114-55780875d64e"
                 }
               ]
             },
@@ -2547,6 +2592,32 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.lvm2.create",
+            "options": {
+              "volumes": [
+                {
+                  "name": "rootlv",
+                  "size": "3221225472B"
+                },
+                {
+                  "name": "optlv",
+                  "size": "1073741824B"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1257472,
+                  "size": 19714015,
                   "lock": true
                 }
               }
@@ -2577,11 +2648,59 @@
             },
             "devices": {
               "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1257472,
+                  "size": 19714015,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1257472,
+                  "size": 19714015,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+            },
+            "devices": {
+              "device": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
                   "start": 208896,
-                  "size": 20762591,
+                  "size": 1048576,
                   "lock": true
                 }
               }
@@ -2607,6 +2726,14 @@
               ]
             },
             "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 208896,
+                  "size": 1048576
+                }
+              },
               "boot.efi": {
                 "type": "org.osbuild.loopback",
                 "options": {
@@ -2615,12 +2742,26 @@
                   "size": 204800
                 }
               },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
               "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
-                  "start": 208896,
-                  "size": 20762591
+                  "start": 1257472,
+                  "size": 19714015
                 }
               }
             },
@@ -2632,12 +2773,41 @@
                 "target": "/"
               },
               {
+                "name": "boot",
+                "type": "org.osbuild.xfs",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
                 "name": "boot.efi",
                 "type": "org.osbuild.fat",
                 "source": "boot.efi",
                 "target": "/boot/efi"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
+          },
+          {
+            "type": "org.osbuild.lvm2.metadata",
+            "options": {
+              "vg_name": "rootvg"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1257472,
+                  "size": 19714015,
+                  "lock": true
+                }
+              }
+            }
           },
           {
             "type": "org.osbuild.grub2.inst",
@@ -2653,8 +2823,8 @@
               "prefix": {
                 "type": "partition",
                 "partlabel": "gpt",
-                "number": 2,
-                "path": "/boot/grub2"
+                "number": 3,
+                "path": "/grub2"
               }
             }
           }
@@ -6891,6 +7061,24 @@
         "checksum": "sha256:c6c77f539e43fa79a202b0939599d2a62a0ddcce4876436c88ae820638803ed8"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:d6566a116551e68db4b4fde7368dd66fc0e5715131a82954c1207913cebbda35"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 8,
+        "version": "1.02.181",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-event-libs-1.02.181-3.el8.x86_64.rpm",
+        "checksum": "sha256:2c6c406ef5f070a06d9369ae64a8e737c3a42f6ce478187327111f6bb28b5edc"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 8,
         "version": "1.02.181",
@@ -6898,6 +7086,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-libs-1.02.181-3.el8.x86_64.rpm",
         "checksum": "sha256:f0f0b9606d40f3e7ca0ac57ab1b5b01cd0c4aa7510a6af2f639544ca78eac613"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "6.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/device-mapper-persistent-data-0.9.0-6.el8.x86_64.rpm",
+        "checksum": "sha256:48877e5a29b708170eff6fe2baeb60082b878229ed55db40a2af8259ef3886ba"
       },
       {
         "name": "dhcp-client",
@@ -7962,6 +8159,15 @@
         "checksum": "sha256:9461fa7a5e74bfd8d9e9961af9d3003d9d2b496830c2fd6b0641ae8b8bc8e178"
       },
       {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.112",
+        "release": "1.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libaio-0.3.112-1.el8.x86_64.rpm",
+        "checksum": "sha256:d8f93540a6a7329a5158d3e543f77110104f30494f4d6f187427e5010d8df379"
+      },
+      {
         "name": "libappstream-glib",
         "epoch": 0,
         "version": "0.7.14",
@@ -8887,6 +9093,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lua-libs-5.3.4-12.el8.x86_64.rpm",
         "checksum": "sha256:1c040f943aba945547ebd7a060f1df910dca5d65cb353d6c7e7edbb51243d4c0"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:a736f5fe95a825fe7712f92b6c366b37883dd03410eea82b27debe77d7c67aa3"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 8,
+        "version": "2.03.14",
+        "release": "3.el8",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/lvm2-libs-2.03.14-3.el8.x86_64.rpm",
+        "checksum": "sha256:3b03c4955dd9cfa1b1aec1378ebb174f9fc93ec587a33b5ab0950fd5fb6b8f8e"
       },
       {
         "name": "lz4-libs",
@@ -10856,8 +11080,8 @@
         "grub_class": "kernel",
         "grub_users": "$grub_users",
         "id": "rhel-20220124162448-0-rescue-ffffffffffffffffffffffffffffffff",
-        "initrd": "/boot/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
-        "linux": "/boot/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff",
+        "initrd": "/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
+        "linux": "/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff",
         "options": "$kernelopts",
         "title": "Red Hat Enterprise Linux (0-rescue-ffffffffffffffffffffffffffffffff) 8.6 (Ootpa)",
         "version": "0-rescue-ffffffffffffffffffffffffffffffff"
@@ -10867,8 +11091,8 @@
         "grub_class": "kernel",
         "grub_users": "$grub_users",
         "id": "rhel-20220124162448-4.18.0-361.el8.x86_64",
-        "initrd": "/boot/initramfs-4.18.0-361.el8.x86_64.img $tuned_initrd",
-        "linux": "/boot/vmlinuz-4.18.0-361.el8.x86_64",
+        "initrd": "/initramfs-4.18.0-361.el8.x86_64.img $tuned_initrd",
+        "linux": "/vmlinuz-4.18.0-361.el8.x86_64",
         "options": "$kernelopts $tuned_params",
         "title": "Red Hat Enterprise Linux (4.18.0-361.el8.x86_64) 8.6 (Ootpa)",
         "version": "4.18.0-361.el8.x86_64"
@@ -11048,12 +11272,28 @@
         "0"
       ],
       [
+        "UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+        "/opt",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
+      ],
+      [
         "UUID=7B77-95E7",
         "/boot/efi",
         "vfat",
         "defaults,uid=0,gid=0,umask=077,shortname=winnt",
         "0",
         "2"
+      ],
+      [
+        "UUID=fb180daf-48a7-4ee0-b10d-394651850fd4",
+        "/boot",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
       ]
     ],
     "groups": [
@@ -11208,7 +11448,10 @@
       "dejavu-fonts-common-2.35-7.el8.noarch",
       "dejavu-sans-mono-fonts-2.35-7.el8.noarch",
       "device-mapper-1.02.181-3.el8.x86_64",
+      "device-mapper-event-1.02.181-3.el8.x86_64",
+      "device-mapper-event-libs-1.02.181-3.el8.x86_64",
       "device-mapper-libs-1.02.181-3.el8.x86_64",
+      "device-mapper-persistent-data-0.9.0-6.el8.x86_64",
       "dhcp-client-4.3.6-47.el8.x86_64",
       "dhcp-common-4.3.6-47.el8.noarch",
       "dhcp-libs-4.3.6-47.el8.x86_64",
@@ -11338,6 +11581,7 @@
       "libXext-1.3.4-1.el8.x86_64",
       "libXrender-0.9.10-7.el8.x86_64",
       "libacl-2.2.53-1.el8.x86_64",
+      "libaio-0.3.112-1.el8.x86_64",
       "libappstream-glib-0.7.14-3.el8.x86_64",
       "libarchive-3.3.3-3.el8_5.x86_64",
       "libassuan-2.5.1-3.el8.x86_64",
@@ -11446,6 +11690,8 @@
       "lshw-B.02.19.2-6.el8.x86_64",
       "lsscsi-0.32-3.el8.x86_64",
       "lua-libs-5.3.4-12.el8.x86_64",
+      "lvm2-2.03.14-3.el8.x86_64",
+      "lvm2-libs-2.03.14-3.el8.x86_64",
       "lz4-libs-1.8.3-3.el8_4.x86_64",
       "lzo-2.08-14.el8.x86_64",
       "man-db-2.7.6.1-18.el8.x86_64",
@@ -11647,13 +11893,27 @@
     "partitions": [
       {
         "bootable": false,
-        "fstype": "xfs",
-        "label": "root",
+        "fstype": "LVM2_member",
+        "label": null,
+        "lvm": true,
+        "lvm.vg": "rootvg",
+        "lvm.volumes": {
+          "optlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+          },
+          "rootlv": {
+            "fstype": "xfs",
+            "label": "root",
+            "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+          }
+        },
         "partuuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
-        "size": 10630446592,
-        "start": 106954752,
-        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-        "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+        "size": 10093575680,
+        "start": 643825664,
+        "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+        "uuid": "VJwT09-PeXd-yXKO-Qeul-Q3BU-uM08-4AA4Yr"
       },
       {
         "bootable": false,
@@ -11664,6 +11924,16 @@
         "start": 2097152,
         "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
         "uuid": "7B77-95E7"
+      },
+      {
+        "bootable": false,
+        "fstype": "xfs",
+        "label": null,
+        "partuuid": "A178892E-E285-4CE1-9114-55780875D64E",
+        "size": 536870912,
+        "start": 106954752,
+        "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
+        "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
       },
       {
         "bootable": false,
@@ -11790,6 +12060,7 @@
     },
     "services-disabled": [
       "arp-ethers.service",
+      "blk-availability.service",
       "chrony-dnssrv@.timer",
       "chrony-wait.service",
       "cockpit.socket",
@@ -11853,6 +12124,7 @@
       "dbus-org.fedoraproject.FirewallD1.service",
       "dbus-org.freedesktop.nm-dispatcher.service",
       "dbus-org.freedesktop.timedate1.service",
+      "dm-event.socket",
       "dnf-makecache.timer",
       "firewalld.service",
       "getty@.service",
@@ -11861,6 +12133,8 @@
       "irqbalance.service",
       "kdump.service",
       "loadmodules.service",
+      "lvm2-lvmpolld.socket",
+      "lvm2-monitor.service",
       "microcode.service",
       "nfs-client.target",
       "nis-domainname.service",
@@ -12041,6 +12315,10 @@
         ],
         "libselinux.conf": [
           "d /run/setrans 0755 root root"
+        ],
+        "lvm2.conf": [
+          "d /run/lock/lvm 0700 root root -",
+          "d /run/lvm 0700 root root -"
         ],
         "man-db.conf": [
           "d /var/cache/man 0755 root root 1w"

--- a/test/data/manifests/rhel_90-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2_customize-boot.json
@@ -86,7 +86,13 @@
           "disabled": [
             "bluetooth.service"
           ]
-        }
+        },
+        "filesystem": [
+          {
+            "mountpoint": "/opt",
+            "minsize": 1073741824
+          }
+        ]
       }
     }
   },
@@ -910,7 +916,16 @@
                     "id": "sha256:66216d9fd4f965c52ff4eb8898c865f55f93ce19026694c906faff5bc8c879d9"
                   },
                   {
+                    "id": "sha256:b5eee578957c7b33801b22e3d4cf9507d0a08573008406c9c8cca1aa79c8e575"
+                  },
+                  {
+                    "id": "sha256:03fe5d0b36685bb3265aa76850b2dc0d592aa0456dbb93feffa1569e8621d07e"
+                  },
+                  {
                     "id": "sha256:06b00dc80e718a1397acb52e66dee621b8212caf1dc3b91456fd035ccf10ccac"
+                  },
+                  {
+                    "id": "sha256:3b5ebc9bc7b8903ec9fe1ca988e6e678dd923ebf3e0d652a1b6e626b47699ed2"
                   },
                   {
                     "id": "sha256:04b753460308e93488a1c68781ff46907dfcb6d83e0023bccbb0c85789f439bc"
@@ -1184,6 +1199,9 @@
                   },
                   {
                     "id": "sha256:5684001de29ef187b78849729334c61ac7f77b4a56e0cdae0df196731777ec7c"
+                  },
+                  {
+                    "id": "sha256:59f83d0fedd13d27e3436834727d9319d419309f0280586d86fb818891818e14"
                   },
                   {
                     "id": "sha256:ed2db8caf254b5ea13720af8b3a691e83ca7964c2b9b7e484d9d7dcf2cd7ce99"
@@ -1496,6 +1514,12 @@
                   },
                   {
                     "id": "sha256:149abbe50fd335fd4031bdead143e5d768def9ff3842664b8fdb13173cb9215b"
+                  },
+                  {
+                    "id": "sha256:323b6cc520c6a89026c93d58edae8453f97be3fdd4ff4e32da917da7f9ee7785"
+                  },
+                  {
+                    "id": "sha256:b3ff011c504a7672e13b6c52f8b4e741b34c522fd557006286f59c8c363ab80e"
                   },
                   {
                     "id": "sha256:e1dbd2c38a65b135427c7c8fe988ea70dc95f7e26c4c8177b7dcb23925020015"
@@ -2232,6 +2256,12 @@
                   "options": "defaults"
                 },
                 {
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
+                  "options": "defaults"
+                },
+                {
                   "uuid": "7B77-95E7",
                   "vfs_type": "vfat",
                   "path": "/boot/efi",
@@ -2297,7 +2327,7 @@
                 {
                   "size": 19535839,
                   "start": 1435648,
-                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
               ]
@@ -2307,6 +2337,32 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.lvm2.create",
+            "options": {
+              "volumes": [
+                {
+                  "name": "rootlv",
+                  "size": "3221225472B"
+                },
+                {
+                  "name": "optlv",
+                  "size": "1073741824B"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1435648,
+                  "size": 19535839,
                   "lock": true
                 }
               }
@@ -2355,6 +2411,37 @@
             },
             "devices": {
               "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1435648,
+                  "size": 19535839,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -2401,7 +2488,21 @@
                   "size": 409600
                 }
               },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
               "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -2428,8 +2529,31 @@
                 "type": "org.osbuild.fat",
                 "source": "boot.efi",
                 "target": "/boot/efi"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
+          },
+          {
+            "type": "org.osbuild.lvm2.metadata",
+            "options": {
+              "vg_name": "rootvg"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1435648,
+                  "size": 19535839,
+                  "lock": true
+                }
+              }
+            }
           }
         ]
       },
@@ -6133,6 +6257,24 @@
         "checksum": "sha256:66216d9fd4f965c52ff4eb8898c865f55f93ce19026694c906faff5bc8c879d9"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 9,
+        "version": "1.02.181",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/device-mapper-event-1.02.181-3.el9.aarch64.rpm",
+        "checksum": "sha256:b5eee578957c7b33801b22e3d4cf9507d0a08573008406c9c8cca1aa79c8e575"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 9,
+        "version": "1.02.181",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/device-mapper-event-libs-1.02.181-3.el9.aarch64.rpm",
+        "checksum": "sha256:03fe5d0b36685bb3265aa76850b2dc0d592aa0456dbb93feffa1569e8621d07e"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 9,
         "version": "1.02.181",
@@ -6140,6 +6282,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/device-mapper-libs-1.02.181-3.el9.aarch64.rpm",
         "checksum": "sha256:06b00dc80e718a1397acb52e66dee621b8212caf1dc3b91456fd035ccf10ccac"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "12.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/device-mapper-persistent-data-0.9.0-12.el9.aarch64.rpm",
+        "checksum": "sha256:3b5ebc9bc7b8903ec9fe1ca988e6e678dd923ebf3e0d652a1b6e626b47699ed2"
       },
       {
         "name": "dhcp-client",
@@ -6959,6 +7110,15 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libacl-2.3.1-3.el9.aarch64.rpm",
         "checksum": "sha256:5684001de29ef187b78849729334c61ac7f77b4a56e0cdae0df196731777ec7c"
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "13.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/libaio-0.3.111-13.el9.aarch64.rpm",
+        "checksum": "sha256:59f83d0fedd13d27e3436834727d9319d419309f0280586d86fb818891818e14"
       },
       {
         "name": "libarchive",
@@ -7895,6 +8055,24 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/lua-libs-5.4.2-4.el9.aarch64.rpm",
         "checksum": "sha256:149abbe50fd335fd4031bdead143e5d768def9ff3842664b8fdb13173cb9215b"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 9,
+        "version": "2.03.14",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/lvm2-2.03.14-3.el9.aarch64.rpm",
+        "checksum": "sha256:323b6cc520c6a89026c93d58edae8453f97be3fdd4ff4e32da917da7f9ee7785"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 9,
+        "version": "2.03.14",
+        "release": "3.el9",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220208/Packages/lvm2-libs-2.03.14-3.el9.aarch64.rpm",
+        "checksum": "sha256:b3ff011c504a7672e13b6c52f8b4e741b34c522fd557006286f59c8c363ab80e"
       },
       {
         "name": "lz4-libs",
@@ -9927,6 +10105,14 @@
         "defaults,uid=0,gid=0,umask=077,shortname=winnt",
         "0",
         "2"
+      ],
+      [
+        "UUID=fb180daf-48a7-4ee0-b10d-394651850fd4",
+        "/opt",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
       ]
     ],
     "groups": [
@@ -9946,7 +10132,7 @@
       "games:x:20:",
       "group1:x:1030:user2",
       "group2:x:1050:",
-      "input:x:998:",
+      "input:x:999:",
       "kmem:x:9:",
       "kvm:x:36:",
       "lock:x:54:",
@@ -9955,17 +10141,17 @@
       "man:x:15:",
       "mem:x:8:",
       "nobody:x:65534:",
-      "polkitd:x:995:",
-      "render:x:997:",
+      "polkitd:x:996:",
+      "render:x:998:",
       "root:x:0:",
       "rpc:x:32:",
       "rpcuser:x:29:",
       "setroubleshoot:x:994:",
-      "ssh_keys:x:999:",
+      "ssh_keys:x:995:",
       "sshd:x:74:",
       "sssd:x:993:",
       "sys:x:3:",
-      "systemd-coredump:x:996:",
+      "systemd-coredump:x:997:",
       "systemd-journal:x:190:",
       "tape:x:33:",
       "tcpdump:x:72:",
@@ -10072,7 +10258,10 @@
       "dbus-libs-1.12.20-5.el9.aarch64",
       "dbus-tools-1.12.20-5.el9.aarch64",
       "device-mapper-1.02.181-3.el9.aarch64",
+      "device-mapper-event-1.02.181-3.el9.aarch64",
+      "device-mapper-event-libs-1.02.181-3.el9.aarch64",
       "device-mapper-libs-1.02.181-3.el9.aarch64",
+      "device-mapper-persistent-data-0.9.0-12.el9.aarch64",
       "dhcp-client-4.4.2-15.b1.el9.aarch64",
       "dhcp-common-4.4.2-15.b1.el9.noarch",
       "diffutils-3.7-12.el9.aarch64",
@@ -10174,6 +10363,7 @@
       "krb5-libs-1.19.1-13.el9.aarch64",
       "less-575-4.el9.aarch64",
       "libacl-2.3.1-3.el9.aarch64",
+      "libaio-0.3.111-13.el9.aarch64",
       "libappstream-glib-0.7.18-4.el9.aarch64",
       "libarchive-3.5.2-1.el9.aarch64",
       "libassuan-2.5.5-3.el9.aarch64",
@@ -10285,6 +10475,8 @@
       "lshw-B.02.19.2-7.el9.aarch64",
       "lsscsi-0.32-6.el9.aarch64",
       "lua-libs-5.4.2-4.el9.aarch64",
+      "lvm2-2.03.14-3.el9.aarch64",
+      "lvm2-libs-2.03.14-3.el9.aarch64",
       "lz4-libs-1.9.3-5.el9.aarch64",
       "lzo-2.10-7.el9.aarch64",
       "man-db-2.9.3-6.el9.aarch64",
@@ -10468,13 +10660,27 @@
     "partitions": [
       {
         "bootable": false,
-        "fstype": "xfs",
-        "label": "root",
+        "fstype": "LVM2_member",
+        "label": null,
+        "lvm": true,
+        "lvm.vg": "rootvg",
+        "lvm.volumes": {
+          "optlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+          },
+          "rootlv": {
+            "fstype": "xfs",
+            "label": "root",
+            "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+          }
+        },
         "partuuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
         "size": 10002349568,
         "start": 735051776,
-        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-        "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+        "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+        "uuid": "SqTdCg-tyNR-AT97-CO0u-0Hwc-I53g-fTQB53"
       },
       {
         "bootable": false,
@@ -10512,7 +10718,7 @@
       "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
       "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
       "operator:x:11:0:operator:/root:/sbin/nologin",
-      "polkitd:x:998:995:User for polkitd:/:/sbin/nologin",
+      "polkitd:x:998:996:User for polkitd:/:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin",
       "rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin",
@@ -10521,7 +10727,7 @@
       "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
       "sssd:x:996:993:User for sssd:/:/sbin/nologin",
       "sync:x:5:0:sync:/sbin:/bin/sync",
-      "systemd-coredump:x:999:996:systemd Core Dumper:/:/sbin/nologin",
+      "systemd-coredump:x:999:997:systemd Core Dumper:/:/sbin/nologin",
       "tcpdump:x:72:72::/:/sbin/nologin",
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
       "user1:x:1000:1000::/home/user1:/bin/bash",
@@ -10603,6 +10809,7 @@
       }
     },
     "services-disabled": [
+      "blk-availability.service",
       "chrony-wait.service",
       "cockpit.socket",
       "console-getty.service",
@@ -10664,6 +10871,7 @@
       "dbus-org.freedesktop.nm-dispatcher.service",
       "dbus.service",
       "dbus.socket",
+      "dm-event.socket",
       "dnf-makecache.timer",
       "firewalld.service",
       "getty@.service",
@@ -10671,6 +10879,8 @@
       "irqbalance.service",
       "kdump.service",
       "logrotate.timer",
+      "lvm2-lvmpolld.socket",
+      "lvm2-monitor.service",
       "nfs-client.target",
       "nis-domainname.service",
       "qemu-guest-agent.service",
@@ -10867,6 +11077,10 @@
         ],
         "libselinux.conf": [
           "d /run/setrans 0755 root root"
+        ],
+        "lvm2.conf": [
+          "d /run/lock/lvm 0700 root root -",
+          "d /run/lvm 0700 root root -"
         ],
         "man-db.conf": [
           "d /var/cache/man 0755 root root 1w"

--- a/test/data/manifests/rhel_90-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-qcow2_customize-boot.json
@@ -86,7 +86,13 @@
           "disabled": [
             "bluetooth.service"
           ]
-        }
+        },
+        "filesystem": [
+          {
+            "mountpoint": "/opt",
+            "minsize": 1073741824
+          }
+        ]
       }
     }
   },
@@ -943,7 +949,16 @@
                     "id": "sha256:e7ed8b7ba3148a3f9ca8ffecb51c84ef0eed5f124502552e40e0472a6e88b143"
                   },
                   {
+                    "id": "sha256:e20e7b83b9f6be6f3e3c04bb78473fb8027b77416c4f91bfe5efabfd37e38c2a"
+                  },
+                  {
+                    "id": "sha256:5d9d272007911ceed6ca9013433562c002753c2d18a52d5a2b5dbcf8bbef558c"
+                  },
+                  {
                     "id": "sha256:39af2eadd2cff0a4ee02122c7a6f9f6eb8884ae23a4f978d73b3083192c06e7a"
+                  },
+                  {
+                    "id": "sha256:64fefd2fb82e9f9cb9d41da7a21bc01146223ba8b6d5c608acf2b0ba46246e9c"
                   },
                   {
                     "id": "sha256:b7990fe7fe4ca6dc95cab8dda3c0b45d16591f9a2af40b6ccc24db76af2a4484"
@@ -1205,6 +1220,9 @@
                   },
                   {
                     "id": "sha256:eaac030e32e33f0a210af2fc43bc284c9500048da8dbcfe07772be0665b63e20"
+                  },
+                  {
+                    "id": "sha256:af02c73e48865362f25124b86afe86ac6c26861fae93762100922a24197f7dac"
                   },
                   {
                     "id": "sha256:f52078e774a7917c249f38ba734c7a3b8f1dece5b200d7efca736d4d1a1ecb11"
@@ -1511,6 +1529,12 @@
                   },
                   {
                     "id": "sha256:1c4ad9573c998b31fd2080a81a7cb078b3e96e3ae33766570a5ba02ec4f06da8"
+                  },
+                  {
+                    "id": "sha256:8e0c22a2eae5e2cfcf410fdd8a36be8d1b45a6593e86a994f5cf09fd1851502d"
+                  },
+                  {
+                    "id": "sha256:59f354013b8786e74c9d633e2416eced89984e78eca732be5f71eb4fe3551ec5"
                   },
                   {
                     "id": "sha256:2a7ef3bd2571c62bf75f3bc1a9206f5715ddcb1cb77f561689de458a417e5914"
@@ -2419,6 +2443,12 @@
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
+                },
+                {
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
+                  "options": "defaults"
                 }
               ]
             }
@@ -2473,7 +2503,8 @@
                 },
                 {
                   "size": 19937280,
-                  "start": 1034240
+                  "start": 1034240,
+                  "type": "8e"
                 }
               ]
             },
@@ -2482,6 +2513,32 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.lvm2.create",
+            "options": {
+              "volumes": [
+                {
+                  "name": "rootlv",
+                  "size": "3221225472B"
+                },
+                {
+                  "name": "optlv",
+                  "size": "1073741824B"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1034240,
+                  "size": 19937280,
                   "lock": true
                 }
               }
@@ -2512,6 +2569,37 @@
             },
             "devices": {
               "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1034240,
+                  "size": 19937280,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -2550,7 +2638,21 @@
                   "size": 1024000
                 }
               },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
               "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -2571,8 +2673,31 @@
                 "type": "org.osbuild.xfs",
                 "source": "boot",
                 "target": "/boot"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
+          },
+          {
+            "type": "org.osbuild.lvm2.metadata",
+            "options": {
+              "vg_name": "rootvg"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1034240,
+                  "size": 19937280,
+                  "lock": true
+                }
+              }
+            }
           },
           {
             "type": "org.osbuild.grub2.inst",
@@ -6550,6 +6675,24 @@
         "checksum": "sha256:e7ed8b7ba3148a3f9ca8ffecb51c84ef0eed5f124502552e40e0472a6e88b143"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 9,
+        "version": "1.02.181",
+        "release": "3.el9",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.0-20220208/Packages/device-mapper-event-1.02.181-3.el9.ppc64le.rpm",
+        "checksum": "sha256:e20e7b83b9f6be6f3e3c04bb78473fb8027b77416c4f91bfe5efabfd37e38c2a"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 9,
+        "version": "1.02.181",
+        "release": "3.el9",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.0-20220208/Packages/device-mapper-event-libs-1.02.181-3.el9.ppc64le.rpm",
+        "checksum": "sha256:5d9d272007911ceed6ca9013433562c002753c2d18a52d5a2b5dbcf8bbef558c"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 9,
         "version": "1.02.181",
@@ -6557,6 +6700,15 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.0-20220208/Packages/device-mapper-libs-1.02.181-3.el9.ppc64le.rpm",
         "checksum": "sha256:39af2eadd2cff0a4ee02122c7a6f9f6eb8884ae23a4f978d73b3083192c06e7a"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "12.el9",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.0-20220208/Packages/device-mapper-persistent-data-0.9.0-12.el9.ppc64le.rpm",
+        "checksum": "sha256:64fefd2fb82e9f9cb9d41da7a21bc01146223ba8b6d5c608acf2b0ba46246e9c"
       },
       {
         "name": "dhcp-client",
@@ -7340,6 +7492,15 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.0-20220208/Packages/libacl-2.3.1-3.el9.ppc64le.rpm",
         "checksum": "sha256:eaac030e32e33f0a210af2fc43bc284c9500048da8dbcfe07772be0665b63e20"
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "13.el9",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.0-20220208/Packages/libaio-0.3.111-13.el9.ppc64le.rpm",
+        "checksum": "sha256:af02c73e48865362f25124b86afe86ac6c26861fae93762100922a24197f7dac"
       },
       {
         "name": "libarchive",
@@ -8258,6 +8419,24 @@
         "arch": "ppc64le",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.0-20220208/Packages/lua-libs-5.4.2-4.el9.ppc64le.rpm",
         "checksum": "sha256:1c4ad9573c998b31fd2080a81a7cb078b3e96e3ae33766570a5ba02ec4f06da8"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 9,
+        "version": "2.03.14",
+        "release": "3.el9",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.0-20220208/Packages/lvm2-2.03.14-3.el9.ppc64le.rpm",
+        "checksum": "sha256:8e0c22a2eae5e2cfcf410fdd8a36be8d1b45a6593e86a994f5cf09fd1851502d"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 9,
+        "version": "2.03.14",
+        "release": "3.el9",
+        "arch": "ppc64le",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-ppc64le-baseos-n9.0-20220208/Packages/lvm2-libs-2.03.14-3.el9.ppc64le.rpm",
+        "checksum": "sha256:59f354013b8786e74c9d633e2416eced89984e78eca732be5f71eb4fe3551ec5"
       },
       {
         "name": "lz4-libs",
@@ -10830,6 +11009,14 @@
         "defaults",
         "0",
         "0"
+      ],
+      [
+        "UUID=fb180daf-48a7-4ee0-b10d-394651850fd4",
+        "/opt",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
       ]
     ],
     "groups": [
@@ -10849,7 +11036,7 @@
       "games:x:20:",
       "group1:x:1030:user2",
       "group2:x:1050:",
-      "input:x:997:",
+      "input:x:998:",
       "kmem:x:9:",
       "kvm:x:36:",
       "lock:x:54:",
@@ -10858,18 +11045,18 @@
       "man:x:15:",
       "mem:x:8:",
       "nobody:x:65534:",
-      "polkitd:x:994:",
-      "render:x:996:",
+      "polkitd:x:995:",
+      "render:x:997:",
       "root:x:0:",
       "rpc:x:32:",
       "rpcuser:x:29:",
       "service:x:999:",
       "setroubleshoot:x:993:",
-      "ssh_keys:x:998:",
+      "ssh_keys:x:994:",
       "sshd:x:74:",
       "sssd:x:992:",
       "sys:x:3:",
-      "systemd-coredump:x:995:",
+      "systemd-coredump:x:996:",
       "systemd-journal:x:190:",
       "tape:x:33:",
       "tcpdump:x:72:",
@@ -10976,7 +11163,10 @@
       "dbus-libs-1.12.20-5.el9.ppc64le",
       "dbus-tools-1.12.20-5.el9.ppc64le",
       "device-mapper-1.02.181-3.el9.ppc64le",
+      "device-mapper-event-1.02.181-3.el9.ppc64le",
+      "device-mapper-event-libs-1.02.181-3.el9.ppc64le",
       "device-mapper-libs-1.02.181-3.el9.ppc64le",
+      "device-mapper-persistent-data-0.9.0-12.el9.ppc64le",
       "dhcp-client-4.4.2-15.b1.el9.ppc64le",
       "dhcp-common-4.4.2-15.b1.el9.noarch",
       "diffutils-3.7-12.el9.ppc64le",
@@ -11072,6 +11262,7 @@
       "krb5-libs-1.19.1-13.el9.ppc64le",
       "less-575-4.el9.ppc64le",
       "libacl-2.3.1-3.el9.ppc64le",
+      "libaio-0.3.111-13.el9.ppc64le",
       "libappstream-glib-0.7.18-4.el9.ppc64le",
       "libarchive-3.5.2-1.el9.ppc64le",
       "libassuan-2.5.5-3.el9.ppc64le",
@@ -11181,6 +11372,8 @@
       "lsscsi-0.32-6.el9.ppc64le",
       "lsvpd-1.7.12-3.el9.ppc64le",
       "lua-libs-5.4.2-4.el9.ppc64le",
+      "lvm2-2.03.14-3.el9.ppc64le",
+      "lvm2-libs-2.03.14-3.el9.ppc64le",
       "lz4-libs-1.9.3-5.el9.ppc64le",
       "lzo-2.10-7.el9.ppc64le",
       "man-db-2.9.3-6.el9.ppc64le",
@@ -11444,13 +11637,27 @@
       },
       {
         "bootable": false,
-        "fstype": "xfs",
+        "fstype": "LVM2_member",
         "label": null,
+        "lvm": true,
+        "lvm.vg": "rootvg",
+        "lvm.volumes": {
+          "optlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+          },
+          "rootlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+          }
+        },
         "partuuid": "14fc63d2-03",
         "size": 10207887360,
         "start": 529530880,
-        "type": "83",
-        "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+        "type": "8e",
+        "uuid": "liRlb1-ISlV-m40d-2jiT-2iR8-QGVW-9HKXBU"
       }
     ],
     "passwd": [
@@ -11468,7 +11675,7 @@
       "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
       "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
       "operator:x:11:0:operator:/root:/sbin/nologin",
-      "polkitd:x:998:994:User for polkitd:/:/sbin/nologin",
+      "polkitd:x:998:995:User for polkitd:/:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin",
       "rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin",
@@ -11477,7 +11684,7 @@
       "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
       "sssd:x:996:992:User for sssd:/:/sbin/nologin",
       "sync:x:5:0:sync:/sbin:/bin/sync",
-      "systemd-coredump:x:999:995:systemd Core Dumper:/:/sbin/nologin",
+      "systemd-coredump:x:999:996:systemd Core Dumper:/:/sbin/nologin",
       "tcpdump:x:72:72::/:/sbin/nologin",
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
       "user1:x:1000:1000::/home/user1:/bin/bash",
@@ -11558,6 +11765,7 @@
       }
     },
     "services-disabled": [
+      "blk-availability.service",
       "chrony-wait.service",
       "cockpit.socket",
       "console-getty.service",
@@ -11620,6 +11828,7 @@
       "dbus-org.freedesktop.nm-dispatcher.service",
       "dbus.service",
       "dbus.socket",
+      "dm-event.socket",
       "dnf-makecache.timer",
       "firewalld.service",
       "getty@.service",
@@ -11628,6 +11837,8 @@
       "irqbalance.service",
       "kdump.service",
       "logrotate.timer",
+      "lvm2-lvmpolld.socket",
+      "lvm2-monitor.service",
       "nfs-client.target",
       "nis-domainname.service",
       "opal-prd.service",
@@ -11826,6 +12037,10 @@
         ],
         "libselinux.conf": [
           "d /run/setrans 0755 root root"
+        ],
+        "lvm2.conf": [
+          "d /run/lock/lvm 0700 root root -",
+          "d /run/lvm 0700 root root -"
         ],
         "man-db.conf": [
           "d /var/cache/man 0755 root root 1w"

--- a/test/data/manifests/rhel_90-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2-boot.json
@@ -11439,7 +11439,7 @@
         "grub_arg": "--unrestricted",
         "grub_class": "kernel",
         "grub_users": "$grub_users",
-        "id": "-20220427114554-5.14.0-55.el9.s390x",
+        "id": "-20220428124956-5.14.0-55.el9.s390x",
         "initrd": "/boot/initramfs-5.14.0-55.el9.s390x.img",
         "linux": "/boot/vmlinuz-5.14.0-55.el9.s390x",
         "options": "root=UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0",

--- a/test/data/manifests/rhel_90-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2_customize-boot.json
@@ -86,7 +86,13 @@
           "disabled": [
             "bluetooth.service"
           ]
-        }
+        },
+        "filesystem": [
+          {
+            "mountpoint": "/opt",
+            "minsize": 1073741824
+          }
+        ]
       }
     }
   },
@@ -1249,7 +1255,16 @@
                     "id": "sha256:357ebf6eab072cbfe7c960e9d520fa6ced0257e3038eceb8cc21c16bf7382453"
                   },
                   {
+                    "id": "sha256:d60c3aa83be221b6dfea2c3ff28b1413e0243e7c9579ac0bce4e0b943d877e70"
+                  },
+                  {
+                    "id": "sha256:25e416ff54a3a415aa3d03161f71e77f03491d30b0ecead44ce144a2caa39c67"
+                  },
+                  {
                     "id": "sha256:3a9ea0598a6a05770661a382446bf51902e3c04aadb6273021e55845d3f92965"
+                  },
+                  {
+                    "id": "sha256:2ef665d8b77a7cacd666b47c17c62fd53957e35fe12389780e9c983cf9327bbb"
                   },
                   {
                     "id": "sha256:0d2943228937cd0ad51f1231ed80798d576aaac0fdc34daa4dba43ece0d2fcb7"
@@ -1484,6 +1499,9 @@
                   },
                   {
                     "id": "sha256:5ca5775e51a80b6b05e87b5b03b844b781c671f564dabcf34681bde490ed3aa3"
+                  },
+                  {
+                    "id": "sha256:260c5b98c0e1c51079bb6965af688f83ae1778556f0e19bea51f42240cc60870"
                   },
                   {
                     "id": "sha256:80190f58136bd7a0376a3e3b6e27c84080ba782c71972c66c56f7496068028c1"
@@ -1775,6 +1793,12 @@
                   },
                   {
                     "id": "sha256:9ba1a808a41b0bdf7ad52d89a512069ad3313152aad7257776f5297f7ff06f5c"
+                  },
+                  {
+                    "id": "sha256:138e5ebcb43fc9ab245b8a816eda3524a47be0aefb0800f2e1a256b54e5e24e5"
+                  },
+                  {
+                    "id": "sha256:bf512ca1895dbfd62c25b1401bf4ca29d49f859d1a6117eb544ba5205060bd04"
                   },
                   {
                     "id": "sha256:c03955837786dadb6b988a7554f30e03e9a536f322921934a1f590db8a142c1d"
@@ -2677,6 +2701,12 @@
                   "vfs_type": "xfs",
                   "path": "/",
                   "options": "defaults"
+                },
+                {
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
+                  "options": "defaults"
                 }
               ]
             }
@@ -2717,7 +2747,8 @@
                 {
                   "bootable": true,
                   "size": 19945472,
-                  "start": 1026048
+                  "start": 1026048,
+                  "type": "8e"
                 }
               ]
             },
@@ -2726,6 +2757,32 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.lvm2.create",
+            "options": {
+              "volumes": [
+                {
+                  "name": "rootlv",
+                  "size": "3221225472B"
+                },
+                {
+                  "name": "optlv",
+                  "size": "1073741824B"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1026048,
+                  "size": 19945472,
                   "lock": true
                 }
               }
@@ -2756,6 +2813,37 @@
             },
             "devices": {
               "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1026048,
+                  "size": 19945472,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -2800,7 +2888,21 @@
                   "filename": "disk.img"
                 }
               },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
               "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -2821,8 +2923,31 @@
                 "type": "org.osbuild.xfs",
                 "source": "boot",
                 "target": "/boot"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
+          },
+          {
+            "type": "org.osbuild.lvm2.metadata",
+            "options": {
+              "vg_name": "rootvg"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1026048,
+                  "size": 19945472,
+                  "lock": true
+                }
+              }
+            }
           },
           {
             "type": "org.osbuild.zipl.inst",
@@ -2845,7 +2970,21 @@
                   "filename": "disk.img"
                 }
               },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
               "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -2866,6 +3005,12 @@
                 "type": "org.osbuild.xfs",
                 "source": "boot",
                 "target": "/boot"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
           }
@@ -7810,6 +7955,24 @@
         "checksum": "sha256:357ebf6eab072cbfe7c960e9d520fa6ced0257e3038eceb8cc21c16bf7382453"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 9,
+        "version": "1.02.181",
+        "release": "3.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/device-mapper-event-1.02.181-3.el9.s390x.rpm",
+        "checksum": "sha256:d60c3aa83be221b6dfea2c3ff28b1413e0243e7c9579ac0bce4e0b943d877e70"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 9,
+        "version": "1.02.181",
+        "release": "3.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/device-mapper-event-libs-1.02.181-3.el9.s390x.rpm",
+        "checksum": "sha256:25e416ff54a3a415aa3d03161f71e77f03491d30b0ecead44ce144a2caa39c67"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 9,
         "version": "1.02.181",
@@ -7817,6 +7980,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/device-mapper-libs-1.02.181-3.el9.s390x.rpm",
         "checksum": "sha256:3a9ea0598a6a05770661a382446bf51902e3c04aadb6273021e55845d3f92965"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "12.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/device-mapper-persistent-data-0.9.0-12.el9.s390x.rpm",
+        "checksum": "sha256:2ef665d8b77a7cacd666b47c17c62fd53957e35fe12389780e9c983cf9327bbb"
       },
       {
         "name": "dhcp-client",
@@ -8519,6 +8691,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/libacl-2.3.1-3.el9.s390x.rpm",
         "checksum": "sha256:5ca5775e51a80b6b05e87b5b03b844b781c671f564dabcf34681bde490ed3aa3"
+      },
+      {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "13.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/libaio-0.3.111-13.el9.s390x.rpm",
+        "checksum": "sha256:260c5b98c0e1c51079bb6965af688f83ae1778556f0e19bea51f42240cc60870"
       },
       {
         "name": "libarchive",
@@ -9392,6 +9573,24 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/lua-libs-5.4.2-4.el9.s390x.rpm",
         "checksum": "sha256:9ba1a808a41b0bdf7ad52d89a512069ad3313152aad7257776f5297f7ff06f5c"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 9,
+        "version": "2.03.14",
+        "release": "3.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/lvm2-2.03.14-3.el9.s390x.rpm",
+        "checksum": "sha256:138e5ebcb43fc9ab245b8a816eda3524a47be0aefb0800f2e1a256b54e5e24e5"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 9,
+        "version": "2.03.14",
+        "release": "3.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/lvm2-libs-2.03.14-3.el9.s390x.rpm",
+        "checksum": "sha256:bf512ca1895dbfd62c25b1401bf4ca29d49f859d1a6117eb544ba5205060bd04"
       },
       {
         "name": "lz4-libs",
@@ -11698,7 +11897,7 @@
         "grub_arg": "--unrestricted",
         "grub_class": "kernel",
         "grub_users": "$grub_users",
-        "id": "-20220427114805-0-rescue-ffffffffffffffffffffffffffffffff",
+        "id": "-20220428125207-0-rescue-ffffffffffffffffffffffffffffffff",
         "initrd": "/boot/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
         "linux": "/boot/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff",
         "options": "root=UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
@@ -11709,7 +11908,7 @@
         "grub_arg": "--unrestricted",
         "grub_class": "kernel",
         "grub_users": "$grub_users",
-        "id": "-20220427114805-5.14.0-55.el9.s390x",
+        "id": "-20220428125207-5.14.0-55.el9.s390x",
         "initrd": "/boot/initramfs-5.14.0-55.el9.s390x.img",
         "linux": "/boot/vmlinuz-5.14.0-55.el9.s390x",
         "options": "root=UUID=6e4ff95f-f662-45ee-a82a-bdf44a2d0b75 console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 debug",
@@ -11919,6 +12118,14 @@
         "defaults",
         "0",
         "0"
+      ],
+      [
+        "UUID=fb180daf-48a7-4ee0-b10d-394651850fd4",
+        "/opt",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
       ]
     ],
     "groups": [
@@ -11938,7 +12145,7 @@
       "games:x:20:",
       "group1:x:1030:user2",
       "group2:x:1050:",
-      "input:x:998:",
+      "input:x:999:",
       "kmem:x:9:",
       "kvm:x:36:",
       "lock:x:54:",
@@ -11947,17 +12154,17 @@
       "man:x:15:",
       "mem:x:8:",
       "nobody:x:65534:",
-      "polkitd:x:995:",
-      "render:x:997:",
+      "polkitd:x:996:",
+      "render:x:998:",
       "root:x:0:",
       "rpc:x:32:",
       "rpcuser:x:29:",
       "setroubleshoot:x:994:",
-      "ssh_keys:x:999:",
+      "ssh_keys:x:995:",
       "sshd:x:74:",
       "sssd:x:993:",
       "sys:x:3:",
-      "systemd-coredump:x:996:",
+      "systemd-coredump:x:997:",
       "systemd-journal:x:190:",
       "tape:x:33:",
       "tcpdump:x:72:",
@@ -12064,7 +12271,10 @@
       "dbus-libs-1.12.20-5.el9.s390x",
       "dbus-tools-1.12.20-5.el9.s390x",
       "device-mapper-1.02.181-3.el9.s390x",
+      "device-mapper-event-1.02.181-3.el9.s390x",
+      "device-mapper-event-libs-1.02.181-3.el9.s390x",
       "device-mapper-libs-1.02.181-3.el9.s390x",
+      "device-mapper-persistent-data-0.9.0-12.el9.s390x",
       "dhcp-client-4.4.2-15.b1.el9.s390x",
       "dhcp-common-4.4.2-15.b1.el9.noarch",
       "diffutils-3.7-12.el9.s390x",
@@ -12151,6 +12361,7 @@
       "krb5-libs-1.19.1-13.el9.s390x",
       "less-575-4.el9.s390x",
       "libacl-2.3.1-3.el9.s390x",
+      "libaio-0.3.111-13.el9.s390x",
       "libappstream-glib-0.7.18-4.el9.s390x",
       "libarchive-3.5.2-1.el9.s390x",
       "libassuan-2.5.5-3.el9.s390x",
@@ -12256,6 +12467,8 @@
       "lshw-B.02.19.2-7.el9.s390x",
       "lsscsi-0.32-6.el9.s390x",
       "lua-libs-5.4.2-4.el9.s390x",
+      "lvm2-2.03.14-3.el9.s390x",
+      "lvm2-libs-2.03.14-3.el9.s390x",
       "lz4-libs-1.9.3-5.el9.s390x",
       "lzo-2.10-7.el9.s390x",
       "man-db-2.9.3-6.el9.s390x",
@@ -12506,13 +12719,27 @@
       },
       {
         "bootable": true,
-        "fstype": "xfs",
+        "fstype": "LVM2_member",
         "label": null,
+        "lvm": true,
+        "lvm.vg": "rootvg",
+        "lvm.volumes": {
+          "optlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+          },
+          "rootlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+          }
+        },
         "partuuid": "14fc63d2-02",
         "size": 10212081664,
         "start": 525336576,
-        "type": "83",
-        "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+        "type": "8e",
+        "uuid": "dD0Q3K-4MLq-eGtp-NeHd-Th0j-NidP-QM6JSQ"
       }
     ],
     "passwd": [
@@ -12530,7 +12757,7 @@
       "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
       "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
       "operator:x:11:0:operator:/root:/sbin/nologin",
-      "polkitd:x:998:995:User for polkitd:/:/sbin/nologin",
+      "polkitd:x:998:996:User for polkitd:/:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin",
       "rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin",
@@ -12539,7 +12766,7 @@
       "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
       "sssd:x:996:993:User for sssd:/:/sbin/nologin",
       "sync:x:5:0:sync:/sbin:/bin/sync",
-      "systemd-coredump:x:999:996:systemd Core Dumper:/:/sbin/nologin",
+      "systemd-coredump:x:999:997:systemd Core Dumper:/:/sbin/nologin",
       "tcpdump:x:72:72::/:/sbin/nologin",
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
       "user1:x:1000:1000::/home/user1:/bin/bash",
@@ -12620,6 +12847,7 @@
       }
     },
     "services-disabled": [
+      "blk-availability.service",
       "chrony-wait.service",
       "cockpit.socket",
       "console-getty.service",
@@ -12682,12 +12910,15 @@
       "dbus.service",
       "dbus.socket",
       "device_cio_free.service",
+      "dm-event.socket",
       "dnf-makecache.timer",
       "firewalld.service",
       "getty@.service",
       "insights-client-boot.service",
       "kdump.service",
       "logrotate.timer",
+      "lvm2-lvmpolld.socket",
+      "lvm2-monitor.service",
       "nfs-client.target",
       "nis-domainname.service",
       "qemu-guest-agent.service",
@@ -12879,6 +13110,10 @@
         ],
         "libselinux.conf": [
           "d /run/setrans 0755 root root"
+        ],
+        "lvm2.conf": [
+          "d /run/lock/lvm 0700 root root -",
+          "d /run/lvm 0700 root root -"
         ],
         "man-db.conf": [
           "d /var/cache/man 0755 root root 1w"

--- a/test/data/manifests/rhel_90-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-qcow2_customize-boot.json
@@ -86,7 +86,13 @@
           "disabled": [
             "bluetooth.service"
           ]
-        }
+        },
+        "filesystem": [
+          {
+            "mountpoint": "/opt",
+            "minsize": 1073741824
+          }
+        ]
       }
     }
   },
@@ -952,7 +958,16 @@
                     "id": "sha256:ada47830190c9c63f8963870b180eca19f00fe3d570eedecd530e48716f5c160"
                   },
                   {
+                    "id": "sha256:84a88ef32206f0562cc7692039281416dae6884ad5009a39638cd3c7b583477d"
+                  },
+                  {
+                    "id": "sha256:29cfcb0061f1d7ae6fabfbfc4357fec18e6320b78229d4f08b4794d68c7136ff"
+                  },
+                  {
                     "id": "sha256:0f97ae871b19c01313979bfc246d1d9aa6cc6bd9a8d3c9f496e6427a3ff50796"
+                  },
+                  {
+                    "id": "sha256:ee21707fd626731a95029fd87a97f3d254283b072491246e951a4e2724e2bd21"
                   },
                   {
                     "id": "sha256:ff756f758cc70a077b8628e4fb8166a29cce7abb62108e43f196b870f28ebce9"
@@ -1270,6 +1285,9 @@
                     "id": "sha256:ff20c1890d9d5eb5135f21acf2b55f27fddac48934285b5b0fa72b591480edbb"
                   },
                   {
+                    "id": "sha256:20a5a375bd1a12950ba6ca5e4ca9f6af11020214da304317070803be37afd27c"
+                  },
+                  {
                     "id": "sha256:b10b0a214cf3eaf58537de9fa83c88ccc90287dde118e53bc1e9f9aed9eb6d18"
                   },
                   {
@@ -1583,6 +1601,12 @@
                   },
                   {
                     "id": "sha256:3ec90a458c2a92a76b7d70b8e360011a597c1637bf76aae6ebbd23971094f2ee"
+                  },
+                  {
+                    "id": "sha256:95f517c1c1130d2fb8b562cbff77a69f5845f5f8fa75b4e18642a8c299fcc065"
+                  },
+                  {
+                    "id": "sha256:b7d9597aa6a247344ffdb19d0805124e718156a87cf0cb259c108ea79d1a43b2"
                   },
                   {
                     "id": "sha256:9658da838021711f687cf283368664984bfb1c8b9176897d7d477a724a11a731"
@@ -2328,6 +2352,12 @@
                   "options": "defaults"
                 },
                 {
+                  "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4",
+                  "vfs_type": "xfs",
+                  "path": "/opt",
+                  "options": "defaults"
+                },
+                {
                   "uuid": "7B77-95E7",
                   "vfs_type": "vfat",
                   "path": "/boot/efi",
@@ -2401,7 +2431,7 @@
                 {
                   "size": 19533791,
                   "start": 1437696,
-                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
                   "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
                 }
               ]
@@ -2411,6 +2441,32 @@
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.lvm2.create",
+            "options": {
+              "volumes": [
+                {
+                  "name": "rootlv",
+                  "size": "3221225472B"
+                },
+                {
+                  "name": "optlv",
+                  "size": "1073741824B"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1437696,
+                  "size": 19533791,
                   "lock": true
                 }
               }
@@ -2459,6 +2515,37 @@
             },
             "devices": {
               "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1437696,
+                  "size": 19533791,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -2505,7 +2592,21 @@
                   "size": 409600
                 }
               },
+              "opt": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "optlv"
+                }
+              },
               "root": {
+                "type": "org.osbuild.lvm2.lv",
+                "parent": "rootvgvg",
+                "options": {
+                  "volume": "rootlv"
+                }
+              },
+              "rootvgvg": {
                 "type": "org.osbuild.loopback",
                 "options": {
                   "filename": "disk.img",
@@ -2532,8 +2633,31 @@
                 "type": "org.osbuild.fat",
                 "source": "boot.efi",
                 "target": "/boot/efi"
+              },
+              {
+                "name": "opt",
+                "type": "org.osbuild.xfs",
+                "source": "opt",
+                "target": "/opt"
               }
             ]
+          },
+          {
+            "type": "org.osbuild.lvm2.metadata",
+            "options": {
+              "vg_name": "rootvg"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 1437696,
+                  "size": 19533791,
+                  "lock": true
+                }
+              }
+            }
           },
           {
             "type": "org.osbuild.grub2.inst",
@@ -6445,6 +6569,24 @@
         "checksum": "sha256:ada47830190c9c63f8963870b180eca19f00fe3d570eedecd530e48716f5c160"
       },
       {
+        "name": "device-mapper-event",
+        "epoch": 9,
+        "version": "1.02.181",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/device-mapper-event-1.02.181-3.el9.x86_64.rpm",
+        "checksum": "sha256:84a88ef32206f0562cc7692039281416dae6884ad5009a39638cd3c7b583477d"
+      },
+      {
+        "name": "device-mapper-event-libs",
+        "epoch": 9,
+        "version": "1.02.181",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/device-mapper-event-libs-1.02.181-3.el9.x86_64.rpm",
+        "checksum": "sha256:29cfcb0061f1d7ae6fabfbfc4357fec18e6320b78229d4f08b4794d68c7136ff"
+      },
+      {
         "name": "device-mapper-libs",
         "epoch": 9,
         "version": "1.02.181",
@@ -6452,6 +6594,15 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/device-mapper-libs-1.02.181-3.el9.x86_64.rpm",
         "checksum": "sha256:0f97ae871b19c01313979bfc246d1d9aa6cc6bd9a8d3c9f496e6427a3ff50796"
+      },
+      {
+        "name": "device-mapper-persistent-data",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "12.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/device-mapper-persistent-data-0.9.0-12.el9.x86_64.rpm",
+        "checksum": "sha256:ee21707fd626731a95029fd87a97f3d254283b072491246e951a4e2724e2bd21"
       },
       {
         "name": "dhcp-client",
@@ -7399,6 +7550,15 @@
         "checksum": "sha256:ff20c1890d9d5eb5135f21acf2b55f27fddac48934285b5b0fa72b591480edbb"
       },
       {
+        "name": "libaio",
+        "epoch": 0,
+        "version": "0.3.111",
+        "release": "13.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libaio-0.3.111-13.el9.x86_64.rpm",
+        "checksum": "sha256:20a5a375bd1a12950ba6ca5e4ca9f6af11020214da304317070803be37afd27c"
+      },
+      {
         "name": "libarchive",
         "epoch": 0,
         "version": "3.5.2",
@@ -8342,6 +8502,24 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/lua-libs-5.4.2-4.el9.x86_64.rpm",
         "checksum": "sha256:3ec90a458c2a92a76b7d70b8e360011a597c1637bf76aae6ebbd23971094f2ee"
+      },
+      {
+        "name": "lvm2",
+        "epoch": 9,
+        "version": "2.03.14",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/lvm2-2.03.14-3.el9.x86_64.rpm",
+        "checksum": "sha256:95f517c1c1130d2fb8b562cbff77a69f5845f5f8fa75b4e18642a8c299fcc065"
+      },
+      {
+        "name": "lvm2-libs",
+        "epoch": 9,
+        "version": "2.03.14",
+        "release": "3.el9",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/lvm2-libs-2.03.14-3.el9.x86_64.rpm",
+        "checksum": "sha256:b7d9597aa6a247344ffdb19d0805124e718156a87cf0cb259c108ea79d1a43b2"
       },
       {
         "name": "lz4-libs",
@@ -10404,6 +10582,14 @@
         "defaults,uid=0,gid=0,umask=077,shortname=winnt",
         "0",
         "2"
+      ],
+      [
+        "UUID=fb180daf-48a7-4ee0-b10d-394651850fd4",
+        "/opt",
+        "xfs",
+        "defaults",
+        "0",
+        "0"
       ]
     ],
     "groups": [
@@ -10423,7 +10609,7 @@
       "games:x:20:",
       "group1:x:1030:user2",
       "group2:x:1050:",
-      "input:x:998:",
+      "input:x:999:",
       "kmem:x:9:",
       "kvm:x:36:",
       "lock:x:54:",
@@ -10432,17 +10618,17 @@
       "man:x:15:",
       "mem:x:8:",
       "nobody:x:65534:",
-      "polkitd:x:995:",
-      "render:x:997:",
+      "polkitd:x:996:",
+      "render:x:998:",
       "root:x:0:",
       "rpc:x:32:",
       "rpcuser:x:29:",
       "setroubleshoot:x:994:",
-      "ssh_keys:x:999:",
+      "ssh_keys:x:995:",
       "sshd:x:74:",
       "sssd:x:993:",
       "sys:x:3:",
-      "systemd-coredump:x:996:",
+      "systemd-coredump:x:997:",
       "systemd-journal:x:190:",
       "tape:x:33:",
       "tcpdump:x:72:",
@@ -10549,7 +10735,10 @@
       "dbus-libs-1.12.20-5.el9.x86_64",
       "dbus-tools-1.12.20-5.el9.x86_64",
       "device-mapper-1.02.181-3.el9.x86_64",
+      "device-mapper-event-1.02.181-3.el9.x86_64",
+      "device-mapper-event-libs-1.02.181-3.el9.x86_64",
       "device-mapper-libs-1.02.181-3.el9.x86_64",
+      "device-mapper-persistent-data-0.9.0-12.el9.x86_64",
       "dhcp-client-4.4.2-15.b1.el9.x86_64",
       "dhcp-common-4.4.2-15.b1.el9.noarch",
       "diffutils-3.7-12.el9.x86_64",
@@ -10665,6 +10854,7 @@
       "krb5-libs-1.19.1-13.el9.x86_64",
       "less-575-4.el9.x86_64",
       "libacl-2.3.1-3.el9.x86_64",
+      "libaio-0.3.111-13.el9.x86_64",
       "libappstream-glib-0.7.18-4.el9.x86_64",
       "libarchive-3.5.2-1.el9.x86_64",
       "libassuan-2.5.5-3.el9.x86_64",
@@ -10778,6 +10968,8 @@
       "lshw-B.02.19.2-7.el9.x86_64",
       "lsscsi-0.32-6.el9.x86_64",
       "lua-libs-5.4.2-4.el9.x86_64",
+      "lvm2-2.03.14-3.el9.x86_64",
+      "lvm2-libs-2.03.14-3.el9.x86_64",
       "lz4-libs-1.9.3-5.el9.x86_64",
       "lzo-2.10-7.el9.x86_64",
       "man-db-2.9.3-6.el9.x86_64",
@@ -10963,13 +11155,27 @@
     "partitions": [
       {
         "bootable": false,
-        "fstype": "xfs",
-        "label": "root",
+        "fstype": "LVM2_member",
+        "label": null,
+        "lvm": true,
+        "lvm.vg": "rootvg",
+        "lvm.volumes": {
+          "optlv": {
+            "fstype": "xfs",
+            "label": null,
+            "uuid": "fb180daf-48a7-4ee0-b10d-394651850fd4"
+          },
+          "rootlv": {
+            "fstype": "xfs",
+            "label": "root",
+            "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+          }
+        },
         "partuuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562",
         "size": 10001300992,
         "start": 736100352,
-        "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-        "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+        "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
+        "uuid": "pddpuQ-HrFS-km2C-TrzX-69o0-tBXk-133xtw"
       },
       {
         "bootable": false,
@@ -11017,7 +11223,7 @@
       "mail:x:8:12:mail:/var/spool/mail:/sbin/nologin",
       "nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin",
       "operator:x:11:0:operator:/root:/sbin/nologin",
-      "polkitd:x:998:995:User for polkitd:/:/sbin/nologin",
+      "polkitd:x:998:996:User for polkitd:/:/sbin/nologin",
       "root:x:0:0:root:/root:/bin/bash",
       "rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin",
       "rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin",
@@ -11026,7 +11232,7 @@
       "sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/sbin/nologin",
       "sssd:x:996:993:User for sssd:/:/sbin/nologin",
       "sync:x:5:0:sync:/sbin:/bin/sync",
-      "systemd-coredump:x:999:996:systemd Core Dumper:/:/sbin/nologin",
+      "systemd-coredump:x:999:997:systemd Core Dumper:/:/sbin/nologin",
       "tcpdump:x:72:72::/:/sbin/nologin",
       "tss:x:59:59:Account used for TPM access:/dev/null:/sbin/nologin",
       "user1:x:1000:1000::/home/user1:/bin/bash",
@@ -11109,6 +11315,7 @@
       }
     },
     "services-disabled": [
+      "blk-availability.service",
       "chrony-wait.service",
       "cockpit.socket",
       "console-getty.service",
@@ -11170,6 +11377,7 @@
       "dbus-org.freedesktop.nm-dispatcher.service",
       "dbus.service",
       "dbus.socket",
+      "dm-event.socket",
       "dnf-makecache.timer",
       "firewalld.service",
       "getty@.service",
@@ -11177,6 +11385,8 @@
       "irqbalance.service",
       "kdump.service",
       "logrotate.timer",
+      "lvm2-lvmpolld.socket",
+      "lvm2-monitor.service",
       "microcode.service",
       "nfs-client.target",
       "nis-domainname.service",
@@ -11374,6 +11584,10 @@
         ],
         "libselinux.conf": [
           "d /run/setrans 0755 root root"
+        ],
+        "lvm2.conf": [
+          "d /run/lock/lvm 0700 root root -",
+          "d /run/lvm 0700 root root -"
         ],
         "man-db.conf": [
           "d /var/cache/man 0755 root root 1w"

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -576,11 +576,242 @@
             "disabled": [
               "bluetooth.service"
             ]
-          }
+          },
+          "filesystem": [
+            {
+              "mountpoint": "/opt",
+              "minsize": 1073741824
+            }
+          ]
         }
       }
     },
     "overrides": {
+      "fedora-34": {
+        "blueprint": {
+          "name": "qcow2-customize-boot-test",
+          "description": "Image for boot test",
+          "packages": [
+            {
+              "name": "bash",
+              "version": "*"
+            }
+          ],
+          "modules": [],
+          "groups": [
+            {
+              "name": "core"
+            }
+          ],
+          "customizations": {
+            "hostname": "my-host",
+            "kernel": {
+              "append": "debug"
+            },
+            "sshkey": [
+              {
+                "user": "user1",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
+            ],
+            "user": [
+              {
+                "name": "user2",
+                "description": "description 2",
+                "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+                "home": "/home/home2",
+                "shell": "/bin/sh",
+                "groups": [
+                  "group1"
+                ],
+                "uid": 1020,
+                "gid": 1050
+              }
+            ],
+            "group": [
+              {
+                "name": "group1",
+                "gid": 1030
+              },
+              {
+                "name": "group2",
+                "gid": 1050
+              }
+            ],
+            "timezone": {
+              "timezone": "Europe/London",
+              "ntpservers": [
+                "time.example.com"
+              ]
+            },
+            "locale": {
+              "languages": [
+                "el_CY.UTF-8"
+              ],
+              "keyboard": "dvorak"
+            },
+            "services": {
+              "enabled": [
+                "sshd.socket"
+              ],
+              "disabled": [
+                "bluetooth.service"
+              ]
+            }
+          }
+        }
+      },
+      "fedora-35": {
+        "blueprint": {
+          "name": "qcow2-customize-boot-test",
+          "description": "Image for boot test",
+          "packages": [
+            {
+              "name": "bash",
+              "version": "*"
+            }
+          ],
+          "modules": [],
+          "groups": [
+            {
+              "name": "core"
+            }
+          ],
+          "customizations": {
+            "hostname": "my-host",
+            "kernel": {
+              "append": "debug"
+            },
+            "sshkey": [
+              {
+                "user": "user1",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
+            ],
+            "user": [
+              {
+                "name": "user2",
+                "description": "description 2",
+                "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+                "home": "/home/home2",
+                "shell": "/bin/sh",
+                "groups": [
+                  "group1"
+                ],
+                "uid": 1020,
+                "gid": 1050
+              }
+            ],
+            "group": [
+              {
+                "name": "group1",
+                "gid": 1030
+              },
+              {
+                "name": "group2",
+                "gid": 1050
+              }
+            ],
+            "timezone": {
+              "timezone": "Europe/London",
+              "ntpservers": [
+                "time.example.com"
+              ]
+            },
+            "locale": {
+              "languages": [
+                "el_CY.UTF-8"
+              ],
+              "keyboard": "dvorak"
+            },
+            "services": {
+              "enabled": [
+                "sshd.socket"
+              ],
+              "disabled": [
+                "bluetooth.service"
+              ]
+            }
+          }
+        }
+      },
+      "rhel-8": {
+        "blueprint": {
+          "name": "qcow2-customize-boot-test",
+          "description": "Image for boot test",
+          "packages": [
+            {
+              "name": "bash",
+              "version": "*"
+            }
+          ],
+          "modules": [],
+          "groups": [
+            {
+              "name": "core"
+            }
+          ],
+          "customizations": {
+            "hostname": "my-host",
+            "kernel": {
+              "append": "debug"
+            },
+            "sshkey": [
+              {
+                "user": "user1",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+              }
+            ],
+            "user": [
+              {
+                "name": "user2",
+                "description": "description 2",
+                "password": "$6$BhyxFBgrEFh0VrPJ$MllG8auiU26x2pmzL4.1maHzPHrA.4gTdCvlATFp8HJU9UPee4zCS9BVl2HOzKaUYD/zEm8r/OF05F2icWB0K/",
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost",
+                "home": "/home/home2",
+                "shell": "/bin/sh",
+                "groups": [
+                  "group1"
+                ],
+                "uid": 1020,
+                "gid": 1050
+              }
+            ],
+            "group": [
+              {
+                "name": "group1",
+                "gid": 1030
+              },
+              {
+                "name": "group2",
+                "gid": 1050
+              }
+            ],
+            "timezone": {
+              "timezone": "Europe/London",
+              "ntpservers": [
+                "time.example.com"
+              ]
+            },
+            "locale": {
+              "languages": [
+                "el_CY.UTF-8"
+              ],
+              "keyboard": "dvorak"
+            },
+            "services": {
+              "enabled": [
+                "sshd.socket"
+              ],
+              "disabled": [
+                "bluetooth.service"
+              ]
+            }
+          }
+        }
+      },
       "rhel-85": {
         "blueprint": {
           "name": "qcow2-customize-boot-test",


### PR DESCRIPTION
When the partition table did not have a boot partition, we created it but then _unconditionally_ returned, which meant that we did not the LVM skeleton and wrap the root partition. Properly handle this case and also re-initialize the `rootPath` in this case since the underlying `Partition[]` array in `PartitionTable` object.
Add an extra blueprint with only one customisation which exposes this bug.
