### PR TITLE
oscap: implement OpenSCAP build remediation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -605,6 +605,20 @@ Multi-tenancy:
     RUNNER: aws/rhel-8.6-ga-x86_64
     INTERNAL_NETWORK: "true"
 
+OpenSCAP:
+  stage: test
+  extends: .terraform
+  rules:
+    - !reference [.upstream_rules, rules]
+  script:
+    - schutzbot/deploy.sh
+    - /usr/libexec/tests/osbuild-composer/oscap.sh
+  parallel:
+    matrix:
+      - RUNNER:
+          - rhos-01/rhel-8.7-nightly-x86_64-large
+          - rhos-01/rhel-9.1-nightly-x86_64-large
+
 Upgrade:
   stage: test
   extends: .terraform/openstack

--- a/internal/blueprint/customizations.go
+++ b/internal/blueprint/customizations.go
@@ -22,6 +22,7 @@ type Customizations struct {
 	Filesystem         []FilesystemCustomization `json:"filesystem,omitempty" toml:"filesystem,omitempty"`
 	InstallationDevice string                    `json:"installation_device,omitempty" toml:"installation_device,omitempty"`
 	FDO                *FDOCustomization         `json:"fdo,omitempty" toml:"fdo,omitempty"`
+	OpenSCAP           *OpenSCAPCustomization    `json:"openscap,omitempty" toml:"openscap,omitempty"`
 }
 
 type FDOCustomization struct {
@@ -88,6 +89,11 @@ type ServicesCustomization struct {
 type FilesystemCustomization struct {
 	Mountpoint string `json:"mountpoint,omitempty" toml:"mountpoint,omitempty"`
 	MinSize    uint64 `json:"minsize,omitempty" toml:"size,omitempty"`
+}
+
+type OpenSCAPCustomization struct {
+	DataStream string `json:"datastream,omitempty" toml:"datastream,omitempty"`
+	ProfileID  string `json:"profile_id,omitempty" toml:"profile_id,omitempty"`
 }
 
 func (fsc *FilesystemCustomization) UnmarshalTOML(data interface{}) error {
@@ -366,4 +372,11 @@ func (c *Customizations) GetFDO() *FDOCustomization {
 		return nil
 	}
 	return c.FDO
+}
+
+func (c *Customizations) GetOpenSCAP() *OpenSCAPCustomization {
+	if c == nil {
+		return nil
+	}
+	return c.OpenSCAP
 }

--- a/internal/blueprint/customizations_test.go
+++ b/internal/blueprint/customizations_test.go
@@ -371,3 +371,19 @@ func TestGetFilesystemsMinSizeNonSectorSize(t *testing.T) {
 
 	assert.EqualValues(t, uint64(5632), retFilesystemsSize)
 }
+
+func TestGetOpenSCAPConfig(t *testing.T) {
+
+	expectedOscap := OpenSCAPCustomization{
+		DataStream: "test-data-stream.xml",
+		ProfileID:  "test_profile",
+	}
+
+	TestCustomizations := Customizations{
+		OpenSCAP: &expectedOscap,
+	}
+
+	retOpenSCAPCustomiztions := TestCustomizations.GetOpenSCAP()
+
+	assert.EqualValues(t, expectedOscap, *retOpenSCAPCustomiztions)
+}

--- a/internal/distro/fedora/images.go
+++ b/internal/distro/fedora/images.go
@@ -7,6 +7,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/image"
 	"github.com/osbuild/osbuild-composer/internal/manifest"
+	"github.com/osbuild/osbuild-composer/internal/osbuild"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/workload"
 )
@@ -88,6 +89,18 @@ func osCustomizations(
 
 	if !imageConfig.NoSElinux {
 		osc.SElinux = "targeted"
+	}
+
+	if oscapConfig := c.GetOpenSCAP(); oscapConfig != nil {
+		if t.rpmOstree {
+			panic("unexpected oscap options for ostree image type")
+		}
+		osc.OpenSCAPConfig = osbuild.NewOscapRemediationStageOptions(
+			osbuild.OscapConfig{
+				Datastream: oscapConfig.DataStream,
+				ProfileID:  oscapConfig.ProfileID,
+			},
+		)
 	}
 
 	osc.Grub2Config = imageConfig.Grub2Config

--- a/internal/distro/rhel7/distro.go
+++ b/internal/distro/rhel7/distro.go
@@ -448,6 +448,10 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 		return fmt.Errorf("The following custom mountpoints are not supported %+q", invalidMountpoints)
 	}
 
+	if osc := customizations.GetOpenSCAP(); osc != nil {
+		return fmt.Errorf(fmt.Sprintf("OpenSCAP unsupported os version: %s", t.arch.distro.osVersion))
+	}
+
 	return nil
 }
 

--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -454,6 +454,15 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 		mergedSets[buildPkgsKey] = mergedSets[buildPkgsKey].Append(extraPkgs)
 	}
 
