### PR TITLE
Add 'core' group back to qcow2 customize in format-request-map

### DIFF
--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -593,7 +593,11 @@
           }
         ],
         "modules": [],
-        "groups": [],
+        "groups": [
+          {
+            "name": "core"
+          }
+        ],
         "customizations": {
           "hostname": "my-host",
           "kernel": {


### PR DESCRIPTION
Removed in 2beb707def18e3d2b5c3f0ac83e8958af1be9442, possibly
accidentally.
The affected manifests were not regenerated based on this change so
they all already contain the core group.