### PR TITLE
scheduled-cloud-cleaner: remove storage account skip

### DIFF
--- a/schutzbot/scheduled_cloud_cleaner.sh
+++ b/schutzbot/scheduled_cloud_cleaner.sh
@@ -69,12 +69,8 @@ STORAGE_ACCOUNT_COUNT=$(echo "$STORAGE_ACCOUNT_LIST" | jq .[].name | wc -l)
 DELETE_TIME=$(date -d "- $HOURS_BACK hours" +%s)
 for i in $(seq 0 $(("$STORAGE_ACCOUNT_COUNT"-1))); do
     STORAGE_ACCOUNT_NAME=$(echo "$STORAGE_ACCOUNT_LIST" | jq .["$i"].name | tr -d '"')
-    if [ "$AZURE_STORAGE_ACCOUNT" = "$STORAGE_ACCOUNT_NAME" ]; then
-        echo "Not checking default storage account $AZURE_STORAGE_ACCOUNT in other storage account script."
-        continue
-    fi
-
     echo "Checking storage account $STORAGE_ACCOUNT_NAME for old blobs."
+    
     CONTAINER_LIST=$(az storage container list --account-name "$STORAGE_ACCOUNT_NAME")
     CONTAINER_COUNT=$(echo "$CONTAINER_LIST" | jq .[].name | wc -l)
     for i2 in $(seq 0 $(("$CONTAINER_COUNT"-1))); do


### PR DESCRIPTION
scheduled cloud cleaner is skipping the default storage account for a
resource group, as this images should get removed. There can be a
situation where this images are not removed and forgotten here. Remove
this skip condition so scc checks also in this storage account.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
