### PR TITLE
Add kube-linter check to github tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,3 +152,23 @@ jobs:
         with:
           name: PR_STATUS
           path: SKIP_CI.txt
+
+  kube-linter:
+    name: "🎀 kube-linter"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: redhat-actions/oc-installer@v1
+    - name: Process template
+      run: |
+        mkdir processed-templates
+        oc process -f templates/composer.yml \
+          -p IMAGE_TAG=image_tag \
+          --local \
+          -o yaml > processed-templates/composer.yml
+
+    - uses: stackrox/kube-linter-action@v1.0.4
+      with:
+        directory: processed-templates
+        config: templates/.kube-linter-config.yml
+        version: 0.3.0

--- a/templates/.kube-linter-config.yml
+++ b/templates/.kube-linter-config.yml
@@ -1,0 +1,4 @@
+checks:
+  exclude:
+  - "no-read-only-root-fs"
+  - "run-as-non-root"

--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -36,6 +36,15 @@ objects:
           app: composer
       spec:
         serviceAccountName: image-builder
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: composer
+                topologyKey: kubernetes.io/hostname
         containers:
         - image: "${IMAGE_NAME}:${IMAGE_TAG}"
           name: composer

--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -164,6 +164,13 @@ objects:
         - name: composer-migrate
           image: "${IMAGE_NAME}:${IMAGE_TAG}"
           command: [ "/opt/migrate/tern", "migrate", "-m", "/opt/migrate/schemas" ]
+          resources:
+            requests:
+              cpu: "${CPU_REQUEST}"
+              memory: "${MEMORY_REQUEST}"
+            limits:
+              cpu: "${CPU_LIMIT}"
+              memory: "${MEMORY_LIMIT}"
           env:
           - name: PGHOST
             valueFrom:


### PR DESCRIPTION
See last few runs in https://github.com/Gundersanne/osbuild-composer/actions/workflows/tests.yml for example runs.

This will at least make sure the template can be processed and get some basic warnings/errors on the deployment.