### PR TITLE
Schutzfile: Indicate whether a snapshot is updateable

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -21,7 +21,8 @@
             "name": "fedora",
             "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512"
           }
-        ]
+        ],
+        "updateable": false
       },
       {
         "file": "/etc/yum.repos.d/fedora-modular.repo",
@@ -38,7 +39,8 @@
             "name": "fedora-modular",
             "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-modular-20210512"
           }
-        ]
+        ],
+        "updateable": false
       },
       {
         "file": "/etc/yum.repos.d/fedora-updates.repo",
@@ -55,7 +57,8 @@
             "name": "updates",
             "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220330"
           }
-        ]
+        ],
+        "updateable": true
       },
       {
         "file": "/etc/yum.repos.d/fedora-updates-modular.repo",
@@ -72,7 +75,8 @@
             "name": "updates-modular",
             "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-modular-20220330"
           }
-        ]
+        ],
+        "updateable": true
       }
     ]
   },
@@ -98,7 +102,8 @@
             "name": "fedora",
             "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106"
           }
-        ]
+        ],
+        "updateable": false
       },
       {
         "file": "/etc/yum.repos.d/fedora-modular.repo",
@@ -115,7 +120,8 @@
             "name": "fedora-modular",
             "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-modular-20220106"
           }
-        ]
+        ],
+        "updateable": false
       },
       {
         "file": "/etc/yum.repos.d/fedora-updates.repo",
@@ -132,7 +138,8 @@
             "name": "updates",
             "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220330"
           }
-        ]
+        ],
+        "updateable": true
       },
       {
         "file": "/etc/yum.repos.d/fedora-updates-modular.repo",
@@ -149,7 +156,8 @@
             "name": "updates-modular",
             "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-modular-20220330"
           }
-        ]
+        ],
+        "updateable": true
       }
     ]
   },
@@ -209,7 +217,8 @@
             "name": "crb",
             "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-crb-n8.6-20220301"
           }
-        ]
+        ],
+        "updateable": true
       }
     ]
   },
@@ -255,7 +264,8 @@
             "name": "crb",
             "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-crb-n9.0-20220301"
           }
-        ]
+        ],
+        "updateable": true
       }
     ]
   },
@@ -310,7 +320,8 @@
             "name": "crb",
             "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-crb-20220330"
           }
-        ]
+        ],
+        "updateable": true
       }
     ]
   },
@@ -331,7 +342,8 @@
             "name": "baseos",
             "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220322"
           }
-        ]
+        ],
+        "updateable": true
       },
       {
         "file": "/etc/yum.repos.d/CentOS-Stream-AppStream.repo",
@@ -348,7 +360,8 @@
             "name": "appstream",
             "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220322"
           }
-        ]
+        ],
+        "updateable": true
       },
       {
         "file": "/etc/yum.repos.d/CentOS-Stream-PowerTools.repo",
@@ -365,7 +378,8 @@
             "name": "powertoosl",
             "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-powertools-20220330"
           }
-        ]
+        ],
+        "updateable": true
       }
     ]
   }


### PR DESCRIPTION
Some repositories like the fedora and fedora-modular don't change after
release and so the snapshots don't change either. Having an updateable
flag to indicate this simplifies automated updating of other snapshots.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
