### PR TITLE
tests/gcp: pick machine type from those available in the zone

### DIFF
--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -1397,10 +1397,15 @@ function verifyInGCP() {
   # Randomize the used GCP zone to prevent hitting "exhausted resources" error on each test re-run
   GCP_ZONE=$($GCP_CMD compute zones list --filter="region=$GCP_COMPUTE_REGION AND status=UP" | jq -r '.[].name' | shuf -n1)
 
+  # Pick the smallest '^n\d-standard-\d$' machine type from those available in the zone
+  local GCP_MACHINE_TYPE
+  GCP_MACHINE_TYPE=$($GCP_CMD compute machine-types list --filter="zone=$GCP_ZONE AND name~^n\d-standard-\d$" | jq -r '.[].name' | sort | head -1)
+
   $GCP_CMD compute instances create "$GCP_INSTANCE_NAME" \
     --zone="$GCP_ZONE" \
     --image-project="$GCP_PROJECT" \
     --image="$GCP_IMAGE_NAME" \
+    --machine-type="$GCP_MACHINE_TYPE" \
     --labels=gitlab-ci-test=true
 
   HOST=$($GCP_CMD compute instances describe "$GCP_INSTANCE_NAME" --zone="$GCP_ZONE" --format='get(networkInterfaces[0].accessConfigs[0].natIP)')


### PR DESCRIPTION
Do not rely on the default machine type when creating a GCE instance,
but rather list the available machine types in the zone and pick from
them. Test cases will pick the smallest machine type which name matches
the `^n\d-standard-\d$` regular expression.

This should prevent CI failures like
https://gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/-/jobs/2497043942#L2930


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
