### PR TITLE
packit: Enable Koji build integration

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,8 +17,12 @@ srpm_build_deps: []
 actions:
   get-current-version: bash -c "git describe --tags --abbrev=0 | sed 's|v||'"
 
-create_pr: false
 jobs:
+- job: koji_build
+  trigger: commit
+  metadata:
+    dist_git_branches:
+      - fedora-all
 - job: propose_downstream
   trigger: release
   metadata:


### PR DESCRIPTION
Packit has recently added integration for running builds on Koji. This job is triggered each time a spec-file change is detected in a new commit in dist-git.
For the time being, this change can be merged and can co-exist with our [fedora-bot](https://github.com/osbuild/fedora-bot) implementation.
Once the same change is merged into the koji-osbuild and osbuild repos as well we can drop it from fedora-bot and update our documentation.

Also drop the `create_pr` option, which was removed by Packit.


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue (aka was recommended by pitti ;) )
- [x] adequate documentation informing people about the change (N/A)

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
