### PR TITLE
spec: require osbuild v55

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -326,10 +326,10 @@ The core osbuild-composer binary. This is suitable both for spawning in containe
 Summary:    The worker for osbuild-composer
 Requires:   systemd
 Requires:   qemu-img
-Requires:   osbuild >= 54
-Requires:   osbuild-ostree >= 54
-Requires:   osbuild-lvm2 >= 54
-Requires:   osbuild-luks2 >= 54
+Requires:   osbuild >= 55
+Requires:   osbuild-ostree >= 55
+Requires:   osbuild-lvm2 >= 55
+Requires:   osbuild-luks2 >= 55
 Requires:   %{name}-dnf-json = %{version}-%{release}
 
 # remove in F34


### PR DESCRIPTION
The new osbuild input schema, for which we added support in https://github.com/osbuild/osbuild-composer/pull/2578, requires osbuild v55 or newer.
