### PR TITLE
test: add prominent message in test script cleanup functions

### DIFF
--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -323,6 +323,7 @@ function dump_db() {
 WORKDIR=$(mktemp -d)
 KILL_PIDS=()
 function cleanup() {
+  greenprint "== Script execution stopped or finished - Cleaning up =="
   set +eu
   case $CLOUD_PROVIDER in
     "$CLOUD_PROVIDER_AWS")
@@ -1188,7 +1189,7 @@ function verifyDisk() {
 
     infofile="${filename}-info.json"
     sudo /usr/libexec/osbuild-composer-test/image-info "${filename}" | tee "${infofile}" > /dev/null
-    
+
     # save image info to artifacts
     cp -v "${infofile}" "${ARTIFACTS}/image-info.json"
 

--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -43,6 +43,7 @@ fi
 
 TEMPDIR=$(mktemp -d)
 function cleanup() {
+    greenprint "== Script execution stopped or finished - Cleaning up =="
     sudo rm -rf "$TEMPDIR"
 }
 trap cleanup EXIT

--- a/test/cases/aws_s3.sh
+++ b/test/cases/aws_s3.sh
@@ -33,6 +33,7 @@ fi
 
 TEMPDIR=$(mktemp -d)
 function cleanup() {
+    echo "== Script execution stopped or finished - Cleaning up =="
     sudo rm -rf "$TEMPDIR"
 }
 trap cleanup EXIT

--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -47,6 +47,7 @@ fi
 
 TEMPDIR=$(mktemp -d)
 function cleanup() {
+    greenprint "== Script execution stopped or finished - Cleaning up =="
     sudo rm -rf "$TEMPDIR"
 }
 trap cleanup EXIT

--- a/test/cases/gcp.sh
+++ b/test/cases/gcp.sh
@@ -67,7 +67,7 @@ function cleanupGCP() {
 
 TEMPDIR=$(mktemp -d)
 function cleanup() {
-    greenprint "🧼 Cleaning up"
+    greenprint "== Script execution stopped or finished - Cleaning up =="
     cleanupGCP
     sudo rm -rf "$TEMPDIR"
 }

--- a/test/cases/generic_s3.sh
+++ b/test/cases/generic_s3.sh
@@ -34,6 +34,7 @@ fi
 
 TEMPDIR=$(mktemp -d)
 function cleanup() {
+    echo "== Script execution stopped or finished - Cleaning up =="
     sudo rm -rf "$TEMPDIR"
 }
 trap cleanup EXIT

--- a/test/cases/multi-tenancy.sh
+++ b/test/cases/multi-tenancy.sh
@@ -26,6 +26,7 @@ function greenprint {
 greenprint "Registering clean ups"
 KILL_PIDS=()
 function cleanup() {
+  greenprint "== Script execution stopped or finished - Cleaning up =="
   set +eu
   greenprint "Stopping containers"
   sudo /usr/libexec/osbuild-composer-test/run-koji-container.sh stop

--- a/test/cases/regression-composer-works-behind-satellite-fallback.sh
+++ b/test/cases/regression-composer-works-behind-satellite-fallback.sh
@@ -110,6 +110,7 @@ case "${ID}" in
 esac
 
 function cleanup {
+    greenprint "== Script execution stopped or finished - Cleaning up =="
     # Make the cleanup function best effort
     set +eu
 

--- a/test/cases/regression-composer-works-behind-satellite.sh
+++ b/test/cases/regression-composer-works-behind-satellite.sh
@@ -40,6 +40,7 @@ function generate_certificates {
 }
 
 function cleanup {
+    greenprint "== Script execution stopped or finished - Cleaning up =="
     # Make the cleanup function best effort
     set +eu
 

--- a/test/cases/regression-old-worker-new-composer.sh
+++ b/test/cases/regression-old-worker-new-composer.sh
@@ -167,6 +167,7 @@ function cleanupAWSS3() {
 WORKDIR=$(mktemp -d)
 KILL_PIDS=()
 function cleanup() {
+  greenprint "== Script execution stopped or finished - Cleaning up =="
   set +eu
   cleanupAWSS3
 

--- a/test/data/upgrade8to9/upgrade_verify.sh
+++ b/test/data/upgrade8to9/upgrade_verify.sh
@@ -4,6 +4,7 @@ set -euxo pipefail
 
 WORKSPACE=$(mktemp -d)
 function cleanup() {
+    echo "== Script execution stopped or finished - Cleaning up =="
     rm -rf "$WORKSPACE"
 }
 trap cleanup EXIT


### PR DESCRIPTION
When a test script fails in CI, it's often difficult to pinpoint the exact line in the log where the script failed and the cleanup() function (trapped on EXIT) begins.

Adding a prominent line (with greenprint where available) at the start of the cleanup function will make reading logs of failed jobs a lot easier.
