### PR TITLE
Switch cleanup targets on or off in service maintenance job

### DIFF
--- a/cmd/osbuild-service-maintenance/config.go
+++ b/cmd/osbuild-service-maintenance/config.go
@@ -9,8 +9,8 @@ import (
 
 // Do not write this config to logs or stdout, it contains secrets!
 type Config struct {
-	DryRun                string `env:"DRY_RUN"`
-	MaxConcurrentRequests string `env:"MAX_CONCURRENT_REQUESTS"`
+	DryRun                bool   `env:"DRY_RUN"`
+	MaxConcurrentRequests int    `env:"MAX_CONCURRENT_REQUESTS"`
 	EnableDBMaintenance   bool   `env:"ENABLE_DB_MAINTENANCE"`
 	EnableGCPMaintenance  bool   `env:"ENABLE_GCP_MAINTENANCE"`
 	EnableAWSMaintenance  bool   `env:"ENABLE_AWS_MAINTENANCE"`
@@ -57,6 +57,12 @@ func LoadConfigFromEnv(intf interface{}) error {
 			switch kind {
 			case reflect.String:
 				fieldV.SetString(confV)
+			case reflect.Int:
+				value, err := strconv.ParseInt(confV, 10, 64)
+				if err != nil {
+					return err
+				}
+				fieldV.SetInt(value)
 			case reflect.Bool:
 				value, err := strconv.ParseBool(confV)
 				if err != nil {

--- a/cmd/osbuild-service-maintenance/config.go
+++ b/cmd/osbuild-service-maintenance/config.go
@@ -4,12 +4,16 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 )
 
 // Do not write this config to logs or stdout, it contains secrets!
 type Config struct {
 	DryRun                string `env:"DRY_RUN"`
 	MaxConcurrentRequests string `env:"MAX_CONCURRENT_REQUESTS"`
+	EnableDBMaintenance   bool   `env:"ENABLE_DB_MAINTENANCE"`
+	EnableGCPMaintenance  bool   `env:"ENABLE_GCP_MAINTENANCE"`
+	EnableAWSMaintenance  bool   `env:"ENABLE_AWS_MAINTENANCE"`
 	PGHost                string `env:"PGHOST"`
 	PGPort                string `env:"PGPORT"`
 	PGDatabase            string `env:"PGDATABASE"`
@@ -51,13 +55,14 @@ func LoadConfigFromEnv(intf interface{}) error {
 		kind := fieldV.Kind()
 		if ok {
 			switch kind {
-			case reflect.Ptr:
-				if fieldT.Type.Elem().Kind() != reflect.String {
-					return fmt.Errorf("Unsupported type")
-				}
-				fieldV.Set(reflect.ValueOf(&confV))
 			case reflect.String:
 				fieldV.SetString(confV)
+			case reflect.Bool:
+				value, err := strconv.ParseBool(confV)
+				if err != nil {
+					return err
+				}
+				fieldV.SetBool(value)
 			default:
 				return fmt.Errorf("Unsupported type")
 			}

--- a/cmd/osbuild-service-maintenance/main.go
+++ b/cmd/osbuild-service-maintenance/main.go
@@ -26,6 +26,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
 	maxCReqs, err := strconv.Atoi(conf.MaxConcurrentRequests)
 	if err != nil {
 		panic(err)
@@ -43,6 +44,11 @@ func main() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		if !conf.EnableAWSMaintenance {
+			logrus.Info("AWS maintenance not enabled, skipping")
+			return
+		}
+
 		logrus.Info("Cleaning up AWS")
 		err := AWSCleanup(maxCReqs, dryRun, conf.AWSAccessKeyID, conf.AWSSecretAccessKey, "us-east-1", cutoff)
 		if err != nil {
@@ -53,6 +59,11 @@ func main() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		if !conf.EnableGCPMaintenance {
+			logrus.Info("GCP maintenance not enabled, skipping")
+			return
+		}
+
 		logrus.Info("Cleaning up GCP")
 		var gcpConf GCPCredentialsConfig
 		err := LoadConfigFromEnv(&gcpConf)
@@ -81,8 +92,8 @@ func main() {
 	wg.Wait()
 	logrus.Info("🦀🦀🦀 cloud cleanup done 🦀🦀🦀")
 
-	if conf.PGHost == "" {
-		logrus.Info("🦀🦀🦀 db host not defined, skipping db cleanup 🦀🦀🦀")
+	if !conf.EnableDBMaintenance {
+		logrus.Info("🦀🦀🦀 DB maintenance not enabled, skipping  🦀🦀🦀")
 		return
 	}
 

--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -368,6 +368,12 @@ objects:
                     key: secret_access_key
               - name: DRY_RUN
                 value: "${MAINTENANCE_DRY_RUN}"
+              - name: ENABLE_AWS_MAINTENANCE
+                value: "${ENABLE_AWS_MAINTENANCE}"
+              - name: ENABLE_GCP_MAINTENANCE
+                value: "${ENABLE_GCP_MAINTENANCE}"
+              - name: ENABLE_DB_MAINTENANCE
+                value: "${ENABLE_DB_MAINTENANCE}"
               - name: MAX_CONCURRENT_REQUESTS
                 value: "${MAINTENANCE_MAX_CONCURRENT_REQUESTS}"
 
@@ -439,6 +445,21 @@ parameters:
     name: MAINTENANCE_DRY_RUN
     # don't change this value, overwrite it in app-interface for a specific namespace
     value: "true"
+    required: true
+  - description: Enable AWS maintenance
+    name: ENABLE_AWS_MAINTENANCE
+    # don't change this value, overwrite it in app-interface for a specific namespace
+    value: "false"
+    required: true
+  - description: Enable GPC maintenance
+    name: ENABLE_GCP_MAINTENANCE
+    # don't change this value, overwrite it in app-interface for a specific namespace
+    value: "false"
+    required: true
+  - description: Enable DB maintenance
+    name: ENABLE_DB_MAINTENANCE
+    # don't change this value, overwrite it in app-interface for a specific namespace
+    value: "false"
     required: true
   - description: composer-maintenance max concurrent requests
     name: MAINTENANCE_MAX_CONCURRENT_REQUESTS


### PR DESCRIPTION
    
Stage and production share the GCP account. To avoid trying to delete each GCP image twice, the maintenance script needs the ability toselectively disable certain parts based on the config.

--- 

Similar to DRY_RUN, these values should be overwritten in app-interface per namespace. At some point the maintenance specific to the CRC tenant (aws and gcp maintenance) should run in the workers namespace rather than the composer namespace. Granularity is needed for this.

