### PR TITLE
composer: add support for logrus syslog hook

### DIFF
--- a/cmd/osbuild-composer/config.go
+++ b/cmd/osbuild-composer/config.go
@@ -11,11 +11,12 @@ import (
 )
 
 type ComposerConfigFile struct {
-	Koji      KojiAPIConfig   `toml:"koji"`
-	Worker    WorkerAPIConfig `toml:"worker"`
-	WeldrAPI  WeldrAPIConfig  `toml:"weldr_api"`
-	LogLevel  string          `toml:"log_level"`
-	LogFormat string          `toml:"log_format"`
+	Koji         KojiAPIConfig   `toml:"koji"`
+	Worker       WorkerAPIConfig `toml:"worker"`
+	WeldrAPI     WeldrAPIConfig  `toml:"weldr_api"`
+	SyslogServer string          `toml:"syslog_server" env:"SYSLOG_SERVER"`
+	LogLevel     string          `toml:"log_level"`
+	LogFormat    string          `toml:"log_format"`
 }
 
 type KojiAPIConfig struct {

--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/coreos/go-systemd/activation"
 	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/syslog"
 )
 
 const (
@@ -67,6 +68,15 @@ func main() {
 	cacheDir, ok := os.LookupEnv("CACHE_DIRECTORY")
 	if !ok {
 		logrus.Fatal("CACHE_DIRECTORY is not set. Is the service file missing CacheDirectory=?")
+	}
+
+	if len(config.SyslogServer) > 0 {
+		hook, err := syslog.NewSyslogHook("tcp", config.SyslogServer, 0, "osbuild-composer")
+		if err != nil {
+			logrus.Fatal("Error connecting to syslog: " + err.Error())
+		}
+
+		logrus.AddHook(hook)
 	}
 
 	composer, err := NewComposer(config, stateDir, cacheDir)

--- a/vendor/github.com/sirupsen/logrus/hooks/syslog/README.md
+++ b/vendor/github.com/sirupsen/logrus/hooks/syslog/README.md
@@ -1,0 +1,39 @@
+# Syslog Hooks for Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>
+
+## Usage
+
+```go
+import (
+  "log/syslog"
+  "github.com/sirupsen/logrus"
+  lSyslog "github.com/sirupsen/logrus/hooks/syslog"
+)
+
+func main() {
+  log       := logrus.New()
+  hook, err := lSyslog.NewSyslogHook("udp", "localhost:514", syslog.LOG_INFO, "")
+
+  if err == nil {
+    log.Hooks.Add(hook)
+  }
+}
+```
+
+If you want to connect to local syslog (Ex. "/dev/log" or "/var/run/syslog" or "/var/run/log"). Just assign empty string to the first two parameters of `NewSyslogHook`. It should look like the following.
+
+```go
+import (
+  "log/syslog"
+  "github.com/sirupsen/logrus"
+  lSyslog "github.com/sirupsen/logrus/hooks/syslog"
+)
+
+func main() {
+  log       := logrus.New()
+  hook, err := lSyslog.NewSyslogHook("", "", syslog.LOG_INFO, "")
+
+  if err == nil {
+    log.Hooks.Add(hook)
+  }
+}
+```

--- a/vendor/github.com/sirupsen/logrus/hooks/syslog/syslog.go
+++ b/vendor/github.com/sirupsen/logrus/hooks/syslog/syslog.go
@@ -1,0 +1,55 @@
+// +build !windows,!nacl,!plan9
+
+package syslog
+
+import (
+	"fmt"
+	"log/syslog"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+// SyslogHook to send logs via syslog.
+type SyslogHook struct {
+	Writer        *syslog.Writer
+	SyslogNetwork string
+	SyslogRaddr   string
+}
+
+// Creates a hook to be added to an instance of logger. This is called with
+// `hook, err := NewSyslogHook("udp", "localhost:514", syslog.LOG_DEBUG, "")`
+// `if err == nil { log.Hooks.Add(hook) }`
+func NewSyslogHook(network, raddr string, priority syslog.Priority, tag string) (*SyslogHook, error) {
+	w, err := syslog.Dial(network, raddr, priority, tag)
+	return &SyslogHook{w, network, raddr}, err
+}
+
+func (hook *SyslogHook) Fire(entry *logrus.Entry) error {
+	line, err := entry.String()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to read entry, %v", err)
+		return err
+	}
+
+	switch entry.Level {
+	case logrus.PanicLevel:
+		return hook.Writer.Crit(line)
+	case logrus.FatalLevel:
+		return hook.Writer.Crit(line)
+	case logrus.ErrorLevel:
+		return hook.Writer.Err(line)
+	case logrus.WarnLevel:
+		return hook.Writer.Warning(line)
+	case logrus.InfoLevel:
+		return hook.Writer.Info(line)
+	case logrus.DebugLevel, logrus.TraceLevel:
+		return hook.Writer.Debug(line)
+	default:
+		return nil
+	}
+}
+
+func (hook *SyslogHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -338,6 +338,7 @@ github.com/segmentio/ksuid
 # github.com/sirupsen/logrus v1.8.1
 ## explicit
 github.com/sirupsen/logrus
+github.com/sirupsen/logrus/hooks/syslog
 # github.com/sony/gobreaker v0.4.2-0.20210216022020-dd874f9dd33b
 github.com/sony/gobreaker
 # github.com/spf13/cobra v1.4.0


### PR DESCRIPTION
Which will be used on crc in the log forwarding setup
NeededBy: COMPOSER-1285


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
