### PR TITLE
composer: fail to start if not listening on any API socket.

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -79,6 +79,8 @@ func main() {
 		logrus.Fatalf("Could not get listening sockets: " + err.Error())
 	}
 
+	hasAPISocket := false
+
 	if l, exists := listeners["osbuild-composer.socket"]; exists {
 		if len(l) != 1 {
 			logrus.Fatal("The osbuild-composer.socket unit is misconfigured. It should contain only one socket.")
@@ -88,6 +90,7 @@ func main() {
 		if err != nil {
 			logrus.Fatalf("Error initializing weldr API: %v", err)
 		}
+		hasAPISocket = true
 	}
 
 	if l, exists := listeners["osbuild-local-worker.socket"]; exists {
@@ -107,6 +110,7 @@ func main() {
 		if err != nil {
 			logrus.Fatalf("Error initializing koji API: %v", err)
 		}
+		hasAPISocket = true
 	}
 
 	if l, exists := listeners["osbuild-remote-worker.socket"]; exists {
@@ -118,6 +122,10 @@ func main() {
 		if err != nil {
 			logrus.Fatalf("Error initializing worker API: %v", err)
 		}
+	}
+
+	if !hasAPISocket {
+		logrus.Fatal("No API socket is enabled! Run 'systemctl enable --now osbuild-composer.socket'.")
 	}
 
 	err = composer.Start()


### PR DESCRIPTION
osbuild-composer can now start and keep running without listening on any
API socket. This effectively means that there is no way to communicate
with such instance of osbuild-composer.

Change osbuild-composer to exit with error in case no API socket has been
activated. The log message is intended for the on-premise use case, since
this is the situation when users tend to start osbuild-composer.service
manually and are observing a weird behavior.

Related to https://github.com/osbuild/osbuild-composer/pull/2550


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