+	// if oscap customizations are enabled we need to add `openscap-scanner`
+	// and `scap-security-guides` packages to build root
+	if bp.Customizations.GetOpenSCAP() != nil {
+		mergedSets[buildPkgsKey] = mergedSets[buildPkgsKey].Append(rpmmd.PackageSet{Include: []string{
+			"openscap-scanner",
+			"scap-security-guide",
+		}})
+	}
+
 	// depsolve bp packages separately
 	// bp packages aren't restricted by exclude lists
 	mergedSets[blueprintPkgsKey] = rpmmd.PackageSet{Include: bpPackages}

--- a/internal/distro/rhel8/pipelines.go
+++ b/internal/distro/rhel8/pipelines.go
@@ -673,6 +673,19 @@ func osPipeline(t *imageType,
 		p.AddStage(bootloader)
 	}
 
+	if oscapConfig := c.GetOpenSCAP(); oscapConfig != nil {
+		if t.rpmOstree {
+			return nil, fmt.Errorf("unexpected oscap options for ostree image type")
+		}
+		remediationOptions := osbuild.NewOscapRemediationStageOptions(
+			osbuild.OscapConfig{
+				Datastream: oscapConfig.DataStream,
+				ProfileID:  oscapConfig.ProfileID,
+			},
+		)
+		p.AddStage(osbuild.NewOscapRemediationStage(remediationOptions))
+	}
+
 	if !imageConfig.NoSElinux {
 		p.AddStage(osbuild.NewSELinuxStage(selinuxStageOptions(false)))
 	}

--- a/internal/distro/rhel90/distro.go
+++ b/internal/distro/rhel90/distro.go
@@ -390,6 +390,15 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 		mergedSets[buildPkgsKey] = mergedSets[buildPkgsKey].Append(extraPkgs)
 	}
 
+	// if oscap customizations are enabled we need to add `openscap-scanner`
+	// and `scap-security-guides` packages to build root
+	if bp.Customizations.GetOpenSCAP() != nil {
+		mergedSets[buildPkgsKey] = mergedSets[buildPkgsKey].Append(rpmmd.PackageSet{Include: []string{
+			"openscap-scanner",
+			"scap-security-guide",
+		}})
+	}
+
 	// depsolve bp packages separately
 	// bp packages aren't restricted by exclude lists
 	mergedSets[blueprintPkgsKey] = rpmmd.PackageSet{Include: bpPackages}

--- a/internal/distro/rhel90/pipelines.go
+++ b/internal/distro/rhel90/pipelines.go
@@ -671,6 +671,19 @@ func osPipeline(t *imageType,
 		p.AddStage(bootloader)
 	}
 
+	if oscapConfig := c.GetOpenSCAP(); oscapConfig != nil {
+		if t.rpmOstree {
+			return nil, fmt.Errorf("unexpected oscap options for ostree image type")
+		}
+		remediationOptions := osbuild.NewOscapRemediationStageOptions(
+			osbuild.OscapConfig{
+				Datastream: oscapConfig.DataStream,
+				ProfileID:  oscapConfig.ProfileID,
+			},
+		)
+		p.AddStage(osbuild.NewOscapRemediationStage(remediationOptions))
+	}
+
 	if !imageConfig.NoSElinux {
 		p.AddStage(osbuild.NewSELinuxStage(selinuxStageOptions(false)))
 	}

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -186,6 +186,9 @@ func (p *OS) getBuildPackages() []string {
 		packages = append(packages, "policycoreutils")
 		packages = append(packages, fmt.Sprintf("selinux-policy-%s", p.SElinux))
 	}
+	if p.OpenSCAPConfig != nil {
+		packages = append(packages, "openscap-scanner", "scap-security-guide")
+	}
 	return packages
 }
 

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -70,23 +70,24 @@ type OSCustomizations struct {
 	Users    []blueprint.UserCustomization
 	Firewall *blueprint.FirewallCustomization
 	// TODO: drop osbuild types from the API
-	Grub2Config   *osbuild.GRUB2Config
-	Sysconfig     []*osbuild.SysconfigStageOptions
-	SystemdLogind []*osbuild.SystemdLogindStageOptions
-	CloudInit     []*osbuild.CloudInitStageOptions
-	Modprobe      []*osbuild.ModprobeStageOptions
-	DracutConf    []*osbuild.DracutConfStageOptions
-	SystemdUnit   []*osbuild.SystemdUnitStageOptions
-	Authselect    *osbuild.AuthselectStageOptions
-	SELinuxConfig *osbuild.SELinuxConfigStageOptions
-	Tuned         *osbuild.TunedStageOptions
-	Tmpfilesd     []*osbuild.TmpfilesdStageOptions
-	PamLimitsConf []*osbuild.PamLimitsConfStageOptions
-	Sysctld       []*osbuild.SysctldStageOptions
-	DNFConfig     []*osbuild.DNFConfigStageOptions
-	SshdConfig    *osbuild.SshdConfigStageOptions
-	AuthConfig    *osbuild.AuthconfigStageOptions
-	PwQuality     *osbuild.PwqualityConfStageOptions
+	Grub2Config    *osbuild.GRUB2Config
+	Sysconfig      []*osbuild.SysconfigStageOptions
+	SystemdLogind  []*osbuild.SystemdLogindStageOptions
+	CloudInit      []*osbuild.CloudInitStageOptions
+	Modprobe       []*osbuild.ModprobeStageOptions
+	DracutConf     []*osbuild.DracutConfStageOptions
+	SystemdUnit    []*osbuild.SystemdUnitStageOptions
+	Authselect     *osbuild.AuthselectStageOptions
+	SELinuxConfig  *osbuild.SELinuxConfigStageOptions
+	Tuned          *osbuild.TunedStageOptions
+	Tmpfilesd      []*osbuild.TmpfilesdStageOptions
+	PamLimitsConf  []*osbuild.PamLimitsConfStageOptions
+	Sysctld        []*osbuild.SysctldStageOptions
+	DNFConfig      []*osbuild.DNFConfigStageOptions
+	SshdConfig     *osbuild.SshdConfigStageOptions
+	AuthConfig     *osbuild.AuthconfigStageOptions
+	PwQuality      *osbuild.PwqualityConfStageOptions
+	OpenSCAPConfig *osbuild.OscapRemediationStageOptions
 }
 
 // OS represents the filesystem tree of the target image. This roughly
