### PR TITLE
Post release version bump

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -9,7 +9,7 @@
 
 %global goipath         github.com/osbuild/osbuild-composer
 
-Version:        52
+Version:        53
 
 %gometa
 


### PR DESCRIPTION
[skip ci]

For some reason our release automation for creating the GitHub release and doing the post-release version bump didn't run at all. Weirdly though, the scheduled action that pushes the tag ran just fine and v52 was created.

Therefore I'm now completing the steps manually by doing the post-release version bump.