### PR TITLE
New functions for resizing partitions based on directory size requirements

### DIFF
--- a/internal/disk/partition_table.go
+++ b/internal/disk/partition_table.go
@@ -425,6 +425,9 @@ func clampFSSize(mountpoint string, size uint64) uint64 {
 	return size
 }
 
+// resizeEntityBranch resizes the first entity in the specified path to be at
+// least the specified size and then grows every entity up the path to the
+// PartitionTable accordingly.
 func resizeEntityBranch(path []Entity, size uint64) {
 	if len(path) == 0 {
 		return

--- a/internal/disk/partition_table.go
+++ b/internal/disk/partition_table.go
@@ -3,6 +3,7 @@ package disk
 import (
 	"fmt"
 	"math/rand"
+	"path/filepath"
 
 	"github.com/google/uuid"
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
@@ -159,6 +160,21 @@ func (pt *PartitionTable) EnsureSize(s uint64) bool {
 		return true
 	}
 	return false
+}
+
+func (pt *PartitionTable) findDirectoryEntityPath(dir string) []Entity {
+	if path := entityPath(pt, dir); path != nil {
+		return path
+	}
+
+	parent := filepath.Dir(dir)
+	if dir == parent {
+		// invalid dir or pt has no root
+		return nil
+	}
+
+	// move up the directory path and check again
+	return pt.findDirectoryEntityPath(parent)
 }
 
 func (pt *PartitionTable) CreateMountpoint(mountpoint string, size uint64) (Entity, error) {


### PR DESCRIPTION
New function that ensures that a partition can hold the total sum of all the required sizes of specific directories on the partition.  The function sums the required directory sizes grouped by their mountpoint and then resizes the entity path of that Mountable.  

This function will be required for resizing entities in a partition table given a set of (sub)directory size requirements.  We can add min sizes for directories to image types (e.g., `/var` should be 2 GiB) and based on the filesystem customizations, we would need to resize the `/var` partition if the user requested one, otherwise we would resize `/`.