### PR TITLE
[RHEL 8.6] disk: fix ensureLVM for partition tables without /boot

### DIFF
--- a/internal/disk/partition_table.go
+++ b/internal/disk/partition_table.go
@@ -477,7 +477,12 @@ func (pt *PartitionTable) ensureLVM() error {
 	bootPath := entityPath(pt, "/boot")
 	if bootPath == nil {
 		_, err := pt.CreateMountpoint("/boot", 512*1024*1024)
-		return err
+
+		if err != nil {
+			return err
+		}
+
+		rootPath = entityPath(pt, "/")
 	}
 
 	parent := rootPath[1] // NB: entityPath has reversed order


### PR DESCRIPTION
#2580 for RHEL 8.6 branch