### PR TITLE
Allow the user to set the location of the certificates

### DIFF
--- a/cmd/osbuild-composer/config.go
+++ b/cmd/osbuild-composer/config.go
@@ -22,6 +22,8 @@ type ComposerConfigFile struct {
 type KojiAPIConfig struct {
 	AllowedDomains          []string  `toml:"allowed_domains"`
 	CA                      string    `toml:"ca"`
+	ServerKeyFile           string    `toml:"server_key_file"`
+	ServerCertFile          string    `toml:"server_cert_file"`
 	EnableTLS               bool      `toml:"enable_tls"`
 	EnableMTLS              bool      `toml:"enable_mtls"`
 	EnableJWT               bool      `toml:"enable_jwt"`
@@ -39,6 +41,8 @@ type AWSConfig struct {
 type WorkerAPIConfig struct {
 	AllowedDomains          []string `toml:"allowed_domains"`
 	CA                      string   `toml:"ca"`
+	ServerKeyFile           string   `toml:"server_key_file"`
+	ServerCertFile          string   `toml:"server_cert_file"`
 	RequestJobTimeout       string   `toml:"request_job_timeout"`
 	BasePath                string   `toml:"base_path"`
 	EnableArtifacts         bool     `toml:"enable_artifacts"`
@@ -92,6 +96,8 @@ func GetDefaultConfig() *ComposerConfigFile {
 			AWS: AWSConfig{
 				Bucket: "image-builder.service",
 			},
+			ServerCertFile: "/etc/osbuild-composer/composer-crt.pem",
+			ServerKeyFile:  "/etc/osbuild-composer/composer-key.pem",
 		},
 		Worker: WorkerAPIConfig{
 			RequestJobTimeout: "0",
@@ -100,6 +106,8 @@ func GetDefaultConfig() *ComposerConfigFile {
 			EnableTLS:         true,
 			EnableMTLS:        true,
 			EnableJWT:         false,
+			ServerCertFile:    "/etc/osbuild-composer/composer-crt.pem",
+			ServerKeyFile:     "/etc/osbuild-composer/composer-key.pem",
 		},
 		WeldrAPI: WeldrAPIConfig{
 			map[string]WeldrDistroConfig{

--- a/cmd/osbuild-composer/config_test.go
+++ b/cmd/osbuild-composer/config_test.go
@@ -36,6 +36,8 @@ func TestDefaultConfig(t *testing.T) {
 		AWS: AWSConfig{
 			Bucket: "image-builder.service",
 		},
+		ServerCertFile: "/etc/osbuild-composer/composer-crt.pem",
+		ServerKeyFile:  "/etc/osbuild-composer/composer-key.pem",
 	}, defaultConfig.Koji)
 
 	require.Equal(t, WorkerAPIConfig{
@@ -45,6 +47,8 @@ func TestDefaultConfig(t *testing.T) {
 		EnableTLS:         true,
 		EnableMTLS:        true,
 		EnableJWT:         false,
+		ServerCertFile:    "/etc/osbuild-composer/composer-crt.pem",
+		ServerKeyFile:     "/etc/osbuild-composer/composer-key.pem",
 	}, defaultConfig.Worker)
 
 	expectedWeldrAPIConfig := WeldrAPIConfig{
@@ -72,9 +76,13 @@ func TestConfig(t *testing.T) {
 
 	require.Equal(t, config.Koji.AllowedDomains, []string{"osbuild.org"})
 	require.Equal(t, config.Koji.CA, "/etc/osbuild-composer/ca-crt.pem")
+	require.Equal(t, config.Koji.ServerKeyFile, "/etc/osbuild-composer/certs/composer-key.pem")
+	require.Equal(t, config.Koji.ServerCertFile, "/etc/osbuild-composer/certs/composer-crt.pem")
 
 	require.Equal(t, config.Worker.AllowedDomains, []string{"osbuild.org"})
 	require.Equal(t, config.Worker.CA, "/etc/osbuild-composer/ca-crt.pem")
+	require.Equal(t, config.Worker.ServerKeyFile, "/etc/osbuild-composer/certs/composer-key.pem")
+	require.Equal(t, config.Worker.ServerCertFile, "/etc/osbuild-composer/certs/composer-crt.pem")
 
 	require.Equal(t, []string{"qcow2", "vmdk"}, config.WeldrAPI.DistroConfigs["*"].ImageTypeDenyList)
 	require.Equal(t, []string{"qcow2"}, config.WeldrAPI.DistroConfigs["rhel-84"].ImageTypeDenyList)

--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -10,9 +10,7 @@ import (
 )
 
 const (
-	configFile     = "/etc/osbuild-composer/osbuild-composer.toml"
-	ServerKeyFile  = "/etc/osbuild-composer/composer-key.pem"
-	ServerCertFile = "/etc/osbuild-composer/composer-crt.pem"
+	configFile = "/etc/osbuild-composer/osbuild-composer.toml"
 )
 
 var repositoryConfigs = []string{
@@ -113,7 +111,7 @@ func main() {
 			logrus.Fatal("The osbuild-composer-api.socket unit is misconfigured. It should contain only one socket.")
 		}
 
-		err = composer.InitAPI(ServerCertFile, ServerKeyFile, config.Koji.EnableTLS, config.Koji.EnableMTLS, config.Koji.EnableJWT, l[0])
+		err = composer.InitAPI(config.Koji.ServerCertFile, config.Koji.ServerKeyFile, config.Koji.EnableTLS, config.Koji.EnableMTLS, config.Koji.EnableJWT, l[0])
 		if err != nil {
 			logrus.Fatalf("Error initializing koji API: %v", err)
 		}
@@ -124,7 +122,7 @@ func main() {
 			logrus.Fatal("The osbuild-remote-worker.socket unit is misconfigured. It should contain only one socket.")
 		}
 
-		err = composer.InitRemoteWorkers(ServerCertFile, ServerKeyFile, config.Worker.EnableTLS, config.Worker.EnableMTLS, config.Worker.EnableJWT, l[0])
+		err = composer.InitRemoteWorkers(config.Worker.ServerCertFile, config.Worker.ServerKeyFile, config.Worker.EnableTLS, config.Worker.EnableMTLS, config.Worker.EnableJWT, l[0])
 		if err != nil {
 			logrus.Fatalf("Error initializing worker API: %v", err)
 		}

--- a/cmd/osbuild-composer/testdata/test.toml
+++ b/cmd/osbuild-composer/testdata/test.toml
@@ -1,6 +1,8 @@
 [koji]
 allowed_domains = [ "osbuild.org" ]
 ca = "/etc/osbuild-composer/ca-crt.pem"
+server_key_file = "/etc/osbuild-composer/certs/composer-key.pem"
+server_cert_file = "/etc/osbuild-composer/certs/composer-crt.pem"
 enable_jwt = false
 jwt_keys_urls = ["https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs"]
 jwt_acl_file = "/var/lib/osbuild-composer/acl"
@@ -8,6 +10,8 @@ jwt_acl_file = "/var/lib/osbuild-composer/acl"
 [worker]
 allowed_domains = [ "osbuild.org" ]
 ca = "/etc/osbuild-composer/ca-crt.pem"
+server_key_file = "/etc/osbuild-composer/certs/composer-key.pem"
+server_cert_file = "/etc/osbuild-composer/certs/composer-crt.pem"
 pg_database = "overwrite-me-db"
 
 [weldr_api.distros."*"]


### PR DESCRIPTION
Allow the user to set the location of the certificates for the composer and the worker in the composer-config file.

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
- [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/