@@ -416,6 +417,10 @@ func (p *OS) serialize() osbuild.Pipeline {
 		}
 
 		pipeline.AddStage(bootloader)
+	}
+
+	if p.OpenSCAPConfig != nil {
+		pipeline.AddStage(osbuild.NewOscapRemediationStage(p.OpenSCAPConfig))
 	}
 
 	if p.SElinux != "" {

--- a/internal/osbuild/oscap_remediation_stage.go
+++ b/internal/osbuild/oscap_remediation_stage.go
@@ -1,0 +1,87 @@
+package osbuild
+
+import "fmt"
+
+type OscapVerbosityLevel string
+
+const (
+	OscapVerbosityLevelDevel   = "DEVEL"
+	OscapVerbosityLevelInfo    = "INFO"
+	OscapVerbosityLevelError   = "ERROR"
+	OscapVerbosityLevelWarning = "WARNING"
+)
+
+type OscapRemediationStageOptions struct {
+	DataDir string      `json:"data_dir,omitempty"`
+	Config  OscapConfig `json:"config"`
+}
+type OscapConfig struct {
+	Datastream   string              `json:"datastream" toml:"datastream"`
+	ProfileID    string              `json:"profile_id" toml:"profile_id"`
+	DatastreamID string              `json:"datastream_id,omitempty" toml:"datastream_id,omitempty"`
+	XCCDFID      string              `json:"xccdf_id,omitempty" toml:"xccdf_id,omitempty"`
+	BenchmarkID  string              `json:"benchmark_id,omitempty" toml:"benchmark_id,omitempty"`
+	Tailoring    string              `json:"tailoring,omitempty" toml:"tailoring,omitempty"`
+	TailoringID  string              `json:"tailoring_id,omitempty" toml:"tailoring_id,omitempty"`
+	ArfResult    string              `json:"arf_result,omitempty" toml:"arf_result,omitempty"`
+	HtmlReport   string              `json:"html_report,omitempty" toml:"html_report,omitempty"`
+	VerboseLog   string              `json:"verbose_log,omitempty" toml:"verbose_log,omitempty"`
+	VerboseLevel OscapVerbosityLevel `json:"verbose_level,omitempty" toml:"verbose_level,omitempty"`
+}
+
+func (OscapRemediationStageOptions) isStageOptions() {}
+
+func (c OscapConfig) validate() error {
+	if c.Datastream == "" {
+		return fmt.Errorf("'datastream' must be specified")
+	}
+	if c.ProfileID == "" {
+		return fmt.Errorf("'profile_id' must be specified")
+	}
+	if c.VerboseLevel != "" {
+		allowedVerboseLevelValues := []OscapVerbosityLevel{
+			OscapVerbosityLevelDevel,
+			OscapVerbosityLevelError,
+			OscapVerbosityLevelInfo,
+			OscapVerbosityLevelWarning,
+		}
+		valid := false
+		for _, value := range allowedVerboseLevelValues {
+			if c.VerboseLevel == value {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			return fmt.Errorf("'verbose_level' option does not allow %q as a value", c.VerboseLevel)
+		}
+	}
+	return nil
+}
+
+func NewOscapRemediationStage(options *OscapRemediationStageOptions) *Stage {
+	if err := options.Config.validate(); err != nil {
+		panic(err)
+	}
+
+	return &Stage{
+		Type:    "org.osbuild.oscap.remediation",
+		Options: options,
+	}
+}
+
+func NewOscapRemediationStageOptions(options OscapConfig) *OscapRemediationStageOptions {
+	return &OscapRemediationStageOptions{
+		Config: OscapConfig{
+			ProfileID:    options.ProfileID,
+			Datastream:   options.Datastream,
+			DatastreamID: options.DatastreamID,
+			XCCDFID:      options.XCCDFID,
+			BenchmarkID:  options.BenchmarkID,
+			ArfResult:    options.ArfResult,
+			HtmlReport:   options.HtmlReport,
+			VerboseLog:   options.VerboseLog,
+			VerboseLevel: options.VerboseLevel,
+		},
+	}
+}

--- a/internal/osbuild/oscap_remediation_stage_test.go
+++ b/internal/osbuild/oscap_remediation_stage_test.go
@@ -1,0 +1,85 @@
+package osbuild
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewOscapRemediationStage(t *testing.T) {
+	stageOptions := &OscapRemediationStageOptions{DataDir: "/var/tmp", Config: OscapConfig{
+		Datastream: "test_stream",
+		ProfileID:  "test_profile",
+	}}
+	expectedStage := &Stage{
+		Type:    "org.osbuild.oscap.remediation",
+		Options: stageOptions,
+	}
+	actualStage := NewOscapRemediationStage(stageOptions)
+	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestOscapRemediationStageOptionsValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		options OscapRemediationStageOptions
+		err     bool
+	}{
+		{
+			name:    "empty-options",
+			options: OscapRemediationStageOptions{},
+			err:     true,
+		},
+		{
+			name: "empty-datastream",
+			options: OscapRemediationStageOptions{
+				Config: OscapConfig{
+					ProfileID: "test-profile",
+				},
+			},
+			err: true,
+		},
+		{
+			name: "empty-profile-id",
+			options: OscapRemediationStageOptions{
+				Config: OscapConfig{
+					Datastream: "test-datastream",
+				},
+			},
+			err: true,
+		},
+		{
+			name: "invalid-verbosity-level",
+			options: OscapRemediationStageOptions{
+				Config: OscapConfig{
+					Datastream:   "test-datastream",
+					ProfileID:    "test-profile",
+					VerboseLevel: "FAKE",
+				},
+			},
+			err: true,
+		},
+		{
+			name: "valid-data",
+			options: OscapRemediationStageOptions{
+				Config: OscapConfig{
+					Datastream:   "test-datastream",
+					ProfileID:    "test-profile",
+					VerboseLevel: "INFO",
+				},
+			},
+			err: false,
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.err {
+				assert.Errorf(t, tt.options.Config.validate(), "%q didn't return an error [idx: %d]", tt.name, idx)
+				assert.Panics(t, func() { NewOscapRemediationStage(&tt.options) })
+			} else {
+				assert.NoErrorf(t, tt.options.Config.validate(), "%q returned an error [idx: %d]", tt.name, idx)
+				assert.NotPanics(t, func() { NewOscapRemediationStage(&tt.options) })
+			}
+		})
+	}
+}

