### PR TITLE
Nightly testing: remove edge testing from nightly pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -297,7 +297,6 @@ OSTree:
   extends: .terraform/openstack
   rules:
     - !reference [.upstream_rules, rules]
-    - !reference [.nightly_rules, rules]
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/ostree.sh
@@ -343,6 +342,12 @@ OSTree simplified installer:
 OSTree raw image:
   stage: test
   extends: OSTree
+  rules:
+    # run only this edge test on nightly to have some testing for sign-off
+    # but still reduce duplication with virt-qe Jenkins and increase nightly
+    # pipelines stability
+    - !reference [.upstream_rules, rules]
+    - !reference [.nightly_rules, rules]
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/ostree-raw-image.sh

--- a/schutzbot/slack_notification.sh
+++ b/schutzbot/slack_notification.sh
@@ -4,7 +4,7 @@ set -eux
 
 COMPOSE_ID=$(cat COMPOSE_ID)
 COMPOSER_NVR=$(cat COMPOSER_NVR)
-MESSAGE="\"Nightly pipeline execution on *$COMPOSE_ID* with *$COMPOSER_NVR* finished with status *$1* $2 \n QE: @atodorov, @jrusz, @jabia, @xiaofwan\n Link to results: $CI_PIPELINE_URL \""
+MESSAGE="\"Nightly pipeline execution on *$COMPOSE_ID* with *$COMPOSER_NVR* finished with status *$1* $2 \n QE: @atodorov, @jrusz, @jabia\n Link to results: $CI_PIPELINE_URL\n For edge testing status please see https://url.corp.redhat.com/edge-pipelines \""
 
 curl \
     -X POST \


### PR DESCRIPTION
All of the edge tests are being ran on every nightly compose inside
virt-qe Jenkins so no need to run them here as well.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
