### PR TITLE
Old worker - New composer test: Use Cloud API

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -251,6 +251,11 @@ regression-include-excluded-packages:
     SCRIPT: regression-include-excluded-packages.sh
 
 regression-old-worker-new-composer:
+  parallel:
+    matrix:
+      - RUNNER:
+          - aws/rhel-8.5-ga-x86_64
+        INTERNAL_NETWORK: ["true"]
   extends: .regression
   variables:
     SCRIPT: regression-old-worker-new-composer.sh

--- a/test/cases/regression-old-worker-new-composer.sh
+++ b/test/cases/regression-old-worker-new-composer.sh
@@ -16,7 +16,7 @@ if [ "$ARCH" != "x86_64" ] || [ "$ID" != rhel ] || ! sudo subscription-manager s
     exit 0
 fi
 
-# Provision the software under test.                                                                                                                                                                              
+# Provision the software under test.
 /usr/libexec/osbuild-composer-test/provision.sh
 
 function get_build_info() {


### PR DESCRIPTION
Use the cloud API for the `old-worker-new-composer` test.

All of the changes are bits and pieces copied from the `api.sh` script.  Most conditions are removed since we only run one test here: a guest image (`qcow2`) build uploaded to S3.  The test only really checks that the job succeeds and the image has the expected contents.  It doesn't check any fail states or image booting like the API test does.

Reasons for this change:
- Mixed versions of composer and worker aren't a realistic use-case for the weldr API (on prem) but we do run mixed versions in hosted IB, so this test is closer to real world scenarios.
- The cloud API runs depsolve jobs in the worker, whereas the weldr API runs them in composer.  By testing the cloud API we also test the backwards compatibility of the depsolve job.