### PR TITLE
tools/generate-all-test-cases: add `manifests` command

### DIFF
--- a/tools/test-case-generators/generate-all-test-cases
+++ b/tools/test-case-generators/generate-all-test-cases
@@ -1259,6 +1259,65 @@ class RemoteTestCaseMatrixGenerator(BaseTestCaseMatrixGenerator):
             generator.generate()
 
 
+@register_generator_cls
+class ManifestTestCaseMatrixGenerator(BaseTestCaseMatrixGenerator):
+    """
+    Class representing generation of all test case manifests based on provided test
+    cases matrix locally.
+    """
+
+    arch_runner_map = {
+        "x86_64": True,
+        "aarch64": True,
+        "ppc64le": True,
+        "s390x": True
+    }
+
+    def __init__(self, arch_gen_matrix, sources, output, repos, keep_workdir, log_level=logging.INFO):
+        """
+        Constructor
+        """
+        super().__init__(arch_gen_matrix=arch_gen_matrix, sources=sources, output=output, ssh_id_file="/dev/null",
+            repos=repos, build_rpms=False, keep_workdir=keep_workdir, log_level=log_level)
+
+    def generate(self):
+        """
+        Generates all test cases based on provided data in a blocking manner.
+        """
+        for arch_name, distros in self.arch_gen_matrix.items():
+            for distro_name, image_types in distros.items():
+                for image_type in image_types:
+                    script_dir = os.path.dirname(__file__)
+                    log.info("Generating manifest for %s-%s-%s", distro_name, arch_name, image_type)
+                    try:
+                        subprocess.check_call([f"{script_dir}/generate-test-cases", "--distro", f"{distro_name}", "--arch",
+                            f"{arch_name}", "--image-types", f"{image_type}", "--store", "/dev/null", "--output", f"{self.output}",
+                            "--keep-image-info"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                    except subprocess.CalledProcessError as e:
+                        log.error("Generating manifest for %s-%s-%s FAILED: %s", distro_name, arch_name, image_type, e)
+
+    @staticmethod
+    def add_subparser(subparsers):
+        """
+        Adds subparser for the 'manifests' command
+        """
+        parser_remote = subparsers.add_parser(
+            "manifests",
+            description="locally generate test case manifests only",
+            help="locally generate test case manifests only"
+        )
+        parser_remote.set_defaults(func=ManifestTestCaseMatrixGenerator.main)
+
+    @staticmethod
+    def main(arch_gen_matrix_dict, sources, output, ssh_id_file, repos, build_rpms, keep_workdir, parser_args):
+        """
+        The main function of the 'manifests' command
+        """
+        with ManifestTestCaseMatrixGenerator(
+            arch_gen_matrix_dict, sources, output, repos, log.level) as generator:
+            generator.generate()
+
+
 def get_default_ssh_id_file():
     """
     Returns the path of the default SSH ID file to use.


### PR DESCRIPTION
Add `manifests` command for generating image test cases without
`image-info` report, so only manifests.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
