### PR TITLE
worker: Specify region when creating autoscaling client

### DIFF
--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -105,7 +105,7 @@ func setProtection(protected bool) {
 		return
 	}
 
-	svc := autoscaling.New(awsSession)
+	svc := autoscaling.New(awsSession, aws.NewConfig().WithRegion(identity.Region))
 
 	// get the autoscaling group info for the auto scaling group name
 	asInstanceInput := &autoscaling.DescribeAutoScalingInstancesInput{


### PR DESCRIPTION
This mitigates the `MissingRegion` error when describing instances.

