### PR TITLE
image-info: dynamically detect the rpm database

### DIFF
--- a/tools/image-info
+++ b/tools/image-info
@@ -421,8 +421,10 @@ def rpm_not_installed_docs(tree, is_ostree):
     # check not installed Docs (e.g. when RPMs are installed with --excludedocs)
     not_installed_docs = []
     cmd = ["rpm", "--root", tree, "-qad", "--state"]
-    if is_ostree:
+    if os.path.exists(os.path.join(tree, "usr/share/rpm")):
         cmd += ["--dbpath", "/usr/share/rpm"]
+    elif os.path.exists(os.path.join(tree, "var/lib/rpm")):
+        cmd += ["--dbpath", "/var/lib/rpm"]
     output = subprocess_check_output(cmd)
     for line in output.splitlines():
         if line.startswith("not installed"):
@@ -454,8 +456,11 @@ def rpm_packages(tree, is_ostree):
     ]
     """
     cmd = ["rpm", "--root", tree, "-qa"]
-    if is_ostree:
+    if os.path.exists(os.path.join(tree, "usr/share/rpm")):
         cmd += ["--dbpath", "/usr/share/rpm"]
+    elif os.path.exists(os.path.join(tree, "var/lib/rpm")):
+        cmd += ["--dbpath", "/var/lib/rpm"]
+    output = subprocess_check_output(cmd)
     pkgs = subprocess_check_output(cmd, str.split)
     return list(sorted(pkgs))
 


### PR DESCRIPTION
Check for the rpm database in `$tree/usr/share/rpm` and explicitly also in `$tree/var/lib/rpm` and if the respective location exists pass it as argument to rpm. This should fix the situation where the default database on the host is in a different location than in the tree. Fedora < 36 and RHEL have the location in /var but Fedora starting 36 and rpm-ostree have it in /usr.