--- a/internal/oscap/oscap.go
+++ b/internal/oscap/oscap.go
@@ -1,0 +1,45 @@
+package oscap
+
+import "strings"
+
+type Profile string
+
+func (p Profile) String() string {
+	return string(p)
+}
+
+const (
+	AnssiBp28Enhanced     Profile = "xccdf_org.ssgproject.content_profile_anssi_bp28_enhanced"
+	AnssiBp28High         Profile = "xccdf_org.ssgproject.content_profile_anssi_bp28_high"
+	AnssiBp28Intermediary Profile = "xccdf_org.ssgproject.content_profile_anssi_bp28_intermediary"
+	AnssiBp28Minimal      Profile = "xccdf_org.ssgproject.content_profile_anssi_bp28_minimal"
+	Cis                   Profile = "xccdf_org.ssgproject.content_profile_cis"
+	CisServerL1           Profile = "xccdf_org.ssgproject.content_profile_cis_server_l1"
+	CisWorkstationL1      Profile = "xccdf_org.ssgproject.content_profile_cis_workstation_l1"
+	CisWorkstationL2      Profile = "xccdf_org.ssgproject.content_profile_cis_workstation_l2"
+	Cui                   Profile = "xccdf_org.ssgproject.content_profile_cui"
+	E8                    Profile = "xccdf_org.ssgproject.content_profile_e8"
+	Hippa                 Profile = "xccdf_org.ssgproject.content_profile_hipaa"
+	IsmO                  Profile = "xccdf_org.ssgproject.content_profile_ism_o"
+	Ospp                  Profile = "xccdf_org.ssgproject.content_profile_ospp"
+	PciDss                Profile = "xccdf_org.ssgproject.content_profile_pci-dss"
+	Standard              Profile = "xccdf_org.ssgproject.content_profile_standard"
+	Stig                  Profile = "xccdf_org.ssgproject.content_profile_stig"
+	StigGui               Profile = "xccdf_org.ssgproject.content_profile_stig_gui"
+)
+
+func IsProfileAllowed(profile string, allowlist []Profile) bool {
+	for _, a := range allowlist {
+		if a.String() == profile {
+			return true
+		}
+		// this enables a user to specify
+		// the full profile or the short
+		// profile id
+		if strings.HasSuffix(a.String(), profile) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/test/cases/oscap.sh
+++ b/test/cases/oscap.sh
@@ -1,0 +1,497 @@
+#!/usr/bin/bash
+set -euo pipefail
+
+OSBUILD_COMPOSER_TEST_DATA=/usr/share/tests/osbuild-composer/
+
+# Provision the software under test.
+/usr/libexec/osbuild-composer-test/provision.sh
+
+# Get OS data.
+source /etc/os-release
+
+# Colorful output.
+function greenprint {
+    echo -e "\033[1;32m[$(date -Isecond)] ${1}\033[0m"
+}
+
+# Start libvirtd and test it.
+greenprint "🚀 Starting libvirt daemon"
+sudo systemctl start libvirtd
+sudo virsh list --all > /dev/null
+
+# Set a customized dnsmasq configuration for libvirt so we always get the
+# same address on bootup.
+sudo tee /tmp/integration.xml > /dev/null << EOF
+<network>
+  <name>integration</name>
+  <uuid>1c8fe98c-b53a-4ca4-bbdb-deb0f26b3579</uuid>
+  <forward mode='nat'>
+    <nat>
+      <port start='1024' end='65535'/>
+    </nat>
+  </forward>
+  <bridge name='integration' stp='on' delay='0'/>
+  <mac address='52:54:00:36:46:ef'/>
+  <ip address='192.168.100.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='192.168.100.2' end='192.168.100.254'/>
+      <host mac='34:49:22:B0:83:30' name='vm-bios' ip='192.168.100.50'/>
+      <host mac='34:49:22:B0:83:31' name='vm-uefi' ip='192.168.100.51'/>
+    </dhcp>
+  </ip>
+</network>
+EOF
+if ! sudo virsh net-info integration > /dev/null 2>&1; then
+    sudo virsh net-define /tmp/integration.xml
+fi
+if [[ $(sudo virsh net-info integration | grep 'Active' | awk '{print $2}') == 'no' ]]; then
+    sudo virsh net-start integration
+fi
+
+# Allow anyone in the wheel group to talk to libvirt.
+greenprint "🚪 Allowing users in wheel group to talk to libvirt"
+sudo tee /etc/polkit-1/rules.d/50-libvirt.rules > /dev/null << EOF
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.libvirt.unix.manage" &&
+        subject.isInGroup("adm")) {
+            return polkit.Result.YES;
+    }
+});
+EOF
+
+TEST_UUID=$(uuidgen)
+IMAGE_KEY="oscap-${TEST_UUID}"
+HTTP_GUEST_ADDRESS=192.168.100.50
+ARTIFACTS="ci-artifacts"
+mkdir -p "${ARTIFACTS}"
+
+# Set up temporary files.
+TEMPDIR=$(mktemp -d)
+BLUEPRINT_FILE=${TEMPDIR}/blueprint.toml
+COMPOSE_START=${TEMPDIR}/compose-start-${IMAGE_KEY}.json
+COMPOSE_INFO=${TEMPDIR}/compose-info-${IMAGE_KEY}.json
+USER_DATA_FILE=${TEMPDIR}/user-data
+
+# SSH setup.
+SSH_OPTIONS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5)
+SSH_DATA_DIR=$(/usr/libexec/osbuild-composer-test/gen-ssh.sh)
+SSH_USER="admin"
+SSH_KEY=${SSH_DATA_DIR}/id_rsa
+SSH_KEY_PUB=$(cat "${SSH_KEY}".pub)
+
+case "${ID}-${VERSION_ID}" in
+    "rhel-8.7")
+        OS_VARIANT="rhel8-unknown"
+        PROFILE="xccdf_org.ssgproject.content_profile_cis"
+        DATASTREAM="/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml"
+        ;;
+    "rhel-9.1")
+        OS_VARIANT="rhel9-unknown"
+        PROFILE="xccdf_org.ssgproject.content_profile_cis"
+        DATASTREAM="/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml"
+        ;;
+    *)
+        echo "$0 is not enabled for ${ID}-${VERSION_ID} skipping..."
+        exit 0
+        ;;
+esac
+
+tee "${USER_DATA_FILE}" > /dev/null << EOF
+#cloud-config
+users:
+    - name: "${SSH_USER}"
+      sudo: "ALL=(ALL) NOPASSWD:ALL"
+      ssh_authorized_keys:
+          - "${SSH_KEY_PUB}"
+EOF
+
+# Prepare cloud-init data.
+CLOUD_INIT_DIR=$(mktemp -d)
+cp "${OSBUILD_COMPOSER_TEST_DATA}"/cloud-init/meta-data "${CLOUD_INIT_DIR}"/
+cp "${USER_DATA_FILE}" "${CLOUD_INIT_DIR}"/
+# cp "${OSBUILD_COMPOSER_TEST_DATA}"/cloud-init/network-config "${CLOUD_INIT_DIR}"/
+
+# Set up a cloud-init ISO.
+gen_iso () {
+    CLOUD_INIT_PATH=/var/lib/libvirt/images/seed.iso
+    sudo rm -f "${CLOUD_INIT_PATH}"
+    pushd "${CLOUD_INIT_DIR}"
+      sudo mkisofs -o "${CLOUD_INIT_PATH}" -V cidata \
+        -r -J user-data meta-data > /dev/null 2>&1  
+    popd
+}
+
+# Insall necessary packages to run
+# scans and check results
+sudo dnf install -y xmlstarlet openscap-utils scap-security-guide
+
+get_build_info() {
+    key="$1"
+    fname="$2"
+    if rpm -q --quiet weldr-client; then
+        key=".body${key}"
+    fi
+    jq -r "${key}" "${fname}"
+}
+
+# Get the compose log.
+get_compose_log () {
+    COMPOSE_ID=$1
+    LOG_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-${COMPOSE_ID}.log
+
+    # Download the logs.
+    sudo composer-cli compose log "${COMPOSE_ID}" | tee "${LOG_FILE}" > /dev/null
+}
+
+# Get the compose metadata.
+get_compose_metadata () {
+    COMPOSE_ID=$1
+    METADATA_FILE=${ARTIFACTS}/osbuild-${ID}-${VERSION_ID}-${COMPOSE_ID}.json
+
+    # Download the metadata.
+    sudo composer-cli compose metadata "${COMPOSE_ID}" > /dev/null
+
+    # Find the tarball and extract it.
+    TARBALL=$(basename "$(find . -maxdepth 1 -type f -name "*-metadata.tar")")
+    sudo tar -xf "${TARBALL}" -C "${TEMPDIR}"
+    sudo rm -f "${TARBALL}"
+
+    # Move the JSON file into place.
+    sudo cat "${TEMPDIR}"/"${COMPOSE_ID}".json | jq -M '.' | tee "${METADATA_FILE}" > /dev/null
+}
+
+# Build ostree image.
+build_image() {
+    blueprint_name=$1
+    image_type=$2
+
+    # Get worker unit file so we can watch the journal.
+    WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
+    sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
+    WORKER_JOURNAL_PID=$!
+    # Stop watching the worker journal when exiting.
+    trap 'sudo pkill -P ${WORKER_JOURNAL_PID}' EXIT
+
+    # Start the compose.
+    greenprint "🚀 Starting compose"
+    sudo composer-cli --json compose start "${blueprint_name}" "${image_type}" | tee "${COMPOSE_START}"
+    COMPOSE_ID=$(get_build_info ".build_id" "${COMPOSE_START}")
+
+    # Wait for the compose to finish.
+    greenprint "⏱ Waiting for compose to finish: ${COMPOSE_ID}"
+    while true; do
+        sudo composer-cli --json compose info "${COMPOSE_ID}" | tee "${COMPOSE_INFO}" > /dev/null
+        COMPOSE_STATUS=$(get_build_info ".queue_status" "${COMPOSE_INFO}")
+
+        # Is the compose finished?
+        if [[ ${COMPOSE_STATUS} != RUNNING ]] && [[ ${COMPOSE_STATUS} != WAITING ]]; then
+            break
+        fi
+
+        # Wait 30 seconds and try again.
+        sleep 5
+    done
+
+    # Capture the compose logs from osbuild.
+    greenprint "💬 Getting compose log and metadata"
+    get_compose_log "${COMPOSE_ID}"
+    get_compose_metadata "${COMPOSE_ID}"
+
+    # Kill the journal monitor immediately and remove the trap
+    sudo pkill -P "${WORKER_JOURNAL_PID}"
+    trap - EXIT
+
+    # Did the compose finish with success?
+    if [[ ${COMPOSE_STATUS} != FINISHED ]]; then
+        echo "Something went wrong with the compose. 😢"
+        exit 1
+    fi
+}
+
+ssh_ready () {
+    SSH_STATUS=$(sudo ssh -q "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" "${SSH_USER}@${1}" '/bin/bash -c "echo -n READY"')
+    if [[ ${SSH_STATUS} == READY ]]; then
+        echo 1
+    else
+        echo 0
+    fi
+}
+
+wait_for_ssh_up () {
+  # shellcheck disable=SC2034  # Unused variables left for readability
+  for LOOP_COUNTER in $(seq 0 45); do
+      RESULTS=$(ssh_ready "${1}")
+      if [[ ${RESULTS} == 1 ]]; then
+          echo "SSH is ready now! 🥳"
+          break
+      fi
+      sleep 20
+  done
+  if [[ ${RESULTS} == 0 ]]; then
+      clean_up "${1}"
+      echo "SSH failed to become ready 😢"
+      exit 1
+  fi
+}
+
+scan_vm() {
+  # oscap package has been installed on vm as
+  # oscap customization has been specified
+  # (the test has to be run as root)
+  sudo ssh -q "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" "${SSH_USER}@${1}" \
+    sudo oscap xccdf eval \
+    --results results.xml \
+    --profile "${PROFILE}" \
+    "${DATASTREAM}" || true # oscap returns exit code 2 for any failed rules
+}
+
+# Clean up our mess.
+clean_up () {
+    # Clear vm
+    if [[ $(sudo virsh domstate "${VIRSH_DOMAIN}") == "running" ]]; then
+        sudo virsh destroy "${VIRSH_DOMAIN}"
+    fi
+    sudo virsh undefine "${VIRSH_DOMAIN}" --nvram
+
+    # Remove qcow2 file.
+    sudo virsh vol-delete --pool images "${LIBVIRT_IMAGE_PATH}"
+}
+
+###############################
+##
+## Baseline Image
+##
+###############################
+
+# Write a blueprint for baseline image.
+tee "${BLUEPRINT_FILE}" > /dev/null << EOF
+name = "baseline"
+description = "A base image"
+version = "0.0.1"
+modules = []
+groups = []
+
+[[packages]]
+name = "openscap-scanner"
+version = "*"
+
+[[packages]]
+name = "scap-security-guide"
+version = "*"
+
+[[customizations.user]]
+name = "${SSH_USER}"
+description = "Administrator account"
+password = "\$6\$GRmb7S0p8vsYmXzH\$o0E020S.9JQGaHkszoog4ha4AQVs3sk8q0DvLjSMxoxHBKnB2FBXGQ/OkwZQfW/76ktHd0NX5nls2LPxPuUdl."
+key = "${SSH_KEY_PUB}"
+home = "/home/${SSH_USER}/"
+groups = ["wheel"]
+EOF
+
+greenprint "📄 baseline blueprint"
+cat "${BLUEPRINT_FILE}"
+
+# Prepare the blueprint for the compose.
+greenprint "📋 Preparing baseline blueprint"
+sudo composer-cli blueprints push "${BLUEPRINT_FILE}"
+sudo composer-cli blueprints depsolve baseline
+
+# Build baseline image.
+build_image baseline qcow2
+
+# Download the image
+greenprint "📥 Downloading the image"
+sudo composer-cli compose image "${COMPOSE_ID}" > /dev/null
+IMAGE_FILENAME="${COMPOSE_ID}-disk.qcow2"
+
+greenprint "🖥 Create qcow2 file for virt install"
+sudo cp "${IMAGE_FILENAME}" "/var/lib/libvirt/images/${IMAGE_KEY}.qcow2"
+LIBVIRT_IMAGE_PATH=/var/lib/libvirt/images/${IMAGE_KEY}.qcow2
+sudo qemu-img resize "${LIBVIRT_IMAGE_PATH}" 20G
+
+# Ensure SELinux is happy with our new images.
+greenprint "👿 Running restorecon on image directory"
+sudo restorecon -Rv /var/lib/libvirt/images/
+
+greenprint "💿 Creating a cloud-init ISO"
+gen_iso
+
+greenprint "📋 Install baseline image"
+VIRSH_DOMAIN="${IMAGE_KEY}-baseline"
+sudo virt-install --name="${VIRSH_DOMAIN}"\
+                  --disk "${LIBVIRT_IMAGE_PATH}",format=qcow2 \
+                  --disk path="${CLOUD_INIT_PATH}",device=cdrom \
+                  --ram 3072 \
+                  --vcpus 2 \
+                  --network network=integration,mac=34:49:22:B0:83:30 \
+                  --os-type linux \
+                  --os-variant "${OS_VARIANT}" \
+                  --import \
+                  --noautoconsole \
+                  --nographics \
+                  --wait=15 \
+                  --noreboot
+
+# Installation can get stuck, destroying VM helps
+# See https://github.com/osbuild/osbuild-composer/issues/2413
+if [[ $(sudo virsh domstate "${VIRSH_DOMAIN}") == "running" ]]; then
+    sudo virsh destroy "${VIRSH_DOMAIN}"
+fi
+
+# Start VM.
+greenprint "💻 Start baseline VM"
+sudo virsh start "${VIRSH_DOMAIN}"
+
+# Check for ssh ready to go.
+greenprint "🛃 Checking for SSH is ready to go"
+wait_for_ssh_up "${HTTP_GUEST_ADDRESS}"
+
+greenprint "🔒 Running oscap scanner"
+scan_vm "${HTTP_GUEST_ADDRESS}"
+
+greenprint "📗 Checking oscap score"
+BASELINE_SCORE=$(sudo ssh -q "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" "${SSH_USER}@${HTTP_GUEST_ADDRESS}" \
+  sudo cat results.xml \
+  | xmlstarlet sel -N x="http://checklists.nist.gov/xccdf/1.2" -t -v "//x:score"
+)
+
+# Clean up BASELINE VM
+greenprint "🧹 Clean up VM"
+clean_up
+
+###############################
+##
+## Hardened Image
+##
+###############################
+
+# Write a blueprint for hardened image.
+tee "${BLUEPRINT_FILE}" > /dev/null << EOF
+name = "hardened"
+description = "A hardened OpenSCAP image"
+version = "0.0.1"
+modules = []
+groups = []
+
+[[ packages ]]
+name = "openscap-scanner"
+version = "*"
+
+[[ packages ]]
+name = "scap-security-guide"
+version = "*"
+
+[customizations.openscap]
+profile_id = "${PROFILE}"
+datastream = "${DATASTREAM}"
+
+[[customizations.user]]
+name = "${SSH_USER}"
+description = "Administrator account"
+password = "\$6\$GRmb7S0p8vsYmXzH\$o0E020S.9JQGaHkszoog4ha4AQVs3sk8q0DvLjSMxoxHBKnB2FBXGQ/OkwZQfW/76ktHd0NX5nls2LPxPuUdl."
+key = "${SSH_KEY_PUB}"
+home = "/home/${SSH_USER}/"
+groups = ["wheel"]
+EOF
+
+greenprint "📄 hardened blueprint"
+cat "${BLUEPRINT_FILE}"
+
+# Prepare the blueprint for the compose.
+greenprint "📋 Preparing hardened blueprint"
+sudo composer-cli blueprints push "${BLUEPRINT_FILE}"
+sudo composer-cli blueprints depsolve hardened
+
+# Build hardened image.
+build_image hardened qcow2
+
+# Download the image
+greenprint "📥 Downloading the image"
+sudo composer-cli compose image "${COMPOSE_ID}" > /dev/null
+IMAGE_FILENAME="${COMPOSE_ID}-disk.qcow2"
+
+greenprint "🖥 Create qcow2 file for virt install"
+sudo cp "${IMAGE_FILENAME}" "/var/lib/libvirt/images/${IMAGE_KEY}.qcow2"
+LIBVIRT_IMAGE_PATH=/var/lib/libvirt/images/${IMAGE_KEY}.qcow2
+sudo qemu-img resize "${LIBVIRT_IMAGE_PATH}" 20G
+
+# Ensure SELinux is happy with our new images.
+greenprint "👿 Running restorecon on image directory"
+sudo restorecon -Rv /var/lib/libvirt/images/
+
+greenprint "💿 Creating a cloud-init ISO"
+gen_iso
+
+greenprint "📋 Install hardened image"
+VIRSH_DOMAIN="${IMAGE_KEY}-hardened"
+sudo virt-install --name="${VIRSH_DOMAIN}"\
+                  --disk "${LIBVIRT_IMAGE_PATH}",format=qcow2 \
+                  --disk path="${CLOUD_INIT_PATH}",device=cdrom \
+                  --ram 3072 \
+                  --vcpus 2 \
+                  --network network=integration,mac=34:49:22:B0:83:30 \
+                  --os-type linux \
+                  --os-variant "${OS_VARIANT}" \
+                  --import \
+                  --nographics \
+                  --noautoconsole \
+                  --wait=15 \
+                  --noreboot
+
+# Installation can get stuck, destroying VM helps
+# See https://github.com/osbuild/osbuild-composer/issues/2413
+if [[ $(sudo virsh domstate "${VIRSH_DOMAIN}") == "running" ]]; then
+    sudo virsh destroy "${VIRSH_DOMAIN}"
+fi
+
+# Start VM.
+greenprint "💻 Start hardened VM"
+sudo virsh start "${VIRSH_DOMAIN}"
+
+# Check for ssh ready to go.
+greenprint "🛃 Checking for SSH is ready to go"
+wait_for_ssh_up "${HTTP_GUEST_ADDRESS}"
+
+greenprint "🔒 Running oscap scanner"
+scan_vm "${HTTP_GUEST_ADDRESS}"
+
+greenprint "📗 Checking oscap score"
+HARDENED_SCORE=$(ssh -q "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" "${SSH_USER}@${HTTP_GUEST_ADDRESS}" \
+  sudo cat results.xml \
+  | xmlstarlet sel -N x="http://checklists.nist.gov/xccdf/1.2" -t -v "//x:score"
+)
+
+greenprint "📗 Checking for failed rules"
+SEVERITY=$(ssh -q "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" "${SSH_USER}@${HTTP_GUEST_ADDRESS}" \
+  sudo cat results.xml \
+  | xmlstarlet sel -N x="http://checklists.nist.gov/xccdf/1.2" -t -v "//x:rule-result[@severity='high']" \
+  | grep -c fail
+)
+
+# Clean up HARDENED VM
+greenprint "🧹 Clean up VM"
+clean_up
+
+# Remomve tmp dir.
+sudo rm -rf "${TEMPDIR}"
+
+greenprint "🎏 Checking for test result"
+echo "Baseline score: ${BASELINE_SCORE}%"
+echo "Hardened score: ${HARDENED_SCORE}%"
+
+# compare floating point numbers
+if python3 -c "exit(${HARDENED_SCORE} > ${BASELINE_SCORE})"; then
+  greenprint "❌ Failed"
+  echo "Hardened image did not improve baseline score"
+  exit 1
+fi
+
+# one grub rule fails (expected)
+# check if any other rules have failed
+if [[ ${SEVERITY} -gt 1 ]]; then
+  greenprint "❌ Failed"
+  echo "More than one oscap rule with high severity failed"
+  exit 1
+fi
+
+greenprint "💚 Success"


### PR DESCRIPTION
This pull request includes:
- blueprint customizations for openscap integration
- osbuild2 stage for oscap remediatoin
- validation of customization options
- add oscap stage to fedora, rhel87 and rhel91 non-rpmostree builds

Depends on:
https://github.com/osbuild/osbuild/pull/1033

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - [x] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
