### PR TITLE
templates/composer: add fluentd sidecar

### DIFF
--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -94,6 +94,8 @@ objects:
             value: "${PGSSLMODE}"
           - name: PGMAXCONNS
             value: "${PGMAXCONNS}"
+          - name: SYSLOG_SERVER
+            value: "localhost:5140"
           ports:
           - name: composer-api
             protocol: TCP
@@ -109,6 +111,32 @@ objects:
             mountPath: "/var/lib/osbuild-composer"
           - name: cache-directory
             mountPath: "/var/cache/osbuild-composer"
+        - image: "fluentd-hec:1.2.13"
+          name: fluentd-sidecar
+          resources:
+            requests:
+              cpu: "${CPU_REQUEST}"
+              memory: "${MEMORY_REQUEST}"
+            limits:
+              cpu: "${CPU_REQUEST}"
+              memory: "${MEMORY_LIMIT}"
+          env:
+            - name: SPLUNK_HEC_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: splunk
+                  key: token
+                  optional: false
+            - name: SPLUNK_HEC_URL
+              valueFrom:
+                secretKeyRef:
+                  name: splunk
+                  key: url
+                  optional: false
+          volumeMounts:
+            - name: fluentd-config
+              mountPath: /fluentd/etc
+              readOnly: true
         volumes:
         - name: composer-config
           configMap:
@@ -224,7 +252,30 @@ objects:
       jwt_keys_urls = ["${RH_SSO_BASE_URL}/protocol/openid-connect/certs", "${MAS_SSO_BASE_URL}/protocol/openid-connect/certs"]
       jwt_acl_file = "${COMPOSER_CONFIG_DIR}/acl.yml"
       jwt_tenant_provider_fields = ["rh-org-id", "account_id"]
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: fluentd-config
+  data:
+    fluent.conf: |
+      <source>
+        @type syslog
+        port 5140
+        bind 127.0.0.1
+        <transport tcp>
+        </transport>
+        tag osbuild-composer
+        <parse>
+          time_format %Y-%m-%dT%H:%M:%SZ
+        </parse>
+      </source>
 
+      <match **>
+        @type splunk_hec
+        hec_host "#{ENV['SPLUNK_HEC_URL']}"
+        hec_port 8088
+        hec_token "#{ENV['SPLUNK_HEC_TOKEN']}"
+      </match>
 - apiVersion: batch/v1
   kind: CronJob
   metadata:

--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -186,7 +186,7 @@ objects:
   metadata:
     name: image-builder
   imagePullSecrets:
-  - name: quay-cloudservices-pull
+  - name: default-dockercfg-8bg88
 
 - apiVersion: v1
   kind: Service


### PR DESCRIPTION
The sidecar receives logs from the service and forwards them to Splunk
HEC


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
